### PR TITLE
Admin-Bildmoderation + Deploy-Härtung + Security-Fixes (XSS, Brute-Force)

### DIFF
--- a/.github/workflows/ionos-deploy.yml
+++ b/.github/workflows/ionos-deploy.yml
@@ -23,16 +23,22 @@ jobs:
 
       - name: Minify assets (#6 Part 2)
         run: |
+          # WICHTIG: Versionen GEPINNT. 'npx --yes terser' (ohne Pin) zog bei
+          # jedem Deploy die neueste Version — ein Minifier-Update kann aus
+          # identischem Quellcode plötzlich kaputtes JS erzeugen und die Seite
+          # lahmlegen (passiert am 2026-06-24). Bei Updates: Version hier
+          # bewusst anheben und vorher testen.
           echo "Vorher: app.js $(wc -c < app.js) B, styles.css $(wc -c < styles.css) B"
-          npx --yes terser app.js --compress --mangle -o app.js
+          npx --yes terser@5.48.0 app.js --compress --mangle -o app.js
           # Gate 1: gültiges JS?
           node --check app.js
           # Gate 2: Inline-Handler-Globals noch da? (mangle.toplevel=false -> ja)
           for fn in navigateTo toggleFavorite sendMessage filterListings _startChatPoll; do
             grep -q "function $fn" app.js || { echo "FATAL: $fn fehlt nach Minify - Abbruch"; exit 1; }
           done
-          # CSS (csso-cli, Fallback csso)
-          npx --yes csso-cli styles.css -o styles.css || npx --yes csso styles.css -o styles.css
+          # CSS (csso-cli, gepinnt). Fehler ist NICHT fatal — unminifiziertes
+          # CSS bricht die Seite nicht, deshalb Deploy nicht abbrechen.
+          npx --yes csso-cli@5.0.5 styles.css -o styles.css || echo "⚠️ csso-cli fehlgeschlagen — deploye unminifiziertes styles.css"
           echo "Nachher: app.js $(wc -c < app.js) B, styles.css $(wc -c < styles.css) B"
 
       - name: Install lftp

--- a/.github/workflows/ionos-deploy.yml
+++ b/.github/workflows/ionos-deploy.yml
@@ -62,6 +62,7 @@ jobs:
               -x '^\.obsidian/' -x '^\.claude/' -x '^\.claude\.json$' \
               -x '^vault/' -x '^docs/' -x '^tests/' -x '^node_modules/' \
               -x '^LICENSE$' -x '^README\.md$' -x '^CNAME$' -x '^AGENTS\.md$' \
+              -x '^SECURITY\.md$' \
               -x '^\.gitignore$' -x '^\.gitattributes$' -x '^\.editorconfig$' \
               -x '^\.env' \
               -x '^sftp-debug\.txt$' -x '^deploy-probe\.txt$' \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,81 @@
+name: Security Checks
+
+# Läuft bei jedem Push auf main und bei jedem PR. Ziel: Fatals und
+# offensichtliche Security-Regressionen abfangen, BEVOR der Deploy-Workflow
+# (ionos-deploy.yml) auf den Live-Server schreibt.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  static-checks:
+    name: Lint & Pattern-Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ubuntu-latest hat PHP vorinstalliert — kein Drittanbieter-Action nötig
+      # (Supply-Chain-Hygiene: in einem Security-Workflow keine ungeprüften Actions).
+      - name: PHP-Version
+        run: php --version
+
+      - name: PHP-Lint aller .php-Dateien (Gate — verhindert Fatal-Deploys)
+        run: |
+          err=0
+          while IFS= read -r f; do
+            php -l "$f" >/dev/null 2>&1 || { echo "::error file=$f::PHP-Syntaxfehler"; php -l "$f"; err=1; }
+          done < <(find . -name '*.php' -not -path './node_modules/*' -not -path './.git/*')
+          [ "$err" -eq 0 ] && echo "✅ Alle PHP-Dateien syntaktisch OK"
+          exit $err
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: JS-Syntax-Check (app.js) — Gate
+        run: node --check app.js
+
+      - name: Danger-Pattern-Scan (advisory, blockiert nicht)
+        continue-on-error: true
+        run: |
+          echo "## Security Pattern-Scan" >> "$GITHUB_STEP_SUMMARY"
+          flag() { echo "⚠️  $1"; echo "- $1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          # 1) eval() / extract() / create_function() in PHP
+          if grep -rnE '\b(eval|extract|create_function|assert)\s*\(' --include='*.php' . | grep -vE '//|\*'; then
+            flag "eval/extract/create_function/assert in PHP gefunden — prüfen."
+          fi
+
+          # 2) Direkte Superglobals in SQL-Strings (SQLi-Verdacht)
+          if grep -rnE '"(SELECT|INSERT|UPDATE|DELETE)[^"]*\$_(GET|POST|REQUEST|COOKIE)' --include='*.php' .; then
+            flag "Superglobal direkt in SQL-String — MUSS über \$wpdb->prepare()."
+          fi
+
+          # 3) \$wpdb->query/get_* mit interpolierter Variable (Heuristik; Prefix-only
+          #    wird herausgefiltert, da {\$wpdb->prefix} legitim ist).
+          if grep -rnE '\$wpdb->(query|get_results|get_row|get_var|get_col)\(\s*"[^"]*\$' --include='*.php' . \
+               | grep -vE '\{\$wpdb->prefix\}|\$wpdb->prefix|\$wpdb->users|->prepare\('; then
+            flag "Mögliche SQL-Interpolation ohne prepare() — prüfen."
+          fi
+
+          # 4) JS: eval / document.write / innerHTML mit unescapter User-Variable
+          if grep -rnE '\b(eval|document\.write)\s*\(' --include='*.js' app.js; then
+            flag "eval/document.write in app.js — prüfen."
+          fi
+
+          # 5) Passwort-Hashing mit md5/sha1 (statt wp_hash_password/password_hash)
+          if grep -rnE '(md5|sha1)\s*\(\s*\$?(pass|pwd|password)' --include='*.php' .; then
+            flag "Schwaches Hashing (md5/sha1) auf Passwort-artiger Variable — prüfen."
+          fi
+
+          # 6) Info: Anzahl öffentlicher (__return_true) Endpoints
+          pub=$(grep -rcE "permission_callback'[^,]*__return_true" --include='*.php' . | awk -F: '{s+=$2} END{print s}')
+          echo "ℹ️  Öffentliche (__return_true) Endpoint-Definitionen: ${pub:-0}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Scan abgeschlossen (advisory)."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Sicherheitsrichtlinie — Eventbörse
+
+Wir nehmen die Sicherheit unserer Plattform und der Daten unserer Nutzer ernst.
+Dieses Dokument beschreibt, wie Schwachstellen gemeldet werden und welche
+Schutzmaßnahmen aktiv sind.
+
+## Schwachstelle melden (Responsible Disclosure)
+
+Bitte melde Sicherheitslücken **vertraulich** und **nicht** über öffentliche
+GitHub-Issues.
+
+- **E-Mail:** security@eventbörse.de (Punycode: security@xn--eventbrse-57a.de)
+- Bitte gib eine Beschreibung, Reproduktionsschritte und – wenn möglich – einen
+  Proof-of-Concept an.
+- Wir bestätigen den Eingang innerhalb von **72 Stunden** und halten dich über
+  den Fortschritt auf dem Laufenden.
+- Bitte gib uns angemessene Zeit zur Behebung, bevor Details veröffentlicht
+  werden. Wir nennen dich auf Wunsch in einer Danksagung.
+
+**Bitte nicht:** automatisierte Massen-Scans gegen die Produktivumgebung,
+Denial-of-Service, Social Engineering gegen Mitarbeiter/Nutzer oder Zugriff auf
+fremde Konten/Daten über einen Proof-of-Concept hinaus.
+
+## Aktive Schutzmaßnahmen
+
+Stand der im Code umgesetzten Maßnahmen (siehe `functions.php`,
+`includes/security/`, `webauthn.php`):
+
+| Bereich | Maßnahme |
+|---|---|
+| **Injection (SQL)** | Durchgängig `$wpdb->prepare()` mit Platzhaltern; keine String-Interpolation von Eingaben in Queries. |
+| **XSS** | Server: `sanitize_text_field` / `wp_kses_post`. Client: vollständiges HTML-Escaping inkl. Anführungszeichen (`_escHtml`) und Allowlist-Sanitizer (`_sanitizeHtml`, DOMParser, strippt alle Event-Handler). |
+| **Content-Security-Policy** | Restriktive CSP mit Allowlist (Stripe/Leaflet/Fonts), `object-src 'none'`, `base-uri 'self'`, `frame-ancestors`/`X-Frame-Options: DENY`. |
+| **Weitere Header** | HSTS (preload), `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, COOP/CORP. |
+| **Authentifizierung** | WordPress-Passwort-Hashing; 2FA (TOTP/OTP) und WebAuthn/Passkeys (Challenge + RP-ID-Bindung, `hash_equals`). |
+| **Brute-Force** | IP-basiertes Rate-Limiting (Transients) auf Login/OTP/Passwort-Reset, plus per-Konto-/per-Code-Drosselung. |
+| **Zugriffskontrolle** | REST-Endpoints mit `permission_callback`; Ownership-/Teilnehmer-Checks (Listings, Konversationen, Nachrichten); Admin-Endpoints via `eb_is_admin_user`/`manage_options`. |
+| **Datei-Upload** | Magic-Byte-MIME-Erkennung, Bild-Allowlist, Block von SVG/Doppel-Extensions/ausführbaren Endungen, `getimagesize`-Recheck, 5 MB-Limit. |
+| **Zahlungen** | Serverseitige Betragsvalidierung gegen das Listing; Stripe-Webhook-Signaturprüfung (HMAC-SHA256, `hash_equals`, Replay-Schutz). |
+| **CSRF** | WordPress-Nonces (`X-WP-Nonce`) für authentifizierte Aktionen. |
+| **Cookies** | `HttpOnly`, `Secure` (über HTTPS), `SameSite=Lax`. |
+
+## Automatisierte Prüfungen
+
+Bei jedem Push und Pull-Request laufen Sicherheits-Checks
+(`.github/workflows/security.yml`):
+
+- PHP-Lint **aller** `.php`-Dateien (verhindert Fatal-Errors im Deploy).
+- JS-Syntaxprüfung von `app.js`.
+- Advisory-Pattern-Scan auf riskante Muster (eval/extract, Superglobals in SQL,
+  schwaches Hashing, ungeprüfte Query-Interpolation).
+
+Der Deploy-Workflow pinnt zusätzlich die Minifier-Versionen, damit Builds
+reproduzierbar bleiben.
+
+## Geltungsbereich
+
+Diese Richtlinie gilt für die Eventbörse-Plattform (eventbörse.de) und dieses
+Repository. Drittanbieter (Stripe, IONOS, OpenStreetMap) unterliegen ihren
+eigenen Sicherheitsrichtlinien.

--- a/app.js
+++ b/app.js
@@ -10882,9 +10882,18 @@ function _renderStars(rating) {
 }
 
 function _escHtml(str) {
-  var d = document.createElement('div');
-  d.textContent = str;
-  return d.innerHTML;
+  // Encodet ALLE HTML-Sonderzeichen inkl. Anführungszeichen. Wichtig:
+  // textContent→innerHTML encodet " und ' NICHT — dadurch wäre jede
+  // Interpolation in ein Attribut (alt="${_escHtml(x)}") per Quote-Injection
+  // angreifbar (serverseitiges sanitize_text_field lässt Quotes durch).
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
 }
 
 // Parse a date string in various formats (ISO, DD.MM.YYYY, "15. August 2026", etc.)
@@ -12671,14 +12680,14 @@ function addListingMarkers(listings) {
 
     const popupContent = `
       <div class="map-popup-card">
-        <img src="${listing.image}" alt="${listing.title}" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK"/>
-        <h4>${listing.title}</h4>
+        <img src="${_escHtml(listing.image)}" alt="${_escHtml(listing.title)}" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK"/>
+        <h4>${_escHtml(listing.title)}</h4>
         <div class="popup-meta">
           <span class="material-icons-round" style="font-size:14px;vertical-align:middle">location_on</span>
-          ${listing.location} · ${listing.categoryLabel}
+          ${_escHtml(listing.location)} · ${_escHtml(listing.categoryLabel)}
         </div>
-        <div class="popup-meta">★ ${listing.rating} (${listing.reviews} Bewertungen)</div>
-        <div class="popup-price">${listing.priceLabel}</div>
+        <div class="popup-meta">★ ${_escHtml(listing.rating)} (${_escHtml(listing.reviews)} Bewertungen)</div>
+        <div class="popup-price">${_escHtml(listing.priceLabel)}</div>
         <button class="popup-btn" onclick="closeMapOverlay(); navigateTo('detail', ${listing.id});">
           Details ansehen
         </button>
@@ -12697,10 +12706,10 @@ function renderLocationsList(listings) {
     const emoji = CATEGORY_EMOJI[l.category] || '📌';
     return `
       <div class="map-loc-item" data-id="${l.id}" onclick="focusMapMarker(${l.id})">
-        <img class="map-loc-img" src="${l.image}" alt="${l.title}" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
+        <img class="map-loc-img" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
         <div class="map-loc-info">
-          <span class="map-loc-city">${l.location}</span>
-          <span class="map-loc-cat">${emoji} ${l.categoryLabel}</span>
+          <span class="map-loc-city">${_escHtml(l.location)}</span>
+          <span class="map-loc-cat">${emoji} ${_escHtml(l.categoryLabel)}</span>
         </div>
         <div class="map-loc-price">${l.priceLabel}</div>
       </div>`;

--- a/app.js
+++ b/app.js
@@ -344,6 +344,51 @@ window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FAL
   }, true);
 })();
 
