### PR TITLE
Admin: Bild-Löschen-Button in der Inserat-Detailgalerie

### DIFF
--- a/app.js
+++ b/app.js
@@ -3239,9 +3239,15 @@ function loadDetail(listingId) {
   }
 
   // Swipeable gallery carousel
+  // Admins sehen pro Bild einen Lösch-Button (fremde Inserate) — entfernt das
+  // Bild persistent (auch bei Demo-Listings) via adminDeleteListingImage.
+  var _detailCanModerate = !!(currentUser && currentUser.isAdmin && listing.providerId !== currentUser.id);
   gallery.innerHTML = '<div class="detail-gallery-track" id="detailGalleryTrack">' +
     imgs.map(function(img, i) {
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' /></div>';
+      var delBtn = _detailCanModerate && img !== window.EB_IMG_FALLBACK
+        ? '<button type="button" class="detail-gallery-admin-del" title="Bild als Admin löschen" aria-label="Bild als Admin löschen" onclick="adminDeleteListingImage(' + i + ', event)"><span class="material-icons-round">delete</span> Löschen</button>'
+        : '';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + delBtn + '</div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" aria-label="Vorheriges Bild" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -4480,6 +4486,36 @@ function adminDeleteProfileImage(index, ev) {
       }
     }
     showToast('Bild als Admin gelöscht.', 'delete');
+  }).catch(function() { showToast('Löschen fehlgeschlagen', 'error'); });
+}
+
+/**
+ * Admin-Moderation auf der INSERAT-DETAILSEITE: löscht ein einzelnes Bild der
+ * aktuell offenen Inserat-Galerie (currentListing) — persistent via Blocklist,
+ * wirkt auch für hardcodierte Demo-Listings.
+ */
+function adminDeleteListingImage(index, ev) {
+  if (ev) { ev.stopPropagation(); if (ev.preventDefault) ev.preventDefault(); }
+  if (!currentUser || !currentUser.isAdmin || !currentListing) return;
+  var imgs = (Array.isArray(currentListing.images) && currentListing.images.length)
+    ? currentListing.images
+    : (currentListing.image ? [currentListing.image] : []);
+  var url = imgs[index];
+  if (!url || url === window.EB_IMG_FALLBACK) return;
+  var targetId = currentListing.providerId;
+  if (!targetId) { showToast('Anbieter-ID unbekannt', 'error'); return; }
+  if (!confirm('Als Admin: Dieses Bild wirklich löschen?')) return;
+  fetch(_apiUrl('admin/moderate-image'), {
+    method: 'POST', credentials: 'same-origin', headers: _apiHeaders(),
+    body: JSON.stringify({ user_id: targetId, image: url })
+  }).then(function(r) {
+    _refreshNonce(r);
+    if (!r.ok) { showToast('Löschen fehlgeschlagen', 'error'); return; }
+    // Blocklist mitziehen (alle Größen-Varianten + Cover) und Detailseite neu rendern
+    if (window.EB_IMG_BLOCKLIST) window.EB_IMG_BLOCKLIST.add(_imgNormPath(url));
+    _applyImageBlocklist(LISTINGS);
+    showToast('Bild als Admin gelöscht.', 'delete');
+    if (currentListing) loadDetail(currentListing.id);
   }).catch(function() { showToast('Löschen fehlgeschlagen', 'error'); });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -4118,6 +4118,30 @@ body.dark-mode .detail-gallery-arrow { background: rgba(40,40,40,0.92); color: #
 body.dark-mode .detail-gallery-arrow:hover { background: rgba(55,55,55,0.98); }
 .detail-gallery-arrow.prev { left: 12px; }
 .detail-gallery-arrow.next { right: 12px; }
+
+/* Admin: Bild-Löschen pro Slide auf der Detailseite (immer sichtbar für Admins) */
+.detail-gallery-admin-del {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 6;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(220,38,38,0.94);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.35);
+  transition: background .2s, transform .1s;
+}
+.detail-gallery-admin-del:hover { background: #dc2626; }
+.detail-gallery-admin-del:active { transform: scale(0.96); }
+.detail-gallery-admin-del .material-icons-round { font-size: 18px; }
 .detail-gallery-counter {
   position: absolute;
   top: 14px;
@@ -5081,17 +5105,11 @@ body.dark-mode .leaflet-control-zoom a:hover { background: #2A2A2C !important; }
   background: rgba(220,38,38,0.92);
   color: #fff;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  opacity: 0;
+  opacity: 1; /* für Admins immer sichtbar (Auffindbarkeit) */
   transition: all var(--transition);
 }
-.prov-portfolio-mod-wrap:hover .prov-portfolio-mod-del,
-.prov-portfolio-mod-del:focus-visible { opacity: 1; }
 .prov-portfolio-mod-del:hover { background: #dc2626; transform: scale(1.1); }
 .prov-portfolio-mod-del .material-icons-round { font-size: 18px; }
-/* Touch-Geräte: Button immer sichtbar (kein Hover) */
-@media (hover: none) {
-  .prov-portfolio-mod-del { opacity: 1; }
-}
 
 /* Admin-Lösch-Button im Provider-Lightbox */
 .plb-admin-delete {


### PR DESCRIPTION
Ergänzt den Admin-Bild-Löschen-Button dort, wo man die Bilder tatsächlich ansieht — in der **Inserat-Detailgalerie** (vorher nur im Provider-Portfolio als Hover-Overlay).

- `app.js`: pro Galerie-Bild ein klar sichtbarer roter „Löschen"-Button (nur Admins, fremde Inserate) → `adminDeleteListingImage` entfernt das Bild persistent über die Blocklist (wirkt auch für hardcodierte Demo-Listings wie Blumenträume München / Pyroshock) und rendert die Galerie neu.
- `styles.css`: Button-Styling; Provider-Portfolio-Lösch-Button jetzt dauerhaft sichtbar (vorher nur bei Hover → schwer auffindbar).

Getestet: `node --check app.js` ✓, CI-Minify (terser@5.48.0) + Funktions-Guard ✓. Keine PHP-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_