### PR TITLE
Auto-Audit 2026-06-17 + Aufräum-Vorschläge zur Abnahme

### DIFF
--- a/vault/AI-Gedaechtnis/Audit-2026-06-17.md
+++ b/vault/AI-Gedaechtnis/Audit-2026-06-17.md
@@ -1,0 +1,114 @@
+# Auto-Audit 2026-06-17
+
+> Automatischer Sichtungsbericht durch den geplanten Claude-Routine-Lauf.
+> Zweck: Zeigen was läuft, was hakt, und welche Aufräum-/Verbesserungs-Vorschläge zur Abnahme bereitliegen.
+> Bedienung: Jede „Vorschlag"-Zeile ist ein eigener Commit-Kandidat — du sagst nur **Ja/Nein**.
+
+---
+
+## 1. Was läuft (grün)
+
+| Bereich | Befund |
+|---|---|
+| Branch `main` | Aktiv, letzter Commit `63785e9` (Vault-API-Notizen). |
+| Branch `claude/stoic-darwin-tq3fip` | Sauberer Working-Tree, 0 Commits voraus von `main` (alles auf `main` gemerged). |
+| Asset-Versionierung | `functions.php` nutzt `filemtime()`-Cache-Busting für `styles.css` und `app.js` — solide. |
+| Service Worker (`sw.js`) | Bewusst minimal: kein HTML/CSS/JS-Cache, nur Offline-Fallback für Navigation. Vermeidet die früheren „stale styles"-Probleme. |
+| PWA Manifest | Vollständig (name, scope, shortcuts, theme, icons als SVG). |
+| Stripe Connect | Onboarding/Status/Diagnose/Disconnect-Routen sind in `functions.php` registriert. |
+| QA-Bot | Launcher schlank, tokenfrei, mit Navigationsaktionen. |
+| Loader/Hero | Doppelte Popper entfernt — UI sauber. |
+| IDN-Login | `eventbörse.de` läuft wieder. |
+
+---
+
+## 2. Was hakt (Drift & offene Bugs)
+
+### 2.1 Vault-Doku ist veraltet (Drift in Code-Statistiken)
+
+| Datei | Vault sagt | Realer Stand | Delta |
+|---|---:|---:|---:|
+| `app.js` | 20 769 Z | 21 061 Z | +292 |
+| `functions.php` | 6 741 Z | 7 061 Z | +320 |
+| `styles.css` | 14 716 Z | 14 956 Z | +240 |
+| `index.php` | 3 934 Z | 4 003 Z | +69 |
+| REST-Routen | „80" / „67" | **82** (`grep register_rest_route`) | korrekt aktualisieren |
+
+**Vorschlag A1:** `vault/Dashboard.md`, `vault/AI-Gedaechtnis/Claude-Kontext.md`, `vault/AI-Gedaechtnis/Code-Stats.md` mit aktuellen Zahlen syncen. Ja/Nein?
+
+### 2.2 Bekannter Bug aus `Bekannte-Bugs.md` ist noch offen
+
+`/admin/listings/{id}/hide` und `/my-listing-moderation` sind weiterhin **nicht** in `functions.php` registriert (verifiziert via Grep). UI-Pfad und Backend-Pfad driften auseinander.
+
+**Vorschlag A2:** Kurz im Admin-UI prüfen, ob die UI-Aktionen „Inserat ausblenden / Moderation" überhaupt noch existieren. Wenn ja → Routen wiederherstellen. Wenn nein → Bug-Eintrag als „obsolet" markieren. Ja/Nein zu Schritt 1 (UI prüfen + Befund melden)?
+
+### 2.3 PWA: Icons nur als SVG
+
+Manifest listet nur `favicon.svg` (`sizes: "any"`). Android verlangt für „Add to Home Screen"-Banner & Splash-Screen typischerweise 192×192 und 512×512 PNG. iOS ignoriert Manifest-Icons komplett.
+
+**Vorschlag A3:** PNG-Icons (192/512) und `apple-touch-icon` in `<head>` ergänzen — `generate-icons.html` ist schon im Repo, also vermutlich vorbereitet. Ja/Nein?
+
+---
+
+## 3. Tot-Code / Aufräum-Kandidaten
+
+Diese Dateien werden im Live-System **nicht geladen** (kein `wp_enqueue_*`-Eintrag, kein `<script>`/`<link>` in `index.php` oder `index.html`). Inhalt geprüft:
+
+| Datei | Größe | Inhalt | Status |
+|---|---:|---|---|
+| `LICENSE.md` | 0 B | leer | tot |
+| `Stripe.md` | 0 B | leer | tot |
+| `functions-analytics-patch.php` | 12 B | nur `<?php` | tot |
+| `_PATCH_ANLEITUNG.md` | 596 B | Markdown-Codefence ohne Inhalt | tot |
+| `_patch_demo_data.md` | 1.9 KB | Stale Patch-Anweisungen aus früherer AI-Session, endet mit „Ich kann nicht die vollständige app.js liefern" | tot |
+| `app-demo-patch.js` | 9 Z | Stub | tot |
+| `app-init-override.js` | 22 Z | DOMContentLoaded-Stub für `loadDbListings` | tot |
+| `app-router.js` | 20 Z | Stub | tot |
+| `app-state.js` | 21 Z | Stub | tot |
+| `app-utils.js` | 39 Z | Stub | tot |
+| `app_patch_listings.js` | 9 Z | Stub | tot |
+| `db-bridge.js` | 19 Z | Stub | tot |
+| `eb-router.js` | 159 Z | Eigener SPA-Router — parallel zu `navigateTo()` in `app.js` (Dead Twin) | tot |
+| `eb-state.js` | 176 Z | Eigener State-Modul-Versuch (Dead Twin) | tot |
+| `listings-loader.js` | 24 Z | Loader-Stub | tot |
+| `js/listings-loader.js` | 24 Z | Doppelt zum obigen | tot |
+| `mock-data.js` | 9 Z | Stub | tot |
+| `mobile-overrides.css` | 485 Z | Mobile-Overrides, nicht enqueued | tot |
+| `ux-improvements.js` | 83 Z | UX-Patch-Datei, nicht geladen | tot |
+
+**Loadliste verifiziert:**
+- `functions.php` enqueued nur: `styles.css` (+ `style.css` Header), `app.js`, Google-Fonts/Material-Icons, Leaflet, Flatpickr, Stripe.js.
+- `index.php` lädt zusätzlich `ui-enhancements.css` (✅ lebt) und `manifest.json`.
+- `index.html` (Static-Fallback) lädt nur `styles.css` und `app.js`.
+
+**Vorschlag B1 (zero-risk):** Die 3 wirklich leeren/leeren-Stub-Dateien löschen: `LICENSE.md`, `Stripe.md`, `functions-analytics-patch.php`. Ja/Nein?
+
+**Vorschlag B2 (low-risk):** Stale Patch-Doku entfernen: `_PATCH_ANLEITUNG.md`, `_patch_demo_data.md`. Inhalt = abgebrochene AI-Anleitungen. Ja/Nein?
+
+**Vorschlag B3 (low-risk, größerer Schnitt):** Alle nicht-geladenen JS/CSS-Stubs löschen (`app-*.js`, `app_patch_listings.js`, `db-bridge.js`, `eb-router.js`, `eb-state.js`, `listings-loader.js`, `js/listings-loader.js`, `mobile-overrides.css`, `mock-data.js`, `ux-improvements.js`). Falls du eines davon noch als „Patch-Vorlage" behalten willst — bitte einzeln rauspicken. Ja/Nein/Teilauswahl?
+
+> Hinweis: Alle Löschungen sind via Git reversibel (`git revert` reicht).
+
+---
+
+## 4. P0/P1 aus dem Sprint, die diese Routine noch nicht angefasst hat
+
+- **Stripe Connect E2E** — Testmodus-Durchlauf braucht echten Stripe-Test-Key + Webhook-Endpoint. Geht nicht autonom ohne Secrets. Status: bleibt offen für Live-Test.
+- **Listings/Board Regression-Schutz** — verlangt automatisierte Tests (aktuell keine vorhanden, siehe „bekannte Schwächen" in CLAUDE.md). Reines Code-Pflastern ohne Tests bringt wenig. Möglicher Mini-Schritt: 1 Playwright-Smoke gegen den Live-Server. Ja/Nein für einen Vorschlag dazu im nächsten Lauf?
+- **Echtzeit-Messaging (SSE/WebSocket)** — größer als ein autonomer Lauf, Architektur-Entscheidung. Bewusst nicht angefasst.
+
+---
+
+## 5. Empfehlung für diesen Lauf
+
+Mein Vorschlag in Reihenfolge (alles via Draft-PR — du klickst Approve auf den Teil, den du willst):
+
+1. **Diesen Audit-Bericht mergen** (kein Code-Risiko, nur Vault-Doku). 
+2. **Vorschlag B1** ausführen (3 leere Tot-Dateien löschen). 
+3. **Vorschlag A1** ausführen (Vault-Drift korrigieren).
+4. Alles ab **B2/B3/A2/A3** erst nach deinem Okay anfassen.
+
+Wenn du auf den Lauf nicht reagierst, bleibt nur dieser Bericht im Vault — keine destruktiven Aktionen.
+
+---
+*Erzeugt vom geplanten Claude-Routine-Lauf am 2026-06-17.*


### PR DESCRIPTION
## Was dieser PR ist

Reiner **Status-Report im Vault** — kein Code-Risiko. Neue Datei: `vault/AI-Gedaechtnis/Audit-2026-06-17.md`.

Dieser Lauf hat die Codebasis + Obsidian-Vault gesichtet und alles in eine **„Vorschlag → Ja/Nein"-Liste** überführt, damit du nur noch abnicken musst.

## TL;DR

- ✅ **Läuft sauber**: Branch, Asset-Versionierung, Service Worker (Pass-Through), QA-Bot, Stripe-Connect-Routen, IDN-Login.
- ⚠️ **Driftet**: Vault-Statistiken zeigen alte Zeilenzahlen (`app.js` +292, `functions.php` +320, `styles.css` +240). REST-Routen sind real **82**, Doku sagt 67/80.
- 🐛 **Offener Bug bestätigt**: `/admin/listings/{id}/hide` & `/my-listing-moderation` nicht registriert (verifiziert per Grep).
- 🧹 **19 nicht geladene Dateien** identifiziert (Tot-Code aus früheren AI-Patch-Sessions) — vollständige Liste mit Größen im Report.

## Approve/Reject-Liste (jede Zeile = eigener Folge-Commit)

### Sicher (zero-risk)
- [ ] **B1** — 3 leere/leere-Stub-Dateien löschen: `LICENSE.md` (0 B), `Stripe.md` (0 B), `functions-analytics-patch.php` (12 B)
- [ ] **A1** — Vault-Drift fixen: `Dashboard.md` + `Claude-Kontext.md` + `Code-Stats.md` auf aktuelle Zahlen

### Low-Risk
- [ ] **B2** — Stale Patch-Doku entfernen: `_PATCH_ANLEITUNG.md`, `_patch_demo_data.md`
- [ ] **B3** — Tot-JS/CSS löschen: `app-*.js`, `app_patch_listings.js`, `db-bridge.js`, `eb-router.js`, `eb-state.js`, `listings-loader.js`, `js/listings-loader.js`, `mobile-overrides.css`, `mock-data.js`, `ux-improvements.js` (Teilauswahl möglich)
- [ ] **A2** — Admin-Moderations-Route-Diagnose (zuerst UI-Pfad prüfen, dann Routen wiederherstellen oder Bug schließen)
- [ ] **A3** — PWA: PNG-Icons 192/512 + `apple-touch-icon` ergänzen (`generate-icons.html` ist schon im Repo)

### Größer (eigenständige PRs)
- [ ] Listings/Board Playwright-Smoke gegen Live-Server
- Stripe Connect E2E (braucht Test-Secrets — manuell)
- Echtzeit-Messaging (Architektur-Entscheidung)

## Bedienung

- **Komplett dafür** → PR mergen (nur Doku) → ich starte beim nächsten Lauf B1+A1 automatisch.
- **Selektiv** → einzelne Checkboxen abhaken / Kommentar mit „ja zu B1, nein zu B2".
- **Nichts davon** → PR schließen → Audit bleibt als Snapshot im Branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_017Eicg32WMSw2iFg3HTtwXh

---
_Generated by [Claude Code](https://claude.ai/code/session_017Eicg32WMSw2iFg3HTtwXh)_