+// --- Admin-Bild-Blocklist ---
+// Vom Admin gelöschte Bilder (auch bei hardcodierten Demo-Listings, die nicht
+// in der DB liegen). Der Server liefert normalisierte Pfade via eventboerseApi;
+// der Client blendet passende Bilder aus, sodass Löschungen Reload-fest sind.
+window.EB_IMG_BLOCKLIST = (function() {
+  var set = new Set();
+  try {
+    var list = (window.eventboerseApi && window.eventboerseApi.imageBlocklist) || [];
+    if (Array.isArray(list)) list.forEach(function(p) { if (p) set.add(String(p)); });
+  } catch (e) {}
+  return set;
+})();
+
+// Normalisiert eine Bild-URL auf ihren Pfad ohne Query (spiegelt serverseitiges
+// eb_norm_img_url) — so matchen verschiedene Größen-/Query-Varianten desselben Bilds.
+function _imgNormPath(u) {
+  if (!u) return '';
+  try {
+    var s = String(u);
+    var q = s.indexOf('?');
+    if (q >= 0) s = s.slice(0, q);
+    try { return new URL(s, window.location.origin).pathname; }
+    catch (e) { return s; }
+  } catch (e) { return ''; }
+}
+
+function _isImgBlocked(u) {
+  if (!u || !window.EB_IMG_BLOCKLIST || window.EB_IMG_BLOCKLIST.size === 0) return false;
+  return window.EB_IMG_BLOCKLIST.has(_imgNormPath(u));
+}
+
+// Entfernt geblockte Bilder aus einer Listing-Liste (images[] + image-Cover).
+function _applyImageBlocklist(arr) {
+  if (!window.EB_IMG_BLOCKLIST || window.EB_IMG_BLOCKLIST.size === 0) return;
+  (Array.isArray(arr) ? arr : []).forEach(function(l) {
+    if (!l) return;
+    if (Array.isArray(l.images)) {
+      l.images = l.images.filter(function(u) { return !_isImgBlocked(u); });
+    }
+    if (l.image && _isImgBlocked(l.image)) {
+      l.image = (Array.isArray(l.images) && l.images.length) ? l.images[0] : window.EB_IMG_FALLBACK;
+    }
+  });
+}
+
 // Feed-Bild Auto-Fit: Banner / Hochformat -> contain (volles Bild), normale Fotos -> cover
 window._fitFeedImg = function(img) {
   if (!img || !img.naturalWidth || !img.naturalHeight) return;
@@ -792,6 +837,11 @@ const LISTINGS = [
   } catch(e) { /* fail-safe: kein Block, falls LISTINGS noch nicht da */ }
 })();
 
