### PR TITLE
fix: robuste Bildanzeige + crash-sichere Detailseite + Filter-Härtung

### DIFF
--- a/app.js
+++ b/app.js
@@ -283,6 +283,31 @@ window.EB_IMG_FALLBACK = window.EB_IMG_FALLBACK || (
 // HTML-Attribut, das Card-Images verwenden – "this.onerror=null" verhindert Endlosschleife.
 window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK"';
 
+// Globaler Bild-Fehler-Auffang (Capture-Phase, da error-Events nicht bubblen).
+// Stellt sicher, dass JEDES <img> ein Fallback bekommt – auch Render-Stellen ohne
+// eigenes inline-onerror. Bilder mit eigenem onerror-Handler werden übersprungen.
+// Avatar-Bilder bekommen einen generierten Avatar, Inhaltsbilder das neutrale Placeholder.
+(function installGlobalImgFallback() {
+  if (window.__ebImgFallbackInstalled) return;
+  window.__ebImgFallbackInstalled = true;
+  document.addEventListener('error', function(e) {
+    var el = e && e.target;
+    if (!el || el.tagName !== 'IMG') return;
+    // Schon ein Fallback gesetzt? -> nichts tun (keine Endlosschleife).
+    if (el.dataset.ebFallback === 'done') return;
+    // Render-Stelle hat einen eigenen inline-onerror -> der kümmert sich selbst.
+    if (el.getAttribute('onerror')) return;
+    el.dataset.ebFallback = 'done';
+    var cls = el.className || '';
+    var isAvatar = /avatar/i.test(cls) || el.hasAttribute('data-eb-avatar');
+    if (isAvatar && typeof ebAvatar === 'function') {
+      el.src = ebAvatar(el.alt || 'user', el.alt || '');
+    } else {
+      el.src = window.EB_IMG_FALLBACK;
+    }
+  }, true);
+})();
+
 // Feed-Bild Auto-Fit: Banner / Hochformat -> contain (volles Bild), normale Fotos -> cover
 window._fitFeedImg = function(img) {
   if (!img || !img.naturalWidth || !img.naturalHeight) return;
@@ -2763,7 +2788,7 @@ function filterListings() {
   });
 
   // Sort
-  const sort = document.getElementById('browseSort').value;
+  const sort = document.getElementById('browseSort')?.value || '';
   switch (sort) {
     case 'preis-asc': filtered.sort((a, b) => a.price - b.price); break;
     case 'preis-desc': filtered.sort((a, b) => b.price - a.price); break;
@@ -3079,16 +3104,23 @@ function loadDetail(listingId) {
   const gallery = document.getElementById('detailGallery');
   const heroImg = document.getElementById('detailHeroImg');
 
+  // Bilder defensiv normalisieren: images-Array → einzelnes image → Placeholder.
+  // Verhindert Crashes bei DB-Listings ohne images-Array und eine leere Galerie
+  // bei Inseraten ganz ohne Foto.
+  var imgs = (Array.isArray(listing.images) && listing.images.length)
+    ? listing.images
+    : (listing.image ? [listing.image] : []);
+  if (!imgs.length) imgs = [window.EB_IMG_FALLBACK];
+
   // Hero image for mobile (first image, shown prominently)
-  if (listing.images.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(listing.images[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo" />`;
+  if (imgs.length > 0) {
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
   }
 
   // Swipeable gallery carousel
-  var imgs = listing.images;
   gallery.innerHTML = '<div class="detail-gallery-track" id="detailGalleryTrack">' +
     imgs.map(function(img, i) {
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" /></div>';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' /></div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -3139,10 +3171,10 @@ function loadDetail(listingId) {
   }
 
   document.getElementById('detailDescription').innerHTML = _sanitizeHtml(listing.description);
-  document.getElementById('detailPrice').textContent = listing.priceLabel.split('/')[0];
+  document.getElementById('detailPrice').textContent = (listing.priceLabel || '').split('/')[0];
 
   // Features
-  document.getElementById('detailFeatures').innerHTML = listing.features.map(f =>
+  document.getElementById('detailFeatures').innerHTML = (Array.isArray(listing.features) ? listing.features : []).map(f =>
     `<div class="feature-item"><span class="material-icons-round">check_circle</span><span>${_escHtml(f)}</span></div>`
   ).join('');
 

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -29,6 +29,13 @@
 
 → [[Frontend/app-js-module]] | [[Features/Authentication]] | [[Features/Payments]]
 
+## Neuester Stand (2026-06-20)
+
+- **Bild-Robustheit:** Globaler `<img>`-Fehler-Handler (Capture-Phase) sorgt dafür, dass JEDES Bild bei toter URL ein sauberes Fallback bekommt (Avatar bzw. „Bild nicht verfügbar"). Vorher hatten nur Card + Hero-Marquee ein Fallback — Detail-Hero/-Galerie zeigten kaputte Icons.
+- **Detailseite crash-sicher:** `loadDetail()` normalisiert `images`/`priceLabel`/`features` defensiv; ein Listing ohne `images`-Array zerstört die Seite nicht mehr.
+- **Filter gehärtet:** `browseSort`-Zugriff defensiv (`?.`). Filterlogik (Tokenisierung, Synonyme, Fuzzy, Kategorie/Ort/Preis/Rating/Datum) per Headless-Browser verifiziert: dj→3, „catering hamburg"→1, fotograf→2, cat+ort→1, keine Treffer→Alternativen.
+- Verifikation: Vanilla-SPA lokal mit Playwright/Chromium durchgeklickt (browse/detail/provider/board/feed/favorites/settings) — **0 Page-Errors**. Backend-/API-gebundene Flows (Login, Inserat-Erstellung, Stripe) brauchen den Live-WordPress-Server und sind hier nicht prüfbar.
+
 ## Neuester Stand (2026-06-06)
 
 - Live-Stand: GitHub `main` `3c1e752`, Domain erreichbar, Assets mit `styles.css?v=2.5.1`.

--- a/vault/Roadmap/Bekannte-Bugs.md
+++ b/vault/Roadmap/Bekannte-Bugs.md
@@ -25,6 +25,20 @@
 
 ## Behoben
 
+### [UI] Einzelne Bilder wurden nicht angezeigt (kaputtes Bild-Icon)
+**Gefunden:** 2026-06-20
+**Betrifft:** `app.js` — alle `<img>`-Render-Stellen (Detail-Hero/-Galerie, Alternativen, Portfolio, Events, Booking u. a.)
+**Symptom:** Nur einige Render-Stellen (Card, Hero-Marquee) hatten ein `onerror`-Fallback. Andere — insbesondere die Detail-Seiten-Hero und -Galerie — zeigten bei einer toten URL ein kaputtes Bild-Icon statt eines Platzhalters.
+**Fix:** Globaler Capture-Phase-`error`-Handler für JEDES `<img>` (Avatar → `ebAvatar`, Inhaltsbild → `EB_IMG_FALLBACK`); Render-Stellen mit eigenem `onerror` werden übersprungen. Zusätzlich `loadDetail()` defensiv: Bilder werden normalisiert (`images` → `image` → Platzhalter), Detailseite zeigt nie mehr eine leere Galerie.
+**Status:** gefixt
+
+### [DETAIL] Detailseite konnte bei Listing ohne `images`-Array crashen
+**Gefunden:** 2026-06-20
+**Betrifft:** `app.js` `loadDetail()`
+**Symptom:** `listing.images.length` / `.map()` ohne Array-Guard → `TypeError`, gesamte Detailseite blieb leer, wenn ein Listing kein `images`-Array trug. Auch `priceLabel.split()` und `features.map()` waren nicht defensiv.
+**Fix:** Defensive Normalisierung von `images`, `priceLabel`, `features`. Zusätzlich `browseSort`-Zugriff in `filterListings()` mit `?.` abgesichert (war als einziger Filterzugriff nicht defensiv).
+**Status:** gefixt
+
 ### [QA] QA-Bot Icon/Launcher wirkte kaputt und nicht wie Support
 **Gefunden:** 2026-06-05
 **Betrifft:** `index.php`, `styles.css`, QA-Bot Launcher


### PR DESCRIPTION
## Ziel
Erste, verifizierte Runde der App-Finalisierung — Fokus auf die konkret gemeldeten Probleme **„manche Bilder werden nicht angezeigt"** und **saubere Filterlogik**, plus Crash-Härtung der Detailseite.

## Änderungen (`app.js`)

### 1. Bilder werden überall zuverlässig angezeigt
- **Globaler `<img>`-Fehler-Handler** (Capture-Phase, da `error`-Events nicht bubblen). Jedes Bild bekommt bei toter URL automatisch das passende Fallback: Avatar-Bilder → `ebAvatar()`, Inhaltsbilder → neutrales „Bild nicht verfügbar"-Placeholder. Render-Stellen mit eigenem `onerror` werden übersprungen.
- **Warum:** Vorher hatten nur 3 von ~38 `<img>`-Stellen ein Fallback (Card + Hero-Marquee). Detail-**Hero**, Detail-**Galerie**, Alternativen-Grid, Portfolio, Event- und Booking-Bilder zeigten bei einer toten URL ein kaputtes Bild-Icon. Jetzt deckt **eine** Stelle alle aktuellen **und künftigen** `<img>` ab.

### 2. Detailseite crash-sicher
- `loadDetail()` normalisiert Bilder defensiv: `images`-Array → einzelnes `image` → Placeholder. Ein Listing **ohne** `images`-Array hat vorher `listing.images.length` geworfen und die **ganze Detailseite** geleert. Inserate komplett ohne Foto zeigen jetzt das Placeholder statt einer leeren Galerie.
- `priceLabel.split()` und `features.map()` ebenfalls defensiv abgesichert.

### 3. Filter-Härtung
- `browseSort`-Zugriff in `filterListings()` mit `?.` abgesichert (war als einziger Filterzugriff ohne Guard → potenzieller Crash).
- Filterlogik selbst (Tokenisierung, Synonyme, Fuzzy, Kategorie/Ort/Preis/Rating/Datum) ist solide und wurde verifiziert.

## Verifikation (Headless-Chromium / Playwright)
- Durchgeklickt: `browse`, `detail`, `provider`, `board`, `aktuelles`, `favorites`, `settings` → **0 Page-Errors**.
- Filter mit sichtbaren Demos: `dj`→3, `catering hamburg`→1, `fotograf`→2, `cat=catering`→2, `loc=berlin`→2, `price 0-500`→4, `cat+loc`→1.
- Crash-Szenario getestet: Detailseite mit Listing **ohne** `images`-Array und mit **leerem** Array → rendert sauber, kein Throw.
- Screenshot-Beleg: Detail-Hero zeigt jetzt das saubere „Bild nicht verfügbar"-Placeholder statt eines kaputten Icons.

## Bewusst NICHT in diesem PR (brauchen den Live-Server / Zugang)
- Backend-/API-gebundene Flows (Login, 2FA/Passkey, Inserat-Erstellung, Chat, **Stripe Connect E2E**, Admin-Moderation) sind aus der Sandbox nicht gegen die echte WordPress-REST-API testbar.
- Die konkret in Produktion toten Demo-Bild-URLs (Pexels/Unsplash) lassen sich hier nicht identifizieren (der Sandbox-Proxy liefert für **alle** externen Hosts 403/Cert-Fehler). Dank des neuen Fallbacks degradiert aber jede tote URL sauber. Empfehlung für eine dauerhafte Lösung: Demo-Bilder lokal im Repo hosten statt externer Hotlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_