### PR TITLE
Add permission-callback helpers + audit logger

### DIFF
--- a/includes/security/permissions.php
+++ b/includes/security/permissions.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Permission-Callbacks fuer Eventboerse REST-Endpoints.
+ *
+ * Datei: includes/security/permissions.php
+ * Aufruf: in functions.php am Ende einbinden mit
+ *   require_once __DIR__ . '/includes/security/permissions.php';
+ *
+ * Audit-Issue: #13 (P0.1  Fehlende Autorisierungspruefung auf REST-Endpoint-Ebene).
+ *
+ * Konvention: Jeder register_rest_route() MUSS einen permission_callback haben.
+ * Default ist NICHT '__return_true' (das ist ein Code-Smell).
+ *
+ * Stattdessen: nutze einen der untenstehenden Helper, der genau dokumentiert,
+ * was die Bedingung ist:
+ *
+ *   // Public Read-only (z.B. Listings-Liste, Suche)
+ *   'permission_callback' => 'eventboerse_perm_public',
+ *
+ *   // Eingeloggte Nutzer (z.B. eigenes Profil, Buchungen anlegen)
+ *   'permission_callback' => 'eventboerse_perm_authenticated',
+ *
+ *   // Admin (z.B. User-Management, Site-Settings)
+ *   'permission_callback' => 'eventboerse_perm_admin',
+ *
+ *   // Owner-Check (Listing bearbeiten / loeschen): Closure mit Datensatz-Check
+ *   'permission_callback' => function ( $request ) {
+ *       return eventboerse_perm_owner( $request, 'listings', $request['id'] );
+ *   },
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Public-Endpoints: jeder darf lesen.
+ * NUR fuer wirklich oeffentliche Daten (z.B. Listings-Index, Kategorien).
+ */
+function eventboerse_perm_public() {
+    return true;
+}
+
+/**
+ * Authenticated-Endpoint: User muss eingeloggt sein.
+ * Nutzt WP-Cookie-Auth bzw. Application-Passwords — Setup wird von WP geregelt.
+ */
+function eventboerse_perm_authenticated() {
+    if ( ! is_user_logged_in() ) {
+        return new WP_Error( 'rest_forbidden', 'Login erforderlich.', array( 'status' => 401 ) );
+    }
+    return true;
+}
+
+/**
+ * Admin-Endpoint: User muss WP-'manage_options'-Capability haben.
+ */
+function eventboerse_perm_admin() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return new WP_Error( 'rest_forbidden', 'Admin-Rechte erforderlich.', array( 'status' => 403 ) );
+    }
+    return true;
+}
+
+/**
+ * Capability-Check.
+ *
+ * @param string $cap WordPress-Capability, z.B. 'edit_posts', 'eventboerse_create_listing'.
+ * @return callable Permission-Callback.
+ */
+function eventboerse_perm_capability( $cap ) {
+    return function () use ( $cap ) {
+        if ( ! current_user_can( $cap ) ) {
+            return new WP_Error( 'rest_forbidden', 'Fehlende Berechtigung.', array( 'status' => 403 ) );
+        }
+        return true;
+    };
+}
+
+/**
+ * Owner-Check via Custom-Post-Type.
+ *
+ * Pruefung: post existiert, post_type matcht, post_author == current_user_id.
+ * Admins duerfen immer.
+ *
+ * @param WP_REST_Request $request
+ * @param string $post_type  z.B. 'listings', 'reviews', 'bookings'.
+ * @param int $post_id
+ * @return true|WP_Error
+ */
+function eventboerse_perm_owner( $request, $post_type, $post_id ) {
+    if ( ! is_user_logged_in() ) {
+        return new WP_Error( 'rest_forbidden', 'Login erforderlich.', array( 'status' => 401 ) );
+    }
+    if ( current_user_can( 'manage_options' ) ) {
+        return true; // Admin-Override
+    }
+    $post = get_post( (int) $post_id );
+    if ( ! $post || $post->post_type !== $post_type ) {
+        return new WP_Error( 'not_found', 'Datensatz nicht gefunden.', array( 'status' => 404 ) );
+    }
+    if ( (int) $post->post_author !== get_current_user_id() ) {
+        return new WP_Error( 'rest_forbidden', 'Kein Zugriff auf fremden Datensatz.', array( 'status' => 403 ) );
+    }
+    return true;
+}
+
+/**
+ * Sicherheits-Logger fuer Endpoints, die ohne permission_callback registriert wurden.
+ * Aktiv nur wenn WP_DEBUG = true.
+ */
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+    add_action( 'rest_api_init', function () {
+        $server = rest_get_server();
+        $routes = $server->get_routes();
+        foreach ( $routes as $route => $handlers ) {
+            if ( strpos( $route, '/eventboerse/' ) !== 0 ) continue;
+            foreach ( $handlers as $handler ) {
+                if ( empty( $handler['permission_callback'] ) ) {
+                    error_log( sprintf( '[eb-perm-audit] Route %s ohne permission_callback', $route ) );
+                }
+            }
+        }
+    }, 100 );
+}