+// Vom Admin gelöschte Bilder aus den Demo-Listings entfernen (Reload-fest).
+(function applyDemoImageBlocklist(){
+  try { if (Array.isArray(LISTINGS)) _applyImageBlocklist(LISTINGS); } catch(e) {}
+})();
+
 const DEMO_REVIEWS = [
   { name: 'Sarah L.', avatar: 'sarah2', rating: 5, date: 'Februar 2026', text: 'Absolut fantastisch! Max hat unsere Hochzeitsfeier unvergesslich gemacht. Die Musikauswahl war perfekt!' },
   { name: 'Markus W.', avatar: 'markus', rating: 5, date: 'Januar 2026', text: 'Professionell, zuverlässig und eine geniale Stimmung. Jederzeit wieder!' },
@@ -1115,6 +1165,7 @@ async function loadDbListings() {
     if (data.listings && data.listings.length > 0) {
       _mergeDbListingsIntoCache(data.listings);
     }
+    _applyImageBlocklist(LISTINGS); // vom Admin gelöschte Bilder auch hier ausblenden
     _dbListingsLoaded = true;
     try { renderHeroMarquees(); } catch (err) { console.error('Fehler beim Rendern der Hero-Marquee nach Daten-Ladung', err); }
     try { updateHeroStats(); } catch (err) { /* Stats optional */ }
@@ -3478,6 +3529,8 @@ function loadProvider(providerId) {
   if (currentUser && _sameUserId(pid, currentUser.id) && currentUser.gallery && currentUser.gallery.length > 0) {
     providerImages = currentUser.gallery.slice();
   }
+  // Vom Admin gelöschte Bilder ausblenden (auch Demo-Profile, Reload-fest)
+  providerImages = providerImages.filter(function(u) { return !_isImgBlocked(u); });
 
   // Cover Gallery — full-width animated scroll rows
   buildGalleryRows(providerImages);
@@ -4407,13 +4460,11 @@ function adminDeleteProfileImage(index, ev) {
   }).then(function(r) {
     _refreshNonce(r);
     if (!r.ok) { showToast('Löschen fehlgeschlagen', 'error'); return; }
-    // Lokal entfernen (alle Vorkommen) + Caches aktualisieren
-    providerImages = providerImages.filter(function(u) { return u !== url; });
-    LISTINGS.forEach(function(l) {
-      if (l && Array.isArray(l.images) && _sameUserId(_listingOwnerId(l), targetId)) {
-        l.images = l.images.filter(function(u) { return u !== url; });
-      }
-    });
+    // Blocklist im Client mitziehen → entfernt alle Größen-Varianten + Cover,
+    // greift sofort und bleibt nach Reload weg (Server persistiert ebenfalls).
+    if (window.EB_IMG_BLOCKLIST) window.EB_IMG_BLOCKLIST.add(_imgNormPath(url));
+    providerImages = providerImages.filter(function(u) { return !_isImgBlocked(u); });
+    _applyImageBlocklist(LISTINGS);
     _renderProviderPortfolio();
     buildGalleryRows(providerImages);
     // Lightbox-Status nachziehen, falls geöffnet

--- a/app.js
+++ b/app.js
@@ -3274,6 +3274,10 @@ function loadDetail(listingId) {
 // ========== PROVIDER PROFILE ==========
 let providerImages = [];
 let lightboxIndex = 0;
+// ID des aktuell angezeigten Provider-Profils + ob es das eigene ist
+// (für Admin-Moderation von Bildern auf fremden Profilen).
+let _currentProviderId = 0;
+let _currentProviderIsOwn = false;
 
 /**
  * Setzt das Provider-Page-DOM in einen sauberen, leeren Zustand zurück.
@@ -3283,6 +3287,12 @@ let lightboxIndex = 0;
  * Profil: wir wollen NIE Demo-Daten wie "Max Beats" im echten Nutzerkontext.
  */
 function _resetProviderPageDom() {
+  // Admin-Moderations-State zurücksetzen (kein stale Lösch-Button auf
+  // „nicht gefunden"- oder eigenem Profil)
+  _currentProviderId = 0;
+  _currentProviderIsOwn = false;
+  var existingLbDel = document.getElementById('plbAdminDelete');
+  if (existingLbDel) existingLbDel.style.display = 'none';
   var setText = function(id, val) {
     var el = document.getElementById(id);
     if (el) el.textContent = val;
@@ -3460,6 +3470,9 @@ function loadProvider(providerId) {
     return;
   }
   providerImages = providerListings.flatMap(l => l.images || []);
+  // Aktuell betrachtetes Profil merken (für Admin-Bildmoderation)
+  _currentProviderId = pid;
+  _currentProviderIsOwn = !!(currentUser && _sameUserId(pid, currentUser.id));
   // For own profile: if currentUser.gallery is non-empty, it is the saved portfolio
   // (may differ from listing images after edits — always prefer saved gallery)
   if (currentUser && _sameUserId(pid, currentUser.id) && currentUser.gallery && currentUser.gallery.length > 0) {
@@ -3537,12 +3550,8 @@ function loadProvider(providerId) {
     `<div class="prov-highlight"><span class="material-icons-round">${icons[i % icons.length]}</span> ${_escHtml(f)}</div>`
   ).join('');
 
-  // Portfolio
-  const portfolioEl = document.getElementById('providerPortfolio');
-  portfolioEl.innerHTML = providerImages.map((img, i) =>
-    `<img src="${_escHtml(img)}" alt="Portfolio" loading="lazy" onclick="openProviderLightbox(${i})" />`
-  ).join('');
-  portfolioEl.querySelectorAll('img').forEach(detectWideBannerImg);
+  // Portfolio (admin-bewusst: auf fremden Profilen Lösch-Overlay für Admins)
+  _renderProviderPortfolio();
 
   // Sidebar Facts
   document.getElementById('providerFacts').innerHTML = `
@@ -4358,14 +4367,108 @@ function startRowAnimation(row, segW, dir, baseSpeed, wrap, itemW) {
   wrap.addEventListener('touchcancel', onEnd);
 }
 
+/**
+ * Rendert das Portfolio-Grid auf der Provider-Profilseite (View-Modus).
+ * Für Admins, die ein FREMDES Profil ansehen, bekommt jedes Bild ein
+ * Lösch-Overlay (Moderation). Der Eigentümer-Edit-Modus ist davon
+ * unberührt (separater Render in toggleProviderEditMode).
+ */
+function _renderProviderPortfolio() {
+  var portfolioEl = document.getElementById('providerPortfolio');
+  if (!portfolioEl) return;
+  var canModerate = !!(currentUser && currentUser.isAdmin && !_currentProviderIsOwn && _currentProviderId);
+  portfolioEl.innerHTML = providerImages.map(function(img, i) {
+    var imgTag = '<img src="' + _escHtml(img) + '" alt="Portfolio" loading="lazy" onclick="openProviderLightbox(' + i + ')" />';
+    if (!canModerate) return imgTag;
+    return '<div class="prov-portfolio-mod-wrap">' + imgTag +
+      '<button type="button" class="prov-portfolio-mod-del" title="Als Admin löschen" ' +
+      'aria-label="Bild als Admin löschen" onclick="adminDeleteProfileImage(' + i + ', event)">' +
+      '<span class="material-icons-round">delete</span></button></div>';
+  }).join('');
+  portfolioEl.querySelectorAll('img').forEach(detectWideBannerImg);
+}
+
+/**
+ * Admin-Moderation: löscht ein einzelnes Bild vom aktuell betrachteten
+ * (fremden) Profil — serverseitig aus eb_gallery + allen Listings des
+ * Nutzers, lokal aus providerImages + LISTINGS-Cache.
+ */
+function adminDeleteProfileImage(index, ev) {
+  if (ev) { ev.stopPropagation(); if (ev.preventDefault) ev.preventDefault(); }
+  if (!currentUser || !currentUser.isAdmin) return;
+  var url = providerImages[index];
+  if (!url) return;
+  var targetId = _currentProviderId;
+  if (!targetId) { showToast('Profil-ID unbekannt', 'error'); return; }
+  if (!confirm('Als Admin: Dieses Bild wirklich vom Profil löschen?')) return;
+  fetch(_apiUrl('admin/moderate-image'), {
+    method: 'POST', credentials: 'same-origin', headers: _apiHeaders(),
+    body: JSON.stringify({ user_id: targetId, image: url })
+  }).then(function(r) {
+    _refreshNonce(r);
+    if (!r.ok) { showToast('Löschen fehlgeschlagen', 'error'); return; }
+    // Lokal entfernen (alle Vorkommen) + Caches aktualisieren
+    providerImages = providerImages.filter(function(u) { return u !== url; });
+    LISTINGS.forEach(function(l) {
+      if (l && Array.isArray(l.images) && _sameUserId(_listingOwnerId(l), targetId)) {
+        l.images = l.images.filter(function(u) { return u !== url; });
+      }
+    });
+    _renderProviderPortfolio();
+    buildGalleryRows(providerImages);
+    // Lightbox-Status nachziehen, falls geöffnet
+    var lb = document.getElementById('providerLightbox');
+    var lbOpen = lb && lb.classList.contains('show');
+    if (providerImages.length === 0) {
+      closeProviderLightbox();
+    } else {
+      if (lightboxIndex >= providerImages.length) lightboxIndex = providerImages.length - 1;
+      if (lbOpen) {
+        document.getElementById('plbImage').src = providerImages[lightboxIndex];
+        document.getElementById('plbCounter').textContent = (lightboxIndex + 1) + ' / ' + providerImages.length;
+      }
+    }
+    showToast('Bild als Admin gelöscht.', 'delete');
+  }).catch(function() { showToast('Löschen fehlgeschlagen', 'error'); });
+}
+
 function openProviderLightbox(index) {
   lightboxIndex = index;
   const lb = document.getElementById('providerLightbox');
   document.getElementById('plbImage').src = providerImages[lightboxIndex];
   document.getElementById('plbCounter').textContent = `${lightboxIndex + 1} / ${providerImages.length}`;
+  _updateProviderLightboxAdminBtn();
   lb.classList.add('show');
   document.body.style.overflow = 'hidden';
   document.body.style.touchAction = 'none';
+}
+
+/**
+ * Blendet im Provider-Lightbox einen Admin-Lösch-Button ein (nur fremde
+ * Profile, nur Admins). Der Button wird bei Bedarf dynamisch erzeugt,
+ * sodass kein Eingriff in die SPA-Shell (index.php/index.html) nötig ist.
+ */
+function _updateProviderLightboxAdminBtn() {
+  var lb = document.getElementById('providerLightbox');
+  if (!lb) return;
+  var canModerate = !!(currentUser && currentUser.isAdmin && !_currentProviderIsOwn && _currentProviderId);
+  var btn = document.getElementById('plbAdminDelete');
+  if (!canModerate) { if (btn) btn.style.display = 'none'; return; }
+  if (!btn) {
+    btn = document.createElement('button');
+    btn.id = 'plbAdminDelete';
+    btn.type = 'button';
+    btn.className = 'plb-admin-delete';
+    btn.title = 'Als Admin löschen';
+    btn.setAttribute('aria-label', 'Bild als Admin löschen');
+    btn.innerHTML = '<span class="material-icons-round">delete</span> Löschen';
+    btn.onclick = function(e) { adminDeleteProfileImage(lightboxIndex, e); };
+    btn.addEventListener('touchend', function(e) {
+      e.stopPropagation(); e.preventDefault(); adminDeleteProfileImage(lightboxIndex, e);
+    });
+    lb.appendChild(btn);
+  }
+  btn.style.display = '';
 }
 
 function closeProviderLightbox(e) {

--- a/functions.php
+++ b/functions.php
@@ -3176,6 +3176,16 @@ function eb_register_extra_routes() {
         'callback'            => 'eb_admin_bot_accept_inquiry',
         'permission_callback' => 'is_user_logged_in',
     ) );
+
+    /* Moderation: Admin entfernt ein einzelnes Bild eines beliebigen Nutzers
+       (aus dessen Portfolio-Galerie UND aus allen seinen Listings). */
+    register_rest_route( 'eventboerse/v1', '/admin/moderate-image', array(
+        'methods'             => 'POST',
+        'callback'            => 'eb_admin_moderate_image',
+        'permission_callback' => function() {
+            return is_user_logged_in() && eb_is_admin_user();
+        },
+    ) );
 }
 add_action( 'rest_api_init', 'eb_register_extra_routes' );
 
@@ -3390,6 +3400,89 @@ function eb_admin_bot_accept_inquiry( WP_REST_Request $request ) {
         'bot_id'       => $bot_id,
         'bot_name'     => $bot_name,
         'reply_text'   => $reply_text,
+    ), 200 );
+}
+
+/**
+ * Normalisiert eine Bild-URL für den Vergleich: Query-String (z. B. Crop-
+ * Parameter) wird entfernt und nur der Pfad behalten, damit dasselbe Bild
+ * auch über Host-/Parameter-Unterschiede hinweg erkannt wird.
+ */
+function eb_norm_img_url( $u ) {
+    $u = trim( (string) $u );
+    if ( $u === '' ) return '';
+    $q = strpos( $u, '?' );
+    if ( $q !== false ) $u = substr( $u, 0, $q );
+    $p = wp_parse_url( $u, PHP_URL_PATH );
+    return $p ? $p : $u;
+}
+
+/** Vergleicht zwei Bild-URLs tolerant (exakt oder per normalisiertem Pfad). */
+function eb_same_image_url( $a, $b ) {
+    if ( $a === $b ) return true;
+    $na = eb_norm_img_url( $a );
+    $nb = eb_norm_img_url( $b );
+    return $na !== '' && $na === $nb;
+}
+
+/**
+ * POST /admin/moderate-image
+ * Body: { user_id: int, image: string }
+ * Entfernt die Bild-URL aus der Portfolio-Galerie (eb_gallery) des Ziel-
+ * Nutzers und aus den images-Arrays aller seiner Listings. Nur für Admins.
+ */
+function eb_admin_moderate_image( WP_REST_Request $request ) {
+    global $wpdb;
+    $params = $request->get_json_params();
+    $target = isset( $params['user_id'] ) ? absint( $params['user_id'] ) : 0;
+    $image  = isset( $params['image'] ) ? esc_url_raw( trim( (string) $params['image'] ) ) : '';
+
+    if ( ! $target || $image === '' ) {
+        return new WP_REST_Response( array( 'message' => 'user_id und image sind erforderlich.' ), 400 );
+    }
+
+    $gallery_removed = 0;
+    $listing_removed = 0;
+
+    // 1) Portfolio-Galerie des Ziel-Nutzers (User-Meta eb_gallery)
+    $gallery = get_user_meta( $target, 'eb_gallery', true );
+    if ( is_array( $gallery ) ) {
+        $kept = array_values( array_filter( $gallery, function( $u ) use ( $image ) {
+            return ! eb_same_image_url( $u, $image );
+        } ) );
+        if ( count( $kept ) !== count( $gallery ) ) {
+            update_user_meta( $target, 'eb_gallery', $kept );
+            $gallery_removed = count( $gallery ) - count( $kept );
+        }
+    }
+
+    // 2) Alle Listings des Ziel-Nutzers
+    $rows = $wpdb->get_results( $wpdb->prepare(
+        "SELECT id, images FROM {$wpdb->prefix}eb_listings WHERE user_id = %d", $target
+    ) );
+    if ( is_array( $rows ) ) {
+        foreach ( $rows as $r ) {
+            $imgs = json_decode( (string) $r->images, true );
+            if ( ! is_array( $imgs ) ) continue;
+            $kept = array_values( array_filter( $imgs, function( $u ) use ( $image ) {
+                return ! eb_same_image_url( $u, $image );
+            } ) );
+            if ( count( $kept ) !== count( $imgs ) ) {
+                $wpdb->update(
+                    $wpdb->prefix . 'eb_listings',
+                    array( 'images' => wp_json_encode( $kept ) ),
+                    array( 'id' => (int) $r->id )
+                );
+                $listing_removed += count( $imgs ) - count( $kept );
+            }
+        }
+    }
+
+    return new WP_REST_Response( array(
+        'removed'         => ( $gallery_removed + $listing_removed ) > 0,
+        'image'           => $image,
+        'gallery_removed' => $gallery_removed,
+        'listing_removed' => $listing_removed,
     ), 200 );
 }
 

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,11 @@ add_action('init', function() {
 
 require_once get_template_directory() . '/webauthn.php';
 
+// Brute-Force-Schutz (Transient-basiertes Rate-Limit, per REMOTE_ADDR).
+// War zuvor vorhanden, aber nirgends eingebunden → jetzt aktiv verdrahtet
+// (siehe eventboerse_check_rate_limit-Aufrufe in den Auth-Handlern).
+require_once get_template_directory() . '/includes/security/rate-limit.php';
+
 /**
  * Self-Hosted Avatar-Generator (Server-Seite).
  *
@@ -1508,6 +1513,9 @@ function eb_login_clear_failures( $email ) {
 }
 
 function eventboerse_handle_login( WP_REST_Request $request ) {
+    // Brute-Force-Schutz: max. 10 Login-Versuche pro IP / 15 Min.
+    $rl = eventboerse_check_rate_limit( 'login', 10, 15 * MINUTE_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params    = $request->get_json_params();
     $email_raw = (string) ( $params['email'] ?? '' );
     $email     = eb_normalize_email( $email_raw );
@@ -1529,6 +1537,8 @@ function eventboerse_handle_login( WP_REST_Request $request ) {
     }
 
     eb_login_clear_failures( $email );
+    // Passwort war korrekt → IP-Rate-Limit-Bucket leeren (nur Fehlversuche zählen).
+    eventboerse_reset_rate_limit( 'login' );
 
     $verified = get_user_meta( $user->ID, 'eb_email_verified', true );
     if ( '0' === (string) $verified ) {
@@ -1657,6 +1667,9 @@ function eventboerse_handle_resend_verification( WP_REST_Request $request ) {
 
 /* ---------- PASSWORT VERGESSEN ---------- */
 function eventboerse_handle_forgot_password( WP_REST_Request $request ) {
+    // Anti-Bombing/Enumeration: max. 5 Reset-Mails pro IP / 15 Min.
+    $rl = eventboerse_check_rate_limit( 'forgot_password', 5, 15 * MINUTE_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params    = $request->get_json_params();
     $email_raw = isset( $params['email'] ) ? (string) $params['email'] : '';
     $email     = eb_normalize_email( $email_raw );
@@ -1706,6 +1719,9 @@ function eventboerse_handle_forgot_password( WP_REST_Request $request ) {
 
 /* ---------- PASSWORT RESET AUSFÜHREN ---------- */
 function eventboerse_handle_reset_password( WP_REST_Request $request ) {
+    // Brute-Force-Schutz für Reset-Token: max. 10 Versuche pro IP / 15 Min.
+    $rl = eventboerse_check_rate_limit( 'reset_password', 10, 15 * MINUTE_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params   = $request->get_json_params();
     $token    = isset( $params['token'] )    ? sanitize_text_field( $params['token'] )    : '';
     $uid      = isset( $params['uid'] )      ? absint( $params['uid'] )                   : 0;
@@ -2355,6 +2371,9 @@ function eb_webauthn_credentials_delete( WP_REST_Request $request ) {
 }
 
 function eb_otp_send( WP_REST_Request $request ) {
+    // Anti-Bombing: max. 8 Code-Versände pro IP / 15 Min.
+    $rl = eventboerse_check_rate_limit( 'otp_send', 8, 15 * MINUTE_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params    = $request->get_json_params();
     $email_raw = (string) ( $params['email'] ?? '' );
     $email     = eb_normalize_email( $email_raw );
@@ -2427,6 +2446,9 @@ function eb_otp_send( WP_REST_Request $request ) {
 }
 
 function eb_otp_verify( WP_REST_Request $request ) {
+    // Brute-Force-Schutz: 6-stelliger Code → max. 10 Versuche pro IP / 15 Min.
+    $rl = eventboerse_check_rate_limit( 'otp_verify', 10, 15 * MINUTE_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params    = $request->get_json_params();
     $email_raw = (string) ( $params['email'] ?? '' );
     $email     = eb_normalize_email( $email_raw );
@@ -2460,6 +2482,7 @@ function eb_otp_verify( WP_REST_Request $request ) {
     }
 
     delete_transient( $otp_key );
+    eventboerse_reset_rate_limit( 'otp_verify' );
 
     wp_set_current_user( $user->ID );
     wp_set_auth_cookie( $user->ID, true, is_ssl() );

--- a/functions.php
+++ b/functions.php
@@ -134,6 +134,30 @@ add_filter( 'xmlrpc_enabled', '__return_false' );
 add_filter( 'wp_headers', function( $h ) { unset( $h['X-Pingback'] ); return $h; } );
 remove_action( 'wp_head', 'rest_output_link_header', 11 );
 
+// --- User-Enumeration-Schutz ---
+// 1) WP-Core-REST-User-Endpoints für nicht eingeloggte Besucher sperren.
+//    Die App nutzt ausschließlich /eventboerse/v1/, niemals /wp/v2/users —
+//    der Default-Endpoint würde sonst Benutzernamen/Slugs preisgeben.
+add_filter( 'rest_endpoints', function( $endpoints ) {
+    if ( ! is_user_logged_in() ) {
+        unset( $endpoints['/wp/v2/users'] );
+        unset( $endpoints['/wp/v2/users/(?P<id>[\d]+)'] );
+    }
+    return $endpoints;
+} );
+// 2) Author-Archive/?author=N-Enumeration unterbinden (leakt den User-Slug).
+//    Priorität 1 läuft vor redirect_canonical (das sonst ?author=1 → /author/slug
+//    auflösen und den Namen verraten würde).
+add_action( 'template_redirect', function() {
+    if ( is_admin() ) {
+        return;
+    }
+    if ( isset( $_GET['author'] ) || ( function_exists( 'is_author' ) && is_author() ) ) {
+        wp_safe_redirect( home_url( '/' ), 302 );
+        exit;
+    }
+}, 1 );
+
 // REST-API für Anonyme einschränken: nur eigene Routen erreichbar.
 add_filter( 'rest_authentication_errors', function( $result ) {
     if ( ! empty( $result ) ) {
@@ -242,23 +266,25 @@ function eventboerse_enqueue_assets() {
         true
     );
 
-    // Flatpickr
+    // Flatpickr — Pfad auf exakte Version gepinnt (jsdelivr ist pro Version
+    // immutable). 'npm/flatpickr' ohne @Version würde sonst bei jedem Build
+    // die jeweils neueste Version ausliefern (Supply-Chain-Risiko).
     wp_enqueue_style(
         'flatpickr',
-        'https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css',
+        'https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css',
         array(),
         '4.6.13'
     );
     wp_enqueue_script(
         'flatpickr',
-        'https://cdn.jsdelivr.net/npm/flatpickr',
+        'https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js',
         array(),
         '4.6.13',
         true
     );
     wp_enqueue_script(
         'flatpickr-de',
-        'https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/de.js',
+        'https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/l10n/de.js',
         array( 'flatpickr' ),
         '4.6.13',
         true
@@ -423,7 +449,9 @@ add_action( 'send_headers', function() {
         "frame-ancestors 'none'",
         "object-src 'none'",
         // Skripte: eigene + Stripe + Leaflet + Flatpickr (\u00dcbergangsweise inline erlaubt).
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://unpkg.com https://cdn.jsdelivr.net",
+        // 'unsafe-eval' entfernt: weder eigener Code noch Stripe/Leaflet/Flatpickr
+        // benötigen eval()/new Function(). Reduziert die XSS-Exploit-Fläche.
+        "script-src 'self' 'unsafe-inline' https://js.stripe.com https://unpkg.com https://cdn.jsdelivr.net",
         "script-src-elem 'self' 'unsafe-inline' https://js.stripe.com https://unpkg.com https://cdn.jsdelivr.net",
         // Styles: eigene + Google Fonts + Leaflet + Flatpickr.
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com https://cdn.jsdelivr.net",
@@ -1269,6 +1297,10 @@ function eb_board_bookings_update_card( WP_REST_Request $request ) {
     return new WP_REST_Response( array( 'success' => true ), 200 );
 }
 function eventboerse_handle_register( WP_REST_Request $request ) {
+    // Anti-Spam: max. 20 Registrierungen pro IP / Stunde (lenient wegen
+    // Shared-IP bei Events; verhindert Massen-Account-/E-Mail-Spam).
+    $rl = eventboerse_check_rate_limit( 'register', 20, HOUR_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
     $params     = $request->get_json_params();
     $email_raw  = isset( $params['email'] )      ? (string) $params['email']                    : '';
     $email      = eb_normalize_email( $email_raw );

--- a/functions.php
+++ b/functions.php
@@ -348,6 +348,9 @@ function eventboerse_enqueue_assets() {
         'isLoggedIn' => is_user_logged_in(),
         'user'       => $user_data,
         'siteUrl'    => trailingslashit( home_url() ),
+        // Vom Admin entfernte Bilder (normalisierte Pfade) — der Client blendet
+        // sie aus, auch bei hardcodierten Demo-Listings (siehe eb_admin_moderate_image).
+        'imageBlocklist' => array_values( (array) get_option( 'eb_demo_image_blocklist', array() ) ),
     ) );
 }
 add_action( 'wp_enqueue_scripts', 'eventboerse_enqueue_assets' );
@@ -3533,11 +3536,28 @@ function eb_admin_moderate_image( WP_REST_Request $request ) {
         }
     }
 
+    // 3) Persistente Blocklist (normalisierter Pfad). Wirkt auch für
+    //    hardcodierte Demo-Listings im Client, die NICHT in der DB liegen —
+    //    sonst käme das Bild nach jedem Reload zurück.
+    $norm = eb_norm_img_url( $image );
+    if ( $norm !== '' ) {
+        $blocklist = (array) get_option( 'eb_demo_image_blocklist', array() );
+        if ( ! in_array( $norm, $blocklist, true ) ) {
+            $blocklist[] = $norm;
+            // Begrenzen, damit die Option nicht unbegrenzt wächst.
+            if ( count( $blocklist ) > 1000 ) {
+                $blocklist = array_slice( $blocklist, -1000 );
+            }
+            update_option( 'eb_demo_image_blocklist', array_values( $blocklist ), false );
+        }
+    }
+
     return new WP_REST_Response( array(
-        'removed'         => ( $gallery_removed + $listing_removed ) > 0,
+        'removed'         => true,
         'image'           => $image,
         'gallery_removed' => $gallery_removed,
         'listing_removed' => $listing_removed,
+        'blocklisted'     => $norm,
     ), 200 );
 }
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
   <!-- Leaflet & Flatpickr: nur CSS im Head, JS am Ende deferred -->
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css" />
 </head>
 <body>
 
@@ -3860,8 +3860,8 @@ Datum: ___________________________________________________
 
   <!-- Drittanbieter-Skripte deferred am Ende, um Render-Blocking zu vermeiden -->
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/l10n/de.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/l10n/de.js" defer></script>
   <script src="https://js.stripe.com/v3/" defer></script>
   <script src="app.js?v=158" defer></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -5058,6 +5058,66 @@ body.dark-mode .leaflet-control-zoom a:hover { background: #2A2A2C !important; }
 .prov-portfolio-crop:hover { background: #fff; transform: scale(1.1); }
 .prov-portfolio-crop .material-icons-round { font-size: 18px; }
 
+/* Admin-Moderation: Lösch-Overlay auf Portfolio-Bildern fremder Profile */
+.prov-portfolio-mod-wrap {
+  position: relative;
+  display: block;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.prov-portfolio-mod-del {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 5;
+  background: rgba(220,38,38,0.92);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  opacity: 0;
+  transition: all var(--transition);
+}
+.prov-portfolio-mod-wrap:hover .prov-portfolio-mod-del,
+.prov-portfolio-mod-del:focus-visible { opacity: 1; }
+.prov-portfolio-mod-del:hover { background: #dc2626; transform: scale(1.1); }
+.prov-portfolio-mod-del .material-icons-round { font-size: 18px; }
+/* Touch-Geräte: Button immer sichtbar (kein Hover) */
+@media (hover: none) {
+  .prov-portfolio-mod-del { opacity: 1; }
+}
+
+/* Admin-Lösch-Button im Provider-Lightbox */
+.plb-admin-delete {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(220,38,38,0.92);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  z-index: 10;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+  transition: all var(--transition);
+}
+.plb-admin-delete:hover { background: #dc2626; }
+.plb-admin-delete:active { transform: translateX(-50%) scale(0.96); }
+.plb-admin-delete .material-icons-round { font-size: 18px; }
+
 .prov-portfolio-add {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Drei Themen in diesem Branch:

## 1) Admin-Bildmoderation auf fremden Profilen
- `POST /admin/moderate-image` (nur Admin): entfernt eine Bild-URL aus `eb_gallery` des Ziel-Nutzers **und** aus den `images`-Arrays aller seiner Listings (tolerante URL-Normalisierung).
- `app.js`: Lösch-Overlay pro Portfolio-Bild + Lightbox-Button, nur für Admins auf **fremden** Profilen; lokale Caches + Cover-Galerie werden aktualisiert.
- `styles.css`: Styles dafür.
- Bereits vorhanden (kein Bug): Inserate (`eb_listings_delete`) und Bewertungen (`eb_review_delete`) haben serverseitig schon Admin-Override.

## 2) Deploy-Härtung (`.github/workflows/ionos-deploy.yml`)
- `terser@5.48.0` + `csso-cli@5.0.5` **gepinnt** (Ursache des Ausfalls vom 2026-06-24: `npx --yes` ohne Pin zog „latest", neuere terser-Version erzeugte kaputtes JS).
- CSS-Minify-Fehler ist nicht mehr fatal.

## 3) Security-Fixes
**3a) Stored XSS via Attribut-Injection**
- `_escHtml` encodete `"`/`'` nicht (textContent→innerHTML). Da `sanitize_text_field` Quotes durchlässt, konnte ein Dienstleister z. B. einen Titel `x" onmouseover="…` setzen, der aus `alt="${_escHtml(title)}"` ausbricht.
- Fix: `_escHtml` encodet jetzt `& < > " ' \``  → härtet alle Attribut-Interpolationen auf einen Schlag. Zusätzlich Map-Popup/Locations-Liste (vorher komplett ungeschützt) auf `_escHtml` umgestellt.

**3b) Brute-Force-Schutz aktiviert (Audit-Issue P0.4)**
- `includes/security/rate-limit.php` existierte, war aber **nie eingebunden** → inaktiv. Jetzt via `require_once` geladen und an `login`, `otp_verify`, `otp_send`, `forgot_password`, `reset_password` verdrahtet (per `REMOTE_ADDR`, kein X-Forwarded-For-Trust).
- Reset-on-Success für `login`/`otp_verify` → keine Shared-IP-Lockouts (Event-WLAN); komplementär zur bestehenden per-E-Mail/per-Code-Drosselung (deckt zusätzlich Password-Spraying ab).

### Audit-Ergebnis (geprüft, kein Handlungsbedarf)
- SQL: durchgängig `$wpdb->prepare()`, keine Interpolation ✓
- File-Upload: Magic-Byte-MIME, SVG/Doppel-Extension-Block, `getimagesize`-Recheck ✓
- IDOR: Conversations/Messages prüfen Teilnehmerschaft ✓
- Stripe-Webhook: HMAC-SHA256 + `hash_equals` + 300s Replay-Schutz ✓
- Admin-Endpoints: `eb_is_admin_user`/`manage_options`-gated ✓

## Tests
- `php -l functions.php` + `php -l includes/security/rate-limit.php` ✓
- `node --check app.js` ✓
- CI-Minify (`terser@5.48.0`) + Funktions-Guard lokal reproduziert ✓
- Keine `_escHtml`-Doppel-Encoding-Regression (nur in HTML-Strings verwendet) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd