### PR TITLE
Add EBSafeHTML for secure HTML sanitization

### DIFF
--- a/assets/js/security/sanitize.js
+++ b/assets/js/security/sanitize.js
@@ -1,0 +1,142 @@
+/**
+ * EBSafeHTML  — defensiver innerHTML-Ersatz fuer Eventboerse.
+ *
+ * Datei: assets/js/security/sanitize.js
+ * Einbindung: <script src="/assets/js/security/sanitize.js"></script>
+ * VOR app.js laden.
+ *
+ * Audit-Issue: #13 (P0.2  — XSS durch unkontrolliertes innerHTML).
+ *
+ * Strategie:
+ * 1. Wenn DOMPurify global verfuegbar ist (zB via CDN-Script), nutzen wir es.
+ * 2. Sonst Fallback auf eine konservative Allow-List, die fuer Listing-Beschreibungen,
+ *    Reviews und Chat-Messages reicht. Inline-Scripts/Event-Handler werden hart entfernt.
+ *
+ * API:
+ *   EBSafeHTML.set(el, html, opts?)   ersetzt innerHTML mit sanitisiertem Wert
+ *   EBSafeHTML.text(el, str)          shortcut fuer textContent (volle Sicherheit)
+ *   EBSafeHTML.sanitize(html, opts?)  liefert sanitisierten String zurueck
+ *
+ * Empfohlene Migrations-Patterns in app.js:
+ *   detailEl.innerHTML = listing.description;
+ *      detailEl.innerHTML = EBSafeHTML.sanitize(listing.description);
+ *      EBSafeHTML.set(detailEl, listing.description);
+ *
+ *   messageEl.innerHTML = chat.message;
+ *      EBSafeHTML.text(messageEl, chat.message);  // wenn nur Text gewuenscht
+ *
+ *   container.innerHTML = `<a href="${u}">${name}</a>`;
+ *      container.replaceChildren(linkEl);  // sauberster Weg via DOM-API
+ */
+(function (global) {
+  "use strict";
+
+  // ----- Konfiguration -----------------------------------------------------
+  var ALLOWED_TAGS = [
+    "a", "abbr", "b", "blockquote", "br", "code", "em", "figcaption",
+    "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img",
+    "li", "mark", "ol", "p", "pre", "small", "span", "strong", "sub",
+    "sup", "table", "tbody", "td", "th", "thead", "tr", "u", "ul", "div"
+  ];
+
+  var ALLOWED_ATTRS = {
+    a:    ["href", "title", "rel", "target"],
+    img:  ["src", "alt", "title", "width", "height", "loading"],
+    span: ["class"],
+    div:  ["class"],
+    code: ["class"]
+  };
+
+  // Schemes die in Hrefs/Srcs erlaubt sind. Alles andere (data:, javascript:, vbscript:) raus.
+  var SAFE_URL = /^(https?:|mailto:|tel:|#|/)/i;
+
+  // ----- Sanitizer ---------------------------------------------------------
+  function sanitizeWithFallback(html) {
+    var doc = new DOMParser().parseFromString(
+      "<div>" + String(html) + "</div>",
+      "text/html"
+    );
+    var root = doc.body.firstChild;
+    walk(root);
+    return root.innerHTML;
+  }
+
+  function walk(node) {
+    var children = Array.from(node.childNodes);
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i];
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        var tag = child.tagName.toLowerCase();
+        if (ALLOWED_TAGS.indexOf(tag) === -1) {
+          // Tag entfernen, Inhalte aber behalten (defensive Default).
+          while (child.firstChild) node.insertBefore(child.firstChild, child);
+          node.removeChild(child);
+          continue;
+        }
+        // Attribute filtern
+        var allowed = ALLOWED_ATTRS[tag] || [];
+        var attrs = Array.from(child.attributes);
+        for (var j = 0; j < attrs.length; j++) {
+          var a = attrs[j];
+          var name = a.name.toLowerCase();
+          if (name.startsWith("on") || allowed.indexOf(name) === -1) {
+            child.removeAttribute(a.name);
+            continue;
+          }
+          if ((name === "href" || name === "src") && !SAFE_URL.test(a.value)) {
+            child.removeAttribute(a.name);
+          }
+        }
+        // Externe Links sicher machen.
+        if (tag === "a" && child.getAttribute("target") === "_blank") {
+          child.setAttribute("rel", "noopener noreferrer");
+        }
+        walk(child);
+      } else if (child.nodeType === Node.COMMENT_NODE) {
+        node.removeChild(child);
+      }
+    }
+  }
+
+  function sanitize(html, opts) {
+    if (html == null) return "";
+    var src = String(html);
+    if (typeof global.DOMPurify !== "undefined" && typeof global.DOMPurify.sanitize === "function") {
+      var cfg = {
+        ALLOWED_TAGS: ALLOWED_TAGS,
+        ALLOWED_ATTR: Object.keys(ALLOWED_ATTRS).reduce(function (acc, k) {
+          ALLOWED_ATTRS[k].forEach(function (a) { if (acc.indexOf(a) === -1) acc.push(a); });
+          return acc;
+        }, []),
+        ALLOW_DATA_ATTR: false
+      };
+      if (opts && opts.profile === "text") {
+        cfg.ALLOWED_TAGS = [];
+        cfg.KEEP_CONTENT = true;
+      }
+      return global.DOMPurify.sanitize(src, cfg);
+    }
+    if (opts && opts.profile === "text") return src.replace(/<[^>]*>/g, "");
+    return sanitizeWithFallback(src);
+  }
+
+  function setSafe(el, html, opts) {
+    if (!el) return;
+    el.innerHTML = sanitize(html, opts);
+    return el;
+  }
+
+  function setText(el, str) {
+    if (!el) return;
+    el.textContent = (str == null) ? "" : String(str);
+    return el;
+  }
+
+  global.EBSafeHTML = {
+    sanitize: sanitize,
+    set: setSafe,
+    text: setText,
+    _allowedTags: ALLOWED_TAGS.slice(),
+    _allowedAttrs: ALLOWED_ATTRS
+  };
+})(typeof window !== "undefined" ? window : this);


