### PR TITLE
Self-Audit 2026-06-16: 8 tote Chat-Endpoints + 12 ungenutzte JS-Patches

### DIFF
--- a/vault/AI-Gedaechtnis/Audit-2026-06-16.md
+++ b/vault/AI-Gedaechtnis/Audit-2026-06-16.md
@@ -1,0 +1,142 @@
+# Self-Audit 2026-06-16
+
+> Automatischer Code-Audit durch Claude Code (Routine-Lauf). Findings sind nach Risiko/Aufwand sortiert. Jeder Block schließt mit einer Empfehlung, die du **freigeben / ablehnen** kannst — der nächste Lauf setzt die freigegebenen Punkte um.
+
+## Zusammenfassung
+
+| Kategorie | Anzahl | Stand |
+|---|---|---|
+| Tote API-Calls aus dem Chat | 8 | UI-Buttons → roter Fehler-Toast |
+| Ungenutzte JS-Dateien im Repo | 12 | werden deployed, aber nirgends geladen |
+| Vault ↔ Code Drift | 1 | `admin/listings/*` Routen sind aspirativ |
+| Bekannte Stripe-/Mess-Lücken | 2 | bereits in `Current-Sprint.md` |
+
+Gesamtbild: Plattform-Kern ist solide (Auth, Listings, Board, Payments). Die Schwachstellen liegen in **Chat-Sekundär­funktionen** (UI verspricht mehr als das Backend kann) und in **Repo-Hygiene** (Patch-Reste aus früheren Refactor-Versuchen).
+
+---
+
+## Finding 1 — Chat-Menü: 8 Frontend-Aktionen ohne Backend
+
+**Schweregrad:** Hoch (User-sichtbar, jeder Klick erzeugt Fehler-Toast)
+**Aufwand:** Mittel (1× Migration + 8 REST-Routen, ~250 LOC PHP)
+
+### Details
+
+Folgende `fetch()`-Calls in `app.js` schlagen mit 404 fehl, weil `functions.php` die Route nicht registriert:
+
+| # | Funktion (app.js) | HTTP-Methode + Pfad |
+|---|---|---|
+| 1 | `hideMessageForMe()` (Zeile 5172) | `POST messages/{id}/hide` |
+| 2 | `_markChatUnread()` (Zeile 5365) | `DELETE conversations/{id}/read` |
+| 3 | `_clearChat()` (Zeile 5373) | `DELETE conversations/{id}` |
+| 4 | `_toggleBlockUser()` (Zeile 5396) | `POST/DELETE users/{id}/block` |
+| 5 | `_reportUser()` (Zeile 5421) | `POST users/{id}/report` |
+| 6 | `_setChatFlag('mute')` (Zeile 5351) | `POST/DELETE conversations/{id}/mute` |
+| 7 | `_setChatFlag('pin')` (Zeile 5351) | `POST/DELETE conversations/{id}/pin` |
+| 8 | `_setChatFlag('archive')` (Zeile 5351) | `POST/DELETE conversations/{id}/archive` |
+
+Im UI gezeigt als 3-Punkte-Menü pro Chat und als „Für mich löschen"-Icon pro Nachricht. Conversation-Objekte transportieren bereits `muted`, `pinned`, `archived`, `blocked_by_me` — das Frontend erwartet diese Felder, das Backend liefert sie aktuell aber nicht (Endpoint fehlt **und** Lese-Pfad in `/conversations` liefert sie nicht).
+
+### Proposal
+
+**Backend (`functions.php`)**
+
+- Neue Tabelle `wp_eb_conversation_flags` (`user_id`, `conversation_id`, `muted`, `pinned`, `archived`, `unread_override`, `cleared_at`).
+- Neue Tabelle `wp_eb_user_blocks` (`blocker_id`, `blocked_id`, `created_at`).
+- Neue Tabelle `wp_eb_user_reports` (`reporter_id`, `reported_id`, `conversation_id`, `reason`, `created_at`).
+- Neue Spalte `hidden_for_user_ids` (JSON) auf `wp_eb_messages` für „nur für mich verstecken".
+- 8 neue REST-Routen analog zu bestehendem Schema (Nonce-Auth, `current_user_can`).
+- `/conversations` GET-Handler erweitern: `muted/pinned/archived/blocked_by_me` aus den neuen Tabellen joinen.
+
+**Frontend**
+
+- Keine Änderung nötig — der Frontend-Pfad ist bereits da, nur das Backend muss antworten.
+
+### Risiko
+
+- Geringes Regressionsrisiko: keine bestehende Funktion wird angefasst, nur neue Routen kommen dazu.
+- DB-Migration läuft on-deploy über `dbDelta()` (WordPress-Standard).
+- Test-Plan: lokal kann nichts getestet werden, weil API nur auf Live läuft → 1× Staging-Deploy + Klick-Test im Chat.
+
+---
+
+## Finding 2 — 12 ungenutzte JS-/Patch-Dateien im Repo
+
+**Schweregrad:** Niedrig (kein Bug, aber Lärm)
+**Aufwand:** Gering (Lösch-Commit)
+
+### Details
+
+Folgende Dateien im Repo-Root werden von **keinem** `<script src>` in `index.html`/`index.php` und **keinem** `wp_enqueue_script()` in `functions.php` geladen:
+
+```
+app-state.js              (22  LOC)
+app-router.js             (21  LOC)
+app-utils.js              (40  LOC)
+app-init-override.js      (22  LOC)
+app-demo-patch.js         (9   LOC)
+app_patch_listings.js     (9   LOC)
+eb-router.js              (159 LOC)
+eb-state.js               (176 LOC)
+db-bridge.js              (20  LOC)
+listings-loader.js        (24  LOC)
+mock-data.js              (9   LOC)
+ux-improvements.js        (83  LOC)
+```
+
+Plus drei begleitende Patch-Reste:
+- `_PATCH_ANLEITUNG.md`
+- `_patch_demo_data.md`
+- `functions-analytics-patch.php` (12 Byte — leere Datei)
+
+Inhaltlich sind das Skizzen aus einem früheren Modularisierungsversuch (z.B. `eb-router.js` definiert einen eigenständigen SPA-Router, der vom Monolithen in `app.js` nie aufgerufen wird). Per SFTP landen sie alle in `/wp-content/themes/eventboerse/` und sind theoretisch direkt aufrufbar — keine Sicherheitslücke, aber Code-Müll.
+
+### Proposal
+
+`git rm` für die 12 JS-Dateien + 3 Markdown/PHP-Patches. **Vorher** stichprobenweise per `grep -r` checken, ob ein externer Service (z.B. ein altes WordPress-Plugin, Manifest, externer Test) auf diese Pfade verweist.
+
+### Risiko
+
+- Mittel — minimal aber existent. Falls jemand die Dateien direkt referenziert hat (z.B. in einem alten WP-Plugin), bricht das.
+- Mitigation: erst Backup-Tag setzen (`git tag pre-cleanup-2026-06-16`), dann löschen.
+
+---
+
+## Finding 3 — Vault ↔ Code Drift: Admin-Moderationsrouten
+
+**Schweregrad:** Niedrig (Doku-Drift)
+**Aufwand:** Gering (Entscheidung + Doku-Update)
+
+### Details
+
+`vault/Roadmap/Bekannte-Bugs.md` listet seit 2026-06-06 die Routen `/admin/listings/{id}/hide` und `/my-listing-moderation` als „im Code fehlend". Aktueller Audit bestätigt: kein Frontend-Pfad in `app.js` ruft diese Routen — es gibt also **kein Symptom**, das die Implementierung erzwingt.
+
+### Proposal
+
+Entscheidung treffen:
+- **a) Feature wirklich bauen** (Moderation hat Produkt-Wert — Spam-Listings ausblenden). Dann Sprint-Eintrag + Spec.
+- **b) Vault-Notizen archivieren** und Eintrag aus `Bekannte-Bugs.md` in `vault/Roadmap/Feature-Ideen.md` verschieben.
+
+---
+
+## Was funktioniert (kurzer Positiv-Check)
+
+- 56 von 56 nicht-Chat-Endpoints aus `app.js` haben ein passendes `register_rest_route()`.
+- Auth-Flow (Login, Register, 2FA, WebAuthn) komplett verdrahtet.
+- Stripe Connect-Pfade vorhanden (E2E-Test in Sprint).
+- SPA-Router + History-State funktionieren über alle bekannten Pages.
+- PWA-Setup (manifest, sw.js) ist sauber.
+
+---
+
+## Vorschlag für nächsten Lauf
+
+In der Reihenfolge:
+
+1. **Bestätigen / Ablehnen Finding 1** — wenn ja, baue ich die 8 fehlenden REST-Routen + DB-Migration in einem fokussierten PR (`functions.php`-only, keine Frontend-Änderung).
+2. **Bestätigen / Ablehnen Finding 2** — wenn ja, ein Cleanup-PR der die 12 toten Dateien löscht (nach `grep`-Check).
+3. **Bestätigen / Ablehnen Finding 3** — eine Zeilen-Antwort reicht: „bauen" oder „archivieren".
+
+---
+
+*Erstellt: 2026-06-16 durch Routine-Lauf auf Branch `claude/stoic-darwin-h0hjz5`.*