### PR DESCRIPTION
## Was macht dieser PR

Liefert ein Set von Permission-Callback-Helpern fuer REST-Endpoints, plus einen Audit-Logger der unprotected Routes findet.

- **Datei:** `includes/security/permissions.php` (neu, ca. 130 Zeilen)
- **Helper:**
  - `eventboerse_perm_public()` — explizit public (Listings-Liste, Suche)
  - `eventboerse_perm_authenticated()` — Login-Pflicht (Profil, Buchungen anlegen)
  - `eventboerse_perm_admin()` — `manage_options`-Capability (Site-Settings)
  - `eventboerse_perm_capability($cap)` — beliebige WP-Capability
  - `eventboerse_perm_owner($request, $post_type, $post_id)` — Ressourcen-Owner-Check (eigenes Listing bearbeiten)
- **Audit-Logger:** Wenn `WP_DEBUG=true` ist, schreibt jede `/eventboerse/`-Route ohne `permission_callback` ins `error_log` mit Praefix `[eb-perm-audit]`.

## Behebt

- **Audit-Issue #13, P0.1** — Fehlende Autorisierungspruefung auf REST-Endpoint-Ebene (~67 Endpoints in `functions.php`)

## Integration nach Merge

1. **In `functions.php`** einbinden:
   ```php
   require_once __DIR__ . '/includes/security/permissions.php';
   ```

2. **WP_DEBUG temporaer auf true setzen** (z.B. in `wp-config.php`), 1 mal die App durchklicken, dann `wp-content/debug.log` lesen — alle ungeschuetzten Routes stehen drin als `[eb-perm-audit] Route /eventboerse/... ohne permission_callback`.

3. **Routes klassifizieren und Callbacks setzen** — Beispielmuster:
   ```php
   // Vorher (UNSICHER):
   register_rest_route( 'eventboerse/v1', '/listings/(?P<id>\\d+)', array(
       'methods'  => 'DELETE',
       'callback' => 'eb_delete_listing',
       // permission_callback fehlt → JEDER kann loeschen!
   ) );
   
   // Nachher:
   register_rest_route( 'eventboerse/v1', '/listings/(?P<id>\\d+)', array(
       'methods'             => 'DELETE',
       'callback'            => 'eb_delete_listing',
       'permission_callback' => function ( $request ) {
           return eventboerse_perm_owner( $request, 'listings', $request['id'] );
       },
   ) );
   ```

4. **Klassifikations-Schema** (Empfehlung):
   - Public Read-only (Listings-Liste, Kategorien, Search) → `eventboerse_perm_public`
   - User-eigene Daten lesen (Profil, eigene Buchungen) → `eventboerse_perm_authenticated`
   - User-eigene Daten schreiben (Listing erstellen) → `eventboerse_perm_authenticated`
   - Fremde Daten editieren/loeschen (Listing bearbeiten) → `eventboerse_perm_owner` mit Owner-Check
   - Andere Nutzer verwalten / Site-Settings → `eventboerse_perm_admin`
   - Stripe-Webhook (HMAC-Auth statt User-Auth) → bleibt `__return_true`, ist OK weil Verifikation im Handler passiert

## Was hier (noch) NICHT drin ist

- **Keine automatische Migration der ~67 existing Routes** — bewusst, weil jede Route eine eigene Klassifikations-Entscheidung braucht (welche Capability passt). Audit-Logger zeigt dir alle Stellen.
- Folge-PRs sollten in Bloecken arbeiten: erst alle Listings-Routes, dann alle Reviews-Routes, etc. — Reviewbarkeit > Big-Bang.

## Verifikation nach Migration

```bash
# Lokal: alle register_rest_route OHNE permission_callback finden
grep -nE "register_rest_route" -A 8 functions.php | grep -B 1 -A 6 -L "permission_callback"
```

Plus: nach Merge `WP_DEBUG=true` setzen und sehen ob noch `[eb-perm-audit]`-Eintraege im Log auftauchen. Sollte 0 sein wenn alle Routes migriert sind.