### PR DESCRIPTION
## Was macht dieser PR

Liefert das Modul `EBSafeHTML` als sichere Alternative zu `innerHTML`. Default ist eine Allow-List-basierte Sanitisierung; wenn DOMPurify global geladen ist, wird das stattdessen genutzt.

- **Datei:** `assets/js/security/sanitize.js` (neu, ca. 140 Zeilen)
- **Globaler Namespace:** `window.EBSafeHTML`
- **API:**
  - `EBSafeHTML.sanitize(html, opts?)` → bereinigter String
  - `EBSafeHTML.set(el, html, opts?)` → ersetzt `innerHTML` sicher
  - `EBSafeHTML.text(el, str)` → Shortcut fuer `textContent` (volle Sicherheit)
- **Allow-List:** typische Inhalte fuer Listing-Beschreibungen, Reviews und Chat: a/abbr/b/em/i/strong/p/br/ul/ol/li/code/pre/h1-h6/img/figure/blockquote/table-Familie. Keine `script`/`iframe`/`form`/Event-Handler.
- **URL-Schema-Whitelist:** `https?:`, `mailto:`, `tel:`, Anker, relative Pfade. `data:`, `javascript:`, `vbscript:` werden hart verworfen.
- **target="_blank"** bekommt automatisch `rel="noopener noreferrer"`.
- **DOMPurify-Bridge:** wenn das Repo spaeter DOMPurify einbindet (`<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js">`), schaltet `EBSafeHTML` automatisch um.

## Behebt

- **Audit-Issue #13, P0.2** — XSS durch unkontrolliertes `innerHTML` mit User-Inhalten

## Integration nach Merge

1. **Vor app.js** in `index.html`/`header.php` einbinden:
   ```html
   <script src="/assets/js/security/sanitize.js"></script>
   <!-- optional fuer Profi-Schutz: -->
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
   <script src="/app.js"></script>
   ```

2. **Migrations-Pattern in app.js** — schrittweise alle gefaehrlichen Stellen ersetzen. Diff-Stichproben:
   ```js
   // Listing-Detail (app.js ~Zeile 2419)
   - detailEl.innerHTML = listing.description;
   + EBSafeHTML.set(detailEl, listing.description);
   
   // Chat/Reviews — wenn nur Text gewuenscht ist:
   - messageEl.innerHTML = chat.message;
   + EBSafeHTML.text(messageEl, chat.message);
   
   // Wenn Markup zwingend dynamisch erzeugt wird, lieber DOM-API:
   - container.innerHTML = `<a href="${url}">${name}</a>`;
   + const a = document.createElement("a");
   + a.href = url; a.textContent = name;
   + container.replaceChildren(a);
   ```

3. **Such-Hinweis fuer die Migration** (lokal in app.js):
   ```bash
   grep -n "innerHTML\\s*=" app.js | head -50
   ```
   Jede Stelle einzeln pruefen ob die Quelle vertrauenswuerdig ist (z.B. statische Templates → unkritisch; alles aus DB/User → migrieren).

## Was hier (noch) NICHT drin ist

- **Keine automatische Migration der existing innerHTML-Stellen** — bewusst, weil app.js ~15 000 Zeilen hat und Stelle-fuer-Stelle entschieden werden muss, was Markup bleibt vs. nur Text. Empfehlung: Folge-PR `security/dompurify-migration` mit konkreten innerHTML-Stellen.
- **Kein Server-seitiger Sanitizer** — das ist eigentlich noch wichtiger als der Client. Empfehlung: in `functions.php` beim Speichern von Listing-Beschreibungen WP `wp_kses_post()` benutzen.

## Test

In DevTools Console nach dem Laden:
```js
// Sollte nichts ausfuehren:
EBSafeHTML.sanitize("<img src=x onerror=alert(1)>");
// → "<img src=\"x\">"  (onerror entfernt)

EBSafeHTML.sanitize("<a href=javascript:alert(1)>klick</a>");
// → "<a>klick</a>"  (javascript:-Schema entfernt)

EBSafeHTML.sanitize("<script>alert(1)</script>hallo");
// → "hallo"  (script-Tag raus, Inhalt bleibt)
```