--- a/vault/Roadmap/Bekannte-Bugs.md
+++ b/vault/Roadmap/Bekannte-Bugs.md
@@ -4,12 +4,41 @@
 
 ## Offen
 
+### [CHAT] 8 Chat-Menü-Aktionen schlagen still fehl — Backend-Routen fehlen
+**Gefunden:** 2026-06-16 (Self-Audit)
+**Betrifft:** `app.js` (Chat-Menü, Nachrichten-Hover-Aktionen), `functions.php` (REST-API)
+**Symptom:** UI-Buttons im Chat zeigen `showToast('Aktion fehlgeschlagen', 'error')` nach Klick. Die Frontend-Funktionen rufen REST-Endpoints auf, die in `functions.php` nicht via `register_rest_route` registriert sind:
+
+| Frontend-Funktion | Endpoint | UI-Button |
+|---|---|---|
+| `hideMessageForMe()` (app.js:5172) | `POST messages/{id}/hide` | „Für mich löschen" pro Nachricht |
+| `_markChatUnread()` (app.js:5365) | `DELETE conversations/{id}/read` | „Als ungelesen markieren" im Chat-Menü |
+| `_clearChat()` (app.js:5373) | `DELETE conversations/{id}` | „Chat löschen" |
+| `_toggleBlockUser()` (app.js:5396) | `POST/DELETE users/{id}/block` | „Blockieren / Blockierung aufheben" |
+| `_reportUser()` (app.js:5421) | `POST users/{id}/report` | „Melden" |
+| `_setChatFlag('mute')` (app.js:5351) | `POST/DELETE conversations/{id}/mute` | „Stummschalten" |
+| `_setChatFlag('pin')` (app.js:5351) | `POST/DELETE conversations/{id}/pin` | „Anheften" |
+| `_setChatFlag('archive')` (app.js:5351) | `POST/DELETE conversations/{id}/archive` | „Archivieren" |
+
+**Reproduzieren:** Im Chat auf das 3-Punkte-Menü → eine der Aktionen klicken. Erwartet: Aktion wird ausgeführt. Tatsächlich: roter Toast „Aktion fehlgeschlagen".
+**Status:** offen (P0 — UI verspricht Funktion, die nirgends implementiert ist)
+**Proposed Fix:** REST-Routen in `functions.php` ergänzen + 1-2 User-Meta-Felder bzw. neue DB-Tabelle für `eb_conversation_flags` (mute/pin/archive/read-state) und `eb_user_blocks` / `eb_user_reports`. Siehe `vault/AI-Gedaechtnis/Audit-2026-06-16.md` für Detail-Vorschlag.
+
+### [REPO] 12 ungenutzte JS-Patch-Dateien werden ausgeliefert
+**Gefunden:** 2026-06-16 (Self-Audit)
+**Betrifft:** Repo-Root (`app-state.js`, `app-router.js`, `app-utils.js`, `app-init-override.js`, `app-demo-patch.js`, `app_patch_listings.js`, `eb-router.js`, `eb-state.js`, `db-bridge.js`, `listings-loader.js`, `mock-data.js`, `ux-improvements.js`) + 2 Patch-Markdowns (`_PATCH_ANLEITUNG.md`, `_patch_demo_data.md`, `functions-analytics-patch.php`)
+**Symptom:** Ca. 615 Zeilen JS werden per SFTP nach IONOS deployed, aber von keinem `<script>`-Tag in `index.html`/`index.php` oder via `wp_enqueue_script` in `functions.php` geladen. Sie können nur über direkte URL-Aufrufe (z.B. `/wp-content/themes/eventboerse/eb-state.js`) ausgeliefert werden — toter Code im Live-Theme.
+**Reproduzieren:** `grep -rE "app-state\.js|eb-router\.js|...." index.html index.php functions.php` liefert keine Treffer.
+**Status:** offen (P2 — kein Funktionsbug, aber Wartungslast + IDE-Verwirrung beim Refactor)
+**Proposed Fix:** Dateien einzeln per `git rm` entfernen, nachdem stichprobenweise bestätigt ist, dass kein externer Service sie referenziert.
+
 ### [ADMIN] Moderationsrouten im Vault vs. Code abgleichen
 **Gefunden:** 2026-06-06
 **Betrifft:** Admin-Moderation, `functions.php`, Vault-Doku
 **Symptom:** Ältere Vault-Notizen dokumentieren `/admin/listings/{id}/hide` und `/my-listing-moderation`; aktueller Code registriert diese REST-Routen nicht.
 **Reproduzieren:** `rg -n "admin/listings|my-listing-moderation" functions.php` liefert keine Route.
 **Status:** offen (P0/P1 prüfen, weil Admin-Ausblenden/Löschen produktrelevant ist)
+**Update 2026-06-16:** Self-Audit bestätigt: in der aktuellen `app.js` ruft kein Frontend-Pfad diese Routen auf. Wahrscheinlich nie implementiert; Vault-Notiz war aspirativ. → Entscheidung nötig: a) Feature bauen oder b) Vault-Notizen archivieren.
 
 ### [PAYMENTS] Stripe Connect E2E noch nicht vollständig verifiziert
 **Gefunden:** 2026-06-06


### PR DESCRIPTION
## Worum es geht

Dieser PR enthält **keinen Code-Fix**, sondern einen Audit-Bericht. Du kannst pro Finding entscheiden, ob ich es im nächsten Lauf umsetze.

Geänderte Dateien:
- `vault/Roadmap/Bekannte-Bugs.md` — 2 neue Einträge oben (Chat-Endpoints + ungenutzte JS-Patches), 1 Update am Admin-Moderations-Eintrag
- `vault/AI-Gedaechtnis/Audit-2026-06-16.md` — Vollbericht mit Aufwand/Risiko pro Finding

## Findings

### 1. Chat-Menü: 8 tote REST-Endpoints (Schwere: hoch)

Diese UI-Buttons im Chat erzeugen aktuell `showToast('Aktion fehlgeschlagen', 'error')`:

| Funktion (`app.js`) | Endpoint (fehlt in `functions.php`) | Button |
|---|---|---|
| `hideMessageForMe()` :5172 | `POST messages/{id}/hide` | „Für mich löschen" pro Nachricht |
| `_markChatUnread()` :5365 | `DELETE conversations/{id}/read` | „Als ungelesen markieren" |
| `_clearChat()` :5373 | `DELETE conversations/{id}` | „Chat löschen" |
| `_toggleBlockUser()` :5396 | `POST/DELETE users/{id}/block` | „Blockieren" |
| `_reportUser()` :5421 | `POST users/{id}/report` | „Melden" |
| `_setChatFlag('mute')` :5351 | `POST/DELETE conversations/{id}/mute` | „Stummschalten" |
| `_setChatFlag('pin')` :5351 | `POST/DELETE conversations/{id}/pin` | „Anheften" |
| `_setChatFlag('archive')` :5351 | `POST/DELETE conversations/{id}/archive` | „Archivieren" |

**Vorschlag:** 3 neue DB-Tabellen (`eb_conversation_flags`, `eb_user_blocks`, `eb_user_reports`) + 1 JSON-Spalte (`eb_messages.hidden_for_user_ids`) + 8 REST-Routen analog zum bestehenden Schema. Frontend bleibt unverändert.

### 2. 12 ungenutzte JS-Patch-Dateien (Schwere: niedrig)

Werden per SFTP nach IONOS deployed, aber von keinem `<script>`-Tag in `index.html` / `index.php` und keinem `wp_enqueue_script` in `functions.php` geladen:

`app-state.js`, `app-router.js`, `app-utils.js`, `app-init-override.js`, `app-demo-patch.js`, `app_patch_listings.js`, `eb-router.js`, `eb-state.js`, `db-bridge.js`, `listings-loader.js`, `mock-data.js`, `ux-improvements.js` + 3 begleitende Patch-Files (`_PATCH_ANLEITUNG.md`, `_patch_demo_data.md`, `functions-analytics-patch.php`).

Ca. 615 LOC toter Code. Reste aus einem früheren Modularisierungsversuch.

**Vorschlag:** `git rm` nach Tag-Backup + `grep`-Stichprobe auf externe Referenzen.

### 3. Vault ↔ Code Drift: Admin-Moderationsrouten (Schwere: niedrig)

Vault-Notiz erwartete `/admin/listings/{id}/hide` und `/my-listing-moderation`. Self-Audit bestätigt: kein Frontend-Pfad ruft sie auf → Feature war aspirativ, nie gebaut.

**Vorschlag:** Entscheidung „bauen" oder „archivieren".

## Wie du jetzt entscheidest

Schreib einfach in der Session/im PR-Kommentar:
- `Finding 1: go` / `nope`
- `Finding 2: go` / `nope`
- `Finding 3: build` / `archive`

Der nächste Routine-Lauf nimmt das auf und setzt um.

## Test plan

- [ ] Audit-Markdown gegenlesen und Findings nachvollziehen
- [ ] Klärung pro Finding (siehe oben)
- [ ] Wenn Finding 1 freigegeben: Folge-PR mit `functions.php`-Routen + DB-Migration → Live-Klick-Test im Chat

🤖 Generated by Claude Code (Routine-Lauf)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfD1sGeiRoh8yEisUNhE2Z)_