### PR TITLE
Docs/security vault

### DIFF
--- a/vault/.obsidian/graph.json
+++ b/vault/.obsidian/graph.json
@@ -38,6 +38,10 @@
     {
       "query": "path:Roadmap",
       "color": { "a": 1, "rgb": 15680580 }
+    },
+    {
+      "query": "path:Security",
+      "color": { "a": 1, "rgb": 15484569 }
     }
   ],
   "collapse-display": false,

--- a/vault/Security/2026-05-02-Security-Hardening.md
+++ b/vault/Security/2026-05-02-Security-Hardening.md
@@ -1,0 +1,56 @@
+---
+tags: [security, audit, p0, hardening]
+date: 2026-05-02
+---
+
+# Security-Hardening 2026-05-02
+
+Index aller Sicherheits-Module die in dieser Session live gegangen sind. Ausloeser: [[Claude-Auto-Audit 2026-05-02|Audit Issue #13]] mit 5 P0-Funden, alle gefixt als isolierte Drop-in-Module.
+
+## Live auf main
+
+| P0 | Modul | Note | PR | Datei |
+|----|-------|------|----|-------|
+| 0.1 | Permission-Callbacks | [[Permissions]] | #20 | `includes/security/permissions.php` |
+| 0.2 | XSS-Schutz | [[EBSafeHTML]] | #19 | `assets/js/security/sanitize.js` |
+| 0.3 | Stripe-Webhook | [[Stripe-Webhook]] | #16 | `includes/security/stripe-webhook.php` |
+| 0.4 | Auth Rate-Limit | [[Rate-Limit]] | #18 | `includes/security/rate-limit.php` |
+| 0.5 | Token-Expiry | [[EBSession]] | #17 | `assets/js/security/session.js` |
+
+## Wie das alles zusammenhaengt
+
+```mermaid
+flowchart TB
+  user([User Browser]) -->|HTTP| frontend[Frontend / app.js]
+  frontend -->|Auth-Token aus| EBSession
+  frontend -->|Render User-Content via| EBSafeHTML
+  frontend -->|REST| backend[functions.php]
+  backend -->|jeder Endpoint| Permissions
+  backend -->|/login etc.| RateLimit[Rate-Limit]
+  stripe[Stripe.com] -->|Webhook| StripeWebhook[Stripe-Webhook]
+  StripeWebhook --> backend
+```
+
+## Was war der Audit-Befund
+
+Alle Befunde stammen aus dem nightly [[Claude-Auto-Audit 2026-05-02|Audit-Run vom 02.05.]]:
+
+1. **REST-Endpoints ohne Auth-Check** — bei ~67 Routes in [[functions.php]] unklar ob `permission_callback` gesetzt → potenziell oeffentliche Mutationen
+2. **XSS via `innerHTML`** — User-Inhalte (Listing-Beschreibung, Chat, Reviews) wurden ungefiltert ins DOM gerendert
+3. **Stripe ohne Signaturverifikation** — Webhook-Endpoint hat Zahlungsstatus ohne HMAC-Check geaendert
+4. **Brute-Force ungeschuetzt** — Login/Register/Reset ohne Rate-Limit
+5. **Sessions unbegrenzt** — Auth-Token in `localStorage` ohne Ablaufdatum
+
+## Was noch zu tun ist
+
+Die Module sind installiert, aber **nicht automatisch in der App verdrahtet** — bewusste Entscheidung gegen Big-Bang. Migrations-Schritte stehen jeweils im PR-Body. Die Reihenfolge laut [[App-Store-Readiness|Roadmap]] ist:
+
+1. `require_once` der drei PHP-Module in [[functions.php]]
+2. `<script>`-Tags fuer die zwei JS-Module vor `app.js`
+3. Schrittweise Migration der bestehenden Code-Stellen pro Modul
+4. WP_DEBUG fuer 1 Tag → Audit-Logger findet alle ungeschuetzten Routes
+5. Phase 2 starten: PWA-Foundation
+
+## Verwandte Notes
+
+[[Authentication]] · [[Payments]] · [[API-Endpoints]] · [[Code-Beziehungen]] · [[App-Store-Readiness]] · [[Dashboard]]

--- a/vault/Security/EBSafeHTML.md
+++ b/vault/Security/EBSafeHTML.md
@@ -1,0 +1,42 @@
+---
+tags: [security, p0, frontend, xss, sanitize]
+date: 2026-05-02
+---
+
+# EBSafeHTML
+
+Sichere Alternative zu `innerHTML`. Behebt P0.2 aus [[2026-05-02-Security-Hardening|Audit]].
+
+## Datei
+
+`assets/js/security/sanitize.js` · PR #19 · globaler Namespace `window.EBSafeHTML`
+
+## API
+
+```js
+EBSafeHTML.sanitize(html, opts?)   // bereinigter String
+EBSafeHTML.set(el, html, opts?)    // ersetzt innerHTML sicher
+EBSafeHTML.text(el, str)           // Shortcut fuer textContent
+```
+
+## Schutz
+
+- Allow-List fuer Tags (a/abbr/b/em/strong/p/br/ul/ol/li/code/pre/h1-h6/img/figure/blockquote/table-Familie)
+- Keine `script`/`iframe`/`form` und keine `on*`-Event-Handler
+- URL-Schemes: nur `https?:`/`mailto:`/`tel:`/Anker/relativ — `data:`/`javascript:`/`vbscript:` werden hart verworfen
+- `target="_blank"` bekommt automatisch `rel="noopener noreferrer"`
+- Wenn DOMPurify global geladen ist, wird das stattdessen verwendet
+
+## Verbindung zu
+
+- [[2026-05-02-Security-Hardening|Hardening-Index]]
+- [[app-js-module]] — alle `innerHTML = userInput` migrieren
+- [[Listings]] / [[Reviews]] / [[Messaging]] — die drei Render-Pfade fuer User-Inhalte
+- [[EBSession]] — zusammen Frontend-Cluster
+
+## TODOs
+
+- `<script src="/assets/js/security/sanitize.js">` vor app.js in [[index.html]]/[[header.php]]
+- Optional DOMPurify CDN einbinden fuer Profi-Schutz
+- Migration der ~50+ `innerHTML`-Stellen in [[app-js-module]] (Folge-PR)
+- WICHTIG: serverseitig zusaetzlich `wp_kses_post()` beim Speichern verwenden

--- a/vault/Security/EBSession.md
+++ b/vault/Security/EBSession.md
@@ -1,0 +1,42 @@
+---
+tags: [security, p0, frontend, session, localStorage]
+date: 2026-05-02
+---
+
+# EBSession
+
+Frontend-Wrapper fuer Auth-Token mit harter Expiry. Behebt P0.5 aus [[2026-05-02-Security-Hardening|Audit]].
+
+## Datei
+
+`assets/js/security/session.js` · PR #17 · globaler Namespace `window.EBSession`
+
+## API
+
+```js
+EBSession.set(token, user, ttlMs?)   // Default-TTL: 24h
+EBSession.get()                       // null wenn abgelaufen
+EBSession.getToken()
+EBSession.getUser()
+EBSession.clear()
+EBSession.refresh(ttlMs?)             // verlaengert
+EBSession.onExpire(handler)
+```
+
+## Storage
+
+Ein Eintrag `eb_session` mit `{v, token, user, iat, exp}`. Bei `get()` wird abgelaufene Session geloescht und `eb:session:expired` event gefeuert. `storage`-Event sorgt fuer Cross-Tab-Sync.
+
+## Verbindung zu
+
+- [[2026-05-02-Security-Hardening|Hardening-Index]]
+- [[app-js-module]] — alle bisherigen `localStorage.setItem("eb_token")` migrieren
+- [[Authentication]] — Login-Response geht durch `EBSession.set`
+- [[Rate-Limit]] — erfolgreicher Login triggert `reset_rate_limit`
+- [[EBSafeHTML]] — zusammen Frontend-Cluster
+
+## TODOs
+
+- `<script src="/assets/js/security/session.js">` VOR app.js in [[index.html]]/[[header.php]]
+- `app.js` Migration: alle `localStorage`-Tokens in einem Folge-PR
+- Optional: `window.addEventListener("eb:session:expired", () => navigateTo("/login"))`

--- a/vault/Security/Permissions.md
+++ b/vault/Security/Permissions.md
@@ -1,0 +1,39 @@
+---
+tags: [security, p0, rest, auth, wordpress]
+date: 2026-05-02
+---
+
+# Permissions
+
+Permission-Callback-Helper fuer alle REST-Endpoints. Behebt P0.1 aus [[2026-05-02-Security-Hardening|Audit]].
+
+## Datei
+
+`includes/security/permissions.php` · PR #20
+
+## Helper
+
+| Funktion | Verwendung |
+|----------|------------|
+| `eventboerse_perm_public()` | Listings-Liste, Suche — wirklich oeffentlich |
+| `eventboerse_perm_authenticated()` | Profil, eigene Buchungen anlegen |
+| `eventboerse_perm_admin()` | Site-Settings, User-Mgmt |
+| `eventboerse_perm_capability($cap)` | beliebige WP-Capability |
+| `eventboerse_perm_owner($r, $type, $id)` | nur Datensatz-Owner darf editieren |
+
+## Audit-Logger
+
+Wenn `WP_DEBUG=true` ist, schreibt jede `/eventboerse/`-Route ohne `permission_callback` ins `error_log` mit Praefix `[eb-perm-audit]`. So findest du alle ungeschuetzten Routes.
+
+## Verbindung zu
+
+- [[2026-05-02-Security-Hardening|Hardening-Index]]
+- [[Authentication]] — Login-Flow
+- [[API-Endpoints]] — alle ~67 Routes
+- [[Stripe-Webhook]] — nutzt explizit `__return_true` (HMAC-Auth statt User-Auth)
+
+## TODOs
+
+- [[functions.php|functions.php]]: `require_once "includes/security/permissions.php"`
+- WP_DEBUG einschalten, Log lesen, alle ~67 Routes klassifizieren
+- Folge-PRs in Bloecken: Listings-Routes, Reviews-Routes, etc.

--- a/vault/Security/Rate-Limit.md
+++ b/vault/Security/Rate-Limit.md
@@ -1,0 +1,44 @@
+---
+tags: [security, p0, auth, rate-limit, brute-force]
+date: 2026-05-02
+---
+
+# Rate-Limit
+
+WP-Transient-basierter Sliding-Window Rate-Limit-Helper. Behebt P0.4 aus [[2026-05-02-Security-Hardening|Audit]].
+
+## Datei
+
+`includes/security/rate-limit.php` · PR #18
+
+## API
+
+```php
+eventboerse_check_rate_limit( $action, $limit, $window_secs, $identifier_override = null )
+eventboerse_reset_rate_limit( $action, $identifier_override = null )
+eventboerse_get_client_ip()
+```
+
+Rueckgabe von `check`: `true` oder `WP_Error` mit HTTP 429 + `retry_after`.
+
+## Empfohlene Limits
+
+| Endpoint | Limit | Fenster |
+|----------|-------|---------|
+| Login | 5 | 15 min |
+| Registrierung | 3 | 1 h |
+| Passwort-Reset | 3 | 1 h |
+| Schreib-Endpoints (generell) | 30 | 1 min |
+
+## Verbindung zu
+
+- [[2026-05-02-Security-Hardening|Hardening-Index]]
+- [[Authentication]] — Login/Register/Reset Flows
+- [[Permissions]] — Rate-Limit kommt VOR Permission-Check
+- [[EBSession]] — erfolgreiche Logins triggern `reset_rate_limit`
+
+## TODOs
+
+- [[functions.php|functions.php]]: `require_once "includes/security/rate-limit.php"`
+- An den drei Auth-Endpoints den Helper als ersten Schritt im Callback
+- Optional gegen Username-Enumeration: `$identifier = $username . "|" . $ip`

--- a/vault/Security/Stripe-Webhook.md
+++ b/vault/Security/Stripe-Webhook.md
@@ -1,0 +1,38 @@
+---
+tags: [security, p0, stripe, payments, webhook]
+date: 2026-05-02
+---
+
+# Stripe-Webhook
+
+Sicher signaturverifizierter Stripe-Endpoint. Behebt P0.3 aus [[2026-05-02-Security-Hardening|Audit]].
+
+## Datei
+
+`includes/security/stripe-webhook.php` · PR #16
+
+## Endpoint
+
+```
+POST /wp-json/eventboerse/v1/stripe/webhook
+```
+
+## Was es tut
+
+- HMAC-SHA256-Verifikation des `Stripe-Signature` Headers (pure-PHP, kein SDK)
+- 5-Minuten-Timestamp-Tolerance gegen Replay
+- Idempotenz via WP-Transient mit Stripe-Event-ID (24h)
+- Dispatch via `do_action("eventboerse_stripe_event_{type}", $event)`
+
+## Verbindung zu
+
+- [[2026-05-02-Security-Hardening|Hardening-Index]]
+- [[Payments]] — Buchungs-Flows die Stripe-Events ausloesen
+- [[API-Endpoints]] — Endpoint-Map
+- Configuration: WP-Option `eventboerse_stripe_webhook_secret`
+
+## TODOs
+
+- Webhook-URL im Stripe-Dashboard eintragen
+- `eventboerse_stripe_webhook_secret` setzen (per `wp option update`)
+- Listener-Funktionen fuer payment_intent.succeeded etc. schreiben (Folge-PR)


### PR DESCRIPTION
## Was macht dieser PR

Bringt die heutige Security-Hardening-Session in den Obsidian-Vault.

- **Neuer Folder:** `vault/Security/` mit 6 Notes:
  - `2026-05-02-Security-Hardening.md` (Index, Mermaid-Diagramm, Verlinkungen)
  - `Stripe-Webhook.md` — PR #16
  - `Permissions.md` — PR #20
  - `Rate-Limit.md` — PR #18
  - `EBSession.md` — PR #17
  - `EBSafeHTML.md` — PR #19
- **graph.json:** neue Color-Group `path:Security` in Magenta `#EC4899` — unterscheidbar von allen anderen Clustern

## Effekt im Graph

- 6 neue Knoten als eigenes Cluster
- Wikilinks zu existing Notes ([[Authentication]], [[Payments]], [[API-Endpoints]], [[App-Store-Readiness]], [[Dashboard]], [[functions.php]], [[app-js-module]] etc.) verbinden das Cluster mit dem Rest des Graphs

## Nach Merge

Lokal `git pull`, in Obsidian `Cmd+R` (Reload Vault) — dann erscheint der neue Security-Cluster in Magenta im Graph.