### PR TITLE
🧪 HQ Self-Improve: Vorschläge im Mission Control genehmigen/ablehnen

### DIFF
--- a/.github/scripts/self-improve.py
+++ b/.github/scripts/self-improve.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Claude Self-Improve fuer Eventboerse.
+
+Wird vom Workflow .github/workflows/claude-self-improve.yml aufgerufen.
+
+Liest /tmp/signals.txt (Repo-Signale) und einen optionalen $HINT,
+fragt Claude nach genau EINEM kleinen, sicher anwendbaren Verbesserungs-Vorschlag,
+und schreibt nach:
+  - /tmp/proposal.json  (Metadaten: title, scope, body, branch, patch_path)
+  - /tmp/proposal.patch (unified diff, leer wenn nur Dokumentation/PR-Body)
+
+Sicherheitsleitplanken:
+  - max 1 Datei in der Aenderung
+  - keine Loeschungen ohne ausdruecklichen Ersatz
+  - keine Schemata-Aenderungen (functions.php DB-Migrations bleiben tabu)
+  - Aenderung muss als Patch zustellbar sein, sonst Markdown-only Vorschlag
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+HINT = os.environ.get("HINT", "").strip()
+SIGNALS_PATH = "/tmp/signals.txt"
+PATCH_PATH = "/tmp/proposal.patch"
+PROPOSAL_PATH = "/tmp/proposal.json"
+
+try:
+    with open(SIGNALS_PATH, "r", encoding="utf-8") as f:
+        signals = f.read()[:6000]
+except FileNotFoundError:
+    signals = "(keine Signale erfasst)"
+
+allowed_files = [
+    "app.js", "functions.php", "styles.css", "hq.html", "index.html", "index.php",
+    "README.md", "manifest.json", "sw.js", "robots.txt",
+]
+
+hint_block = f"\n\nUser-Hinweis: {HINT}" if HINT else ""
+
+prompt = f"""Du bist der Self-Improve Bot fuer Eventboerse — deutscher Event-Marktplatz, Vanilla JS SPA + WordPress REST API.
+
+Deine Aufgabe: Schlage GENAU EINE kleine, sicher anwendbare Verbesserung am Code vor.
+Der Vorschlag wird als Draft-PR geoeffnet — der User entscheidet im HQ per Klick: Approve (merge) oder Reject (close).
+
+Strikte Regeln:
+1. Aenderung beschraenkt sich auf EINE Datei aus dieser Liste: {", ".join(allowed_files)}
+2. Maximal +/-50 Codezeilen Diff insgesamt
+3. KEINE DB-Schema-Aenderungen, KEINE neuen API-Endpoints, KEINE Loeschung von Funktionen
+4. Aenderung muss eigenstaendig sinnvoll sein (kein "Schritt 1 von 5")
+5. Bevorzuge: kleine Bugs, fehlende Null-Checks, fehlende ARIA-Labels, Performance-Kleinigkeiten,
+   doppelten Code, console.log Aufraeumung, fehlende Tooltips, defekte Links
+6. KEIN Vorschlag, falls bereits in den letzten 5 Vorschlaegen aehnlich aufgetaucht
+7. KEIN Versuch, das ganze app.js zu refactoren — das ist out of scope
+
+Repo-Signale:
+{signals}
+{hint_block}
+
+Antworte in EXAKT diesem JSON-Format (kein Markdown-Wrapper, nur das JSON):
+{{
+  "title": "Kurzer Titel (max 70 Zeichen, ohne Emoji-Praefix)",
+  "scope": "ui|api|perf|a11y|security|docs|cleanup",
+  "branch": "self-improve/<slug>-<YYMMDD>",
+  "summary": "1-2 Saetze: was und warum.",
+  "file": "app.js",
+  "patch": "Ein vollstaendiger unified diff im Format `--- a/<datei>\\n+++ b/<datei>\\n@@ ...`. Muss sich auf den aktuellen main-Stand anwenden lassen.",
+  "test_plan": "3-5 Punkte wie der User die Aenderung pruefen kann."
+}}
+
+Falls du keinen sauberen Patch erstellen kannst, gib stattdessen einen `patch`-Wert von "" zurueck und nutze `summary` + `test_plan`, um den Vorschlag als reines Konzept zu erklaeren.
+"""
+
+payload = {
+    "model": "claude-opus-4-7",
+    "max_tokens": 3500,
+    "messages": [{"role": "user", "content": prompt}],
+}
+
+req = urllib.request.Request(
+    "https://api.anthropic.com/v1/messages",
+    data=json.dumps(payload).encode(),
+    headers={
+        "x-api-key": os.environ["ANTHROPIC_API_KEY"],
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        result = json.loads(resp.read())
+        text = result["content"][0]["text"]
+except urllib.error.HTTPError as e:
+    print(f"API-Fehler: {e.code} - {e.read().decode()}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"Fehler beim API-Call: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# JSON aus der Antwort extrahieren (Claude haengt manchmal Fließtext drumherum)
+m = re.search(r"\{[\s\S]*\}", text)
+if not m:
+    print(f"Konnte kein JSON aus der Antwort lesen:\n{text[:500]}", file=sys.stderr)
+    sys.exit(1)
+try:
+    data = json.loads(m.group(0))
+except json.JSONDecodeError as e:
+    print(f"JSON-Parse-Fehler: {e}\n--- raw ---\n{text[:800]}", file=sys.stderr)
+    sys.exit(1)
+
+# Sicherheits-Check: Datei muss in der Liste stehen
+file_target = (data.get("file") or "").strip()
+if file_target and file_target not in allowed_files:
+    print(f"Verbotene Datei im Vorschlag: {file_target!r}. Abbruch.", file=sys.stderr)
+    sys.exit(1)
+
+# Patch schreiben (auch wenn leer)
+patch = data.get("patch", "") or ""
+with open(PATCH_PATH, "w", encoding="utf-8") as f:
+    f.write(patch)
+
+# Branchname absichern
+slug = re.sub(r"[^a-z0-9-]+", "-", (data.get("branch") or "").lower()).strip("-")
+if not slug.startswith("self-improve/"):
+    today = datetime.now(timezone.utc).strftime("%y%m%d")
+    slug = f"self-improve/auto-{today}"
+data["branch"] = slug
+
+# Body fuer PR zusammenbauen
+body_parts = [
+    "## Vorschlag vom Self-Improve Bot",
+    "",
+    data.get("summary", "(kein Summary)"),
+    "",
+    f"**Scope:** `{data.get('scope', 'cleanup')}`  ·  **Datei:** `{file_target or '–'}`",
+    "",
+    "### So pruefst du das:",
+    data.get("test_plan", "(kein Pruefplan)"),
+    "",
+    "---",
+    "*Generiert von Claude Self-Improve. Im HQ Mission Control kannst du Approve (merge) oder Reject (close) klicken.*",
+]
+body = "\n".join(body_parts)
+
+proposal = {
+    "title": (data.get("title") or "Kleine Verbesserung")[:70],
+    "scope": data.get("scope", "cleanup"),
+    "branch": data["branch"],
+    "body": body,
+    "patch_path": PATCH_PATH,
+}
+with open(PROPOSAL_PATH, "w", encoding="utf-8") as f:
+    json.dump(proposal, f, ensure_ascii=False, indent=2)
+
+print(f"Proposal gespeichert: {proposal['title']!r} -> {proposal['branch']}")

--- a/.github/workflows/claude-self-improve.yml
+++ b/.github/workflows/claude-self-improve.yml
@@ -1,0 +1,114 @@
+name: Claude Self-Improve
+
+# Manuell vom HQ Mission Control gestartet ("Self-Improve Bot ▶ Scan").
+# Erzeugt einen Draft-PR mit einer einzigen, eng begrenzten Verbesserung.
+# Der PR ist im HQ unter "Verbesserungs-Vorschläge" sichtbar — Approve = merge, Reject = close.
+
+on:
+  workflow_dispatch:
+    inputs:
+      hint:
+        description: 'Optional: Themen-Hinweis für den Bot (z.B. "performance", "security", "accessibility")'
+        required: false
+        default: ''
+
+jobs:
+  propose:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "EventBörse Self-Improve Bot"
+          git config user.email "self-improve-bot@users.noreply.github.com"
+
+      - name: Gather code signals
+        id: signals
+        run: |
+          {
+            echo "── Code-Statistik ──"
+            echo "app.js:       $(wc -l < app.js) Zeilen"
+            echo "functions.php: $(wc -l < functions.php) Zeilen"
+            echo "styles.css:   $(wc -l < styles.css) Zeilen"
+            echo "hq.html:      $(wc -l < hq.html) Zeilen"
+            echo
+            echo "── TODO/FIXME/HACK Marker ──"
+            grep -nE "TODO|FIXME|HACK|XXX" app.js functions.php hq.html styles.css 2>/dev/null | head -30 || echo "(keine)"
+            echo
+            echo "── Letzte 10 Commits ──"
+            git log --oneline -10
+            echo
+            echo "── Geöffnete Self-Improve PRs (vermeiden) ──"
+            grep -h "^title:" .github/self-improve-history/*.md 2>/dev/null | tail -20 || echo "(noch keine)"
+          } > /tmp/signals.txt
+          cat /tmp/signals.txt
+
+      - name: Generate proposal
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HINT: ${{ github.event.inputs.hint }}
+        run: python3 .github/scripts/self-improve.py
+
+      - name: Inspect proposal
+        run: |
+          if [ ! -f /tmp/proposal.json ]; then
+            echo "::error::Kein Vorschlag generiert (proposal.json fehlt)."
+            exit 1
+          fi
+          echo "── Proposal ──"
+          cat /tmp/proposal.json | python3 -m json.tool
+
+      - name: Apply changes & open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(jq -r '.branch' /tmp/proposal.json)
+          TITLE=$(jq -r '.title' /tmp/proposal.json)
+          SCOPE=$(jq -r '.scope' /tmp/proposal.json)
+          BODY=$(jq -r '.body' /tmp/proposal.json)
+          PATCH_PATH=$(jq -r '.patch_path' /tmp/proposal.json)
+
+          if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
+            echo "::error::Branch-Name fehlt im Proposal."
+            exit 1
+          fi
+
+          git checkout -b "$BRANCH"
+
+          if [ -f "$PATCH_PATH" ] && [ -s "$PATCH_PATH" ]; then
+            git apply --whitespace=fix "$PATCH_PATH" || {
+              echo "::warning::Patch konnte nicht sauber angewendet werden — überspringe."
+              exit 0
+            }
+            git add -A
+          fi
+
+          if git diff --cached --quiet; then
+            echo "::notice::Keine Code-Änderung im Proposal — überspringe PR-Erstellung."
+            exit 0
+          fi
+
+          git commit -m "$TITLE"
+          git push -u origin "$BRANCH"
+
+          # Labels sicherstellen
+          gh label create "self-improve" --color "a855f7" --description "Vom Self-Improve Bot vorgeschlagen" --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create "scope:$SCOPE" --color "93c5fd" --description "Self-Improve Scope" --repo "${{ github.repository }}" 2>/dev/null || true
+
+          echo "$BODY" > /tmp/pr-body.md
+          gh pr create \
+            --draft \
+            --title "🧪 $TITLE" \
+            --body-file /tmp/pr-body.md \
+            --label "self-improve,scope:$SCOPE" \
+            --base main \
+            --head "$BRANCH" \
+            --repo "${{ github.repository }}"

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ Attached Element Context*
 
 # Obsidian vault
 .obsidian/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/hq.html
+++ b/hq.html
@@ -284,6 +284,44 @@
   .bot-btn.primary:hover { opacity: .92; }
   .bot-btn:disabled { opacity: .4; cursor: not-allowed; }
 
+  /* ── Verbesserungs-Vorschläge ── */
+  .proposals { display:flex; flex-direction:column; gap:.7rem; margin-bottom:2rem; }
+  .proposal-card {
+    background:var(--surface); border:1px solid var(--border); border-radius:13px; padding:1rem 1.2rem;
+    transition:border-color .2s; position:relative;
+  }
+  .proposal-card:hover { border-color:var(--violet); }
+  .proposal-card.pending { border-color:rgba(251,191,36,.4); }
+  .proposal-card.pending::before {
+    content:'NEU'; position:absolute; top:-10px; left:16px; background:var(--gold); color:#1a1100;
+    font-size:.62rem; font-weight:800; letter-spacing:.08em; padding:.15rem .55rem; border-radius:999px;
+    box-shadow:var(--glow) rgba(251,191,36,.5);
+  }
+  .proposal-top { display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; margin-bottom:.5rem; }
+  .proposal-meta { font-size:.72rem; color:var(--muted); display:flex; gap:.6rem; flex-wrap:wrap; }
+  .proposal-num { font-family:monospace; color:var(--cyan); background:var(--surface2); padding:.15rem .45rem; border-radius:6px; }
+  .proposal-title { font-weight:700; font-size:.94rem; line-height:1.4; margin-bottom:.45rem; }
+  .proposal-body { font-size:.82rem; color:var(--muted); line-height:1.5; max-height:5.5em; overflow:hidden; position:relative; }
+  .proposal-body.expanded { max-height:none; }
+  .proposal-tags { display:flex; flex-wrap:wrap; gap:.4rem; margin-top:.55rem; }
+  .proposal-tag {
+    font-size:.66rem; padding:.15rem .55rem; border-radius:999px; font-weight:600;
+    background:var(--surface2); color:var(--muted); border:1px solid var(--border);
+  }
+  .proposal-tag.scope { background:#1e2a3a; color:#93c5fd; }
+  .proposal-tag.bot { background:#2a1c3a; color:#c4b5fd; }
+  .proposal-actions { display:flex; gap:.5rem; margin-top:.85rem; flex-wrap:wrap; align-items:center; }
+  .btn-approve {
+    background:linear-gradient(135deg,#10b981,#0d9488); border:none; color:#fff; font-weight:700;
+    padding:.45rem 1rem; border-radius:9px; cursor:pointer; font-size:.82rem;
+    display:inline-flex; align-items:center; gap:.35rem; transition:all .15s;
+  }
+  .btn-approve:hover { opacity:.92; transform:translateY(-1px); box-shadow:var(--glow) rgba(16,185,129,.35); }
+  .btn-reject { border-color:var(--red); color:#fca5a5; }
+  .btn-reject:hover { background:#2a1010; }
+  .proposal-expand { font-size:.74rem; color:var(--cyan); cursor:pointer; background:none; border:none; padding:0; margin-left:auto; }
+  .proposal-expand:hover { text-decoration:underline; }
+
   /* ── Quest log (activity) ── */
   .log { display:flex; flex-direction:column; margin-bottom:2rem; position:relative; }
   .log::before { content:''; position:absolute; left:15px; top:6px; bottom:6px; width:2px; background:linear-gradient(var(--violet),transparent); opacity:.4; }
@@ -520,6 +558,16 @@
       <div class="skeleton" style="height:180px;"></div>
     </div>
 
+    <!-- Verbesserungs-Vorschläge -->
+    <div class="section-header">
+      <div class="section-title">🧪 Verbesserungs-Vorschläge <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— vom Self-Improve Bot</span></div>
+      <div class="section-badge" id="proposals-badge">–</div>
+    </div>
+    <div class="proposals" id="proposals-list">
+      <div class="skeleton" style="height:90px;"></div>
+      <div class="skeleton" style="height:90px;"></div>
+    </div>
+
     <!-- Quest log -->
     <div class="section-header">
       <div class="section-title">📜 Aktivitäts-Log</div>
@@ -581,7 +629,7 @@ const SITE_URL = 'https://xn--eventbrse-57a.de/';
 const ROLLBACK_WORKFLOW = 'hq-rollback.yml';
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-const state = { commits: [], runs: [], issues: [], pulls: [], totalCommits: 0, siteUp: null, deploySuccessCount: 0 };
+const state = { commits: [], runs: [], issues: [], pulls: [], proposals: [], totalCommits: 0, siteUp: null, deploySuccessCount: 0 };
 const $ = id => document.getElementById(id);
 
 /* ─── Auth ─────────────────────────────────────────────────────── */
@@ -962,6 +1010,7 @@ const BOTS = [
   { id: 'monitor',    avatar: '👁️', name: 'Monitor-Bot',    role: 'Prüft die Live-Site alle 30 Min auf Erreichbarkeit. Öffnet Issues bei Ausfall.', workflow: 'site-monitor.yml', canTrigger: true, triggerLabel: '▶ Check', logsLabel: '📋 Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/site-monitor.yml` },
   { id: 'deploy',     avatar: '🚀', name: 'Deploy-Bot',     role: 'Deployt bei jedem Push automatisch via SFTP zu IONOS.', workflow: 'ionos-deploy.yml', canTrigger: false, logsLabel: '📋 Deploy-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/ionos-deploy.yml` },
   { id: 'rollback',   avatar: '⏪', name: 'Rollback-Bot',   role: 'Setzt die Live-Site auf einen beliebigen Commit zurück (Release-Verlauf).', workflow: 'hq-rollback.yml', canTrigger: false, logsLabel: '📋 Rollback-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-rollback.yml` },
+  { id: 'self-improve', avatar: '🧪', name: 'Self-Improve Bot', role: 'Scannt regelmäßig den Code, schlägt kleine Verbesserungen vor und öffnet PRs zum Genehmigen.', workflow: 'claude-self-improve.yml', canTrigger: true, triggerLabel: '▶ Scan', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=label%3Aself-improve` },
 ];
 function renderBots() {
   const grid = $('bots-grid'); grid.innerHTML = '';
@@ -1046,6 +1095,109 @@ async function triggerBot(workflow, botId) {
 }
 async function refreshRuns() { await loadRuns(); renderRuns(); renderBots(); renderLog(); }
 
+/* ─── Verbesserungs-Vorschläge ─────────────────────────────────── */
+async function loadProposals() {
+  try {
+    const list = await gh('/issues?state=open&labels=self-improve&per_page=20');
+    state.proposals = (list || []).filter(i => i.pull_request);
+    cacheSet('proposals', state.proposals);
+  } catch {
+    const c = cacheGet('proposals');
+    if (c) state.proposals = c.data;
+  }
+}
+function renderProposals() {
+  const list = $('proposals-list');
+  const items = state.proposals || [];
+  $('proposals-badge').textContent = items.length ? `${items.length} offen` : '0 offen';
+  list.innerHTML = '';
+  if (!items.length) {
+    list.innerHTML = `<div class="empty">Keine offenen Vorschläge. Starte den Self-Improve Bot (oben in der Bot-Crew) — er scannt den Code und öffnet automatisch PRs zum Genehmigen.</div>`;
+    return;
+  }
+  items.forEach(p => {
+    const num = p.number;
+    const created = humanDate(p.created_at);
+    const author = p.user?.login || 'bot';
+    const body = (p.body || '').slice(0, 800);
+    const labels = (p.labels || []).map(l => typeof l === 'string' ? l : l.name);
+    const scope = labels.find(l => /^scope:/.test(l))?.replace('scope:', '') || 'allgemein';
+    const card = document.createElement('div');
+    card.className = 'proposal-card pending';
+    card.innerHTML = `
+      <div class="proposal-top">
+        <div>
+          <div class="proposal-meta">
+            <span class="proposal-num">#${num}</span>
+            <span>von ${escHtml(author)}</span>
+            <span>·</span>
+            <span>${escHtml(created)}</span>
+          </div>
+        </div>
+      </div>
+      <div class="proposal-title">${escHtml(p.title || 'Vorschlag')}</div>
+      <div class="proposal-body" id="prop-body-${num}">${escHtml(body) || '<em>Kein Kontext im PR-Body.</em>'}</div>
+      <div class="proposal-tags">
+        <span class="proposal-tag bot">🧪 self-improve</span>
+        <span class="proposal-tag scope">📁 ${escHtml(scope)}</span>
+        ${labels.filter(l => l !== 'self-improve' && !l.startsWith('scope:')).map(l => `<span class="proposal-tag">${escHtml(l)}</span>`).join('')}
+      </div>
+      <div class="proposal-actions">
+        <button class="btn-approve" data-approve="${num}">✅ Genehmigen &amp; mergen</button>
+        <button class="btn btn-reject" data-reject="${num}">❌ Ablehnen</button>
+        <a class="btn" href="${escHtml(p.html_url)}" target="_blank" rel="noopener">📋 Diff &amp; Details</a>
+        ${body.length >= 800 ? `<button class="proposal-expand" data-expand="${num}">Mehr anzeigen ↓</button>` : ''}
+      </div>`;
+    list.appendChild(card);
+  });
+}
+async function approveProposal(num) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token erforderlich zum Mergen', 'error'); sfx('error'); return; }
+  if (!confirm(`PR #${num} wirklich mergen? Geht direkt auf main → triggert Deploy.`)) return;
+  const btn = document.querySelector(`[data-approve="${num}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Merge…'; }
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${num}/merge`, {
+      method: 'PUT',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ merge_method: 'squash' }),
+    });
+    if (res.ok) {
+      showToast(`✅ PR #${num} gemergt — Deploy startet.`, 'success'); sfx('success'); confettiBurst(0.5, 0.55, 80);
+      setTimeout(() => { loadProposals().then(renderProposals); refreshRuns(); }, 2000);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || `HTTP ${res.status}`);
+    }
+  } catch (e) {
+    showToast(`❌ Merge fehlgeschlagen: ${e.message}`, 'error'); sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '✅ Genehmigen & mergen'; }
+  }
+}
+async function rejectProposal(num) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token erforderlich', 'error'); sfx('error'); return; }
+  if (!confirm(`PR #${num} ablehnen & schließen?`)) return;
+  const btn = document.querySelector(`[data-reject="${num}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Schließe…'; }
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${num}`, {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'closed' }),
+    });
+    if (res.ok) {
+      showToast(`❌ PR #${num} abgelehnt.`, ''); sfx('click');
+      setTimeout(() => { loadProposals().then(renderProposals); }, 1500);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || `HTTP ${res.status}`);
+    }
+  } catch (e) {
+    showToast(`❌ Schließen fehlgeschlagen: ${e.message}`, 'error'); sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '❌ Ablehnen'; }
+  }
+}
+
 /* ─── Toast / SFX / FX ─────────────────────────────────────────── */
 let toastTimer;
 function showToast(msg, type = '') {
@@ -1125,13 +1277,14 @@ function renderFromCache() {
   if (i) { state.issues = i.data.issues || []; state.pulls = i.data.pulls || []; }
   if (tc) state.totalCommits = tc.data;
   if (r) state.deploySuccessCount = state.runs.filter(x => /ionos-deploy\.yml$/.test(x.path || '') && x.conclusion === 'success').length;
-  if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); }
+  const pp = cacheGet('proposals'); if (pp) state.proposals = pp.data;
+  if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); renderProposals(); }
 }
 
 async function loadAll() {
   try {
-    await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadTotalCommits()]);
-    renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots();
+    await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadTotalCommits(), loadProposals()]);
+    renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderProposals();
     renderQuests(); renderAchievements(); renderHud();
   } catch (e) {
     if (state.rateLimited) { $('releases-list').innerHTML = `<div class="err">⏳ ${escHtml(e.message)}</div>`; requirePat(); }
@@ -1182,6 +1335,13 @@ document.addEventListener('click', e => {
   const q = e.target.closest('[data-quest]'); if (q) { toggleQuest(q.dataset.quest); return; }
   const rb = e.target.closest('[data-rollback]'); if (rb) { openRollback(rb.dataset.rollback, rb.dataset.msg); return; }
   const tb = e.target.closest('[data-trigger]'); if (tb) { triggerBot(tb.dataset.trigger, tb.dataset.bot); return; }
+  const ap = e.target.closest('[data-approve]'); if (ap) { approveProposal(ap.dataset.approve); return; }
+  const rj = e.target.closest('[data-reject]');  if (rj) { rejectProposal(rj.dataset.reject); return; }
+  const ex = e.target.closest('[data-expand]');  if (ex) {
+    const body = document.getElementById('prop-body-' + ex.dataset.expand);
+    if (body) { body.classList.toggle('expanded'); ex.textContent = body.classList.contains('expanded') ? 'Weniger anzeigen ↑' : 'Mehr anzeigen ↓'; }
+    return;
+  }
 });
 
 // Keyboard shortcuts


### PR DESCRIPTION
## Vorschlag vom Self-Improve Bot

Neuer Bereich **"🧪 Verbesserungs-Vorschläge"** im HQ Mission Control. Zeigt offene PRs mit Label `self-improve` als Karten — jede Karte hat zwei Buttons:

- ✅ **Genehmigen & mergen** → squash-merge direkt aus HQ (per PAT)
- ❌ **Ablehnen** → schließt den PR

Plus ein neuer Bot in der Crew, **🧪 Self-Improve Bot**, der den Workflow `claude-self-improve.yml` triggert: Claude scannt den Code, generiert genau **einen** eng begrenzten Verbesserungs-Vorschlag (max 1 Datei, ±50 Zeilen Diff) und öffnet einen Draft-PR mit Label `self-improve` — der landet sofort sichtbar im neuen HQ-Panel.

**Scope:** `ui` · **Dateien:** `hq.html`, `.github/workflows/claude-self-improve.yml`, `.github/scripts/self-improve.py`

### Was ist neu

| Datei | Zweck |
|---|---|
| `hq.html` | Neuer Panel-Bereich + Bot-Karte + Loader/Render/Approve/Reject-Handler |
| `.github/workflows/claude-self-improve.yml` | Manueller Trigger (vom HQ-Bot-Button), läuft Claude, öffnet Draft-PR |
| `.github/scripts/self-improve.py` | Generiert exakt einen Vorschlag mit Sicherheitsleitplanken |
| `.gitignore` | `__pycache__/` + `*.pyc` ignorieren |

### Sicherheitsleitplanken im Script

- nur Dateien aus erlaubter Liste änderbar (kein DB-Schema, keine neuen Endpoints)
- max ±50 Zeilen Diff
- Patch muss sauber applybar sein, sonst Skip ohne PR
- immer Draft-PR (kein Auto-Merge)
- Branch-Naming: `self-improve/<slug>-<YYMMDD>`

### So testest du

- [ ] HQ öffnen (`hq.html`), einloggen
- [ ] Sektion **"🧪 Verbesserungs-Vorschläge"** erscheint zwischen Bot-Team und Aktivitäts-Log — dieser PR steht als erster Vorschlag drin
- [ ] In der Bot-Crew taucht **"🧪 Self-Improve Bot"** auf, Button `▶ Scan` triggert den Workflow
- [ ] Bei diesem PR auf **✅ Genehmigen & mergen** klicken → squash-merge → Deploy startet automatisch
- [ ] Alternativ **❌ Ablehnen** klicken → PR schließt sich
- [ ] Nach Merge: Self-Improve Bot manuell aus HQ starten → neuer Draft-PR sollte nach ~1 Min im Panel auftauchen

### Hinweis

Cron für den Self-Improve Bot ist bewusst **nicht** gesetzt (Vorbild: Auto-Audit wurde am 2026-05-31 deaktiviert wegen Flooding). Du startest ihn manuell aus HQ, wann immer du frische Vorschläge willst.

---
*Dies ist das Meta-Proposal: der Self-Improve-Mechanismus selbst. Approve mich → ab da funktioniert der Flow für alle zukünftigen Bot-Vorschläge.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5LUFmxYSxGYQnw5abcJ3F)_