### PR TITLE
Self-Audit Loop + HQ-Panel „Selbstcheck"

### DIFF
--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,0 +1,95 @@
+{
+  "schema": "eb-self-audit/v1",
+  "generatedAt": "2026-06-29T11:09:33Z",
+  "commit": "2330172",
+  "counts": {
+    "total": 7,
+    "error": 0,
+    "warn": 2,
+    "info": 4,
+    "ok": 1
+  },
+  "findings": [
+    {
+      "id": "dsgvo-analytics-inert",
+      "title": "analytics.php ist inert (kein Tracking)",
+      "area": "security",
+      "severity": "ok",
+      "status": "fixed",
+      "detail": "Keine Verarbeitung personenbezogener Daten — kann nach Deploy-Verifikation gelöscht werden.",
+      "suggestion": "Datei nach Live-Verifikation entfernen (chore-PR).",
+      "evidence": null
+    },
+    {
+      "id": "route-admin-mod-missing",
+      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
+      "area": "backend",
+      "severity": "warn",
+      "status": "open",
+      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
+      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
+      "evidence": null
+    },
+    {
+      "id": "size-app.js-watch",
+      "title": "app.js wächst (21501 Zeilen)",
+      "area": "maintainability",
+      "severity": "info",
+      "status": "open",
+      "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
+      "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
+      "evidence": {
+        "lines": 21501,
+        "threshold": 20000
+      }
+    },
+    {
+      "id": "size-functions.php-watch",
+      "title": "functions.php wächst (7553 Zeilen)",
+      "area": "maintainability",
+      "severity": "info",
+      "status": "open",
+      "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
+      "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
+      "evidence": {
+        "lines": 7553,
+        "threshold": 6000
+      }
+    },
+    {
+      "id": "size-styles.css-watch",
+      "title": "styles.css wächst (15078 Zeilen)",
+      "area": "maintainability",
+      "severity": "info",
+      "status": "open",
+      "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
+      "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
+      "evidence": {
+        "lines": 15078,
+        "threshold": 12000
+      }
+    },
+    {
+      "id": "console-noise",
+      "title": "17 console.*-Aufrufe in app.js",
+      "area": "cleanup",
+      "severity": "info",
+      "status": "open",
+      "detail": "Aufrufe landen in der Browser-Konsole der Nutzer. Für Production wäre ein Debug-Flag sauberer.",
+      "suggestion": "Kosmetik: console-Aufrufe hinter einen `EB_DEBUG`-Flag stellen oder in production strippen.",
+      "evidence": {
+        "count": 17
+      }
+    },
+    {
+      "id": "no-tests",
+      "title": "Keine automatisierten Tests im Repo",
+      "area": "quality",
+      "severity": "warn",
+      "status": "open",
+      "detail": "Bekannte Schwäche aus CLAUDE.md. Ein paar Smoke-Tests gegen die SPA wären schon viel wert.",
+      "suggestion": "Playwright-Smoke-Suite für browse/detail/board/chat (regression-Schutz P0).",
+      "evidence": null
+    }
+  ]
+}

--- a/hq.html
+++ b/hq.html
@@ -384,6 +384,38 @@
   .empty { color: var(--muted); padding: 1rem; text-align:center; font-size:.85rem; }
   .err { color: #fca5a5; padding: 1rem; font-size:.85rem; }
 
+  /* ── Selbstcheck (KI-Audit) ── */
+  .audit-summary {
+    display:flex; gap:.45rem; flex-wrap:wrap; align-items:center; margin-bottom:.85rem;
+    background:var(--surface); border:1px solid var(--border); border-radius:14px;
+    padding:.7rem 1rem; font-size:.82rem;
+  }
+  .audit-summary .as-meta { color:var(--muted); font-size:.74rem; margin-left:auto; }
+  .audit-chip { display:inline-flex; align-items:center; gap:.35rem; padding:.18rem .55rem; border-radius:999px;
+    font-weight:700; font-size:.74rem; border:1px solid var(--border); background:var(--surface2); }
+  .audit-chip.error { background:#3a1414; color:#fca5a5; border-color:rgba(239,68,68,.5); }
+  .audit-chip.warn  { background:#3a2a14; color:#fcd34d; border-color:rgba(245,158,11,.5); }
+  .audit-chip.info  { background:#14283a; color:#93c5fd; border-color:rgba(34,211,238,.4); }
+  .audit-chip.ok    { background:#14321f; color:#86efac; border-color:rgba(34,197,94,.4); }
+  .findings { display:grid; gap:.6rem; margin-bottom:2rem; }
+  .finding {
+    background:var(--surface); border:1px solid var(--border); border-radius:13px;
+    padding:.85rem 1rem; transition:border-color .2s, transform .15s; position:relative;
+  }
+  .finding.sev-error { border-color:rgba(239,68,68,.55); }
+  .finding.sev-warn  { border-color:rgba(245,158,11,.45); }
+  .finding.sev-ok    { border-color:rgba(34,197,94,.4); }
+  .finding-head { display:flex; align-items:center; gap:.55rem; margin-bottom:.35rem; flex-wrap:wrap; }
+  .finding-title { font-weight:700; font-size:.92rem; line-height:1.35; flex:1; min-width:0; }
+  .finding-area { font-size:.62rem; padding:.12rem .45rem; border-radius:6px; background:var(--surface2);
+    color:var(--muted); text-transform:uppercase; letter-spacing:.06em; font-weight:700; }
+  .finding-detail { font-size:.8rem; color:var(--muted); line-height:1.5; margin-bottom:.4rem; }
+  .finding-sugg {
+    font-size:.78rem; padding:.5rem .7rem; border-left:3px solid var(--cyan);
+    background:rgba(34,211,238,.06); border-radius:0 8px 8px 0; line-height:1.5;
+  }
+  .finding-actions { display:flex; gap:.4rem; margin-top:.6rem; flex-wrap:wrap; }
+
   @media (max-width: 720px) {
     .hud-stats { grid-template-columns: 1fr 1fr; }
     .release-top { flex-direction: column; gap: .3rem; }
@@ -488,6 +520,23 @@
           <button class="btn btn-primary" id="pat-save">Speichern</button>
         </div>
       </div>
+    </div>
+
+    <!-- Selbstcheck (KI-Audit) -->
+    <div class="section-header">
+      <div class="section-title">🔧 Selbstcheck <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— was läuft, was nicht</span></div>
+      <div class="section-badge" id="audit-badge">–</div>
+    </div>
+    <div class="audit-summary" id="audit-summary">
+      <span class="audit-chip" id="audit-chip-err">❌ –</span>
+      <span class="audit-chip" id="audit-chip-warn">⚠️ –</span>
+      <span class="audit-chip" id="audit-chip-info">💡 –</span>
+      <span class="audit-chip" id="audit-chip-ok">✅ –</span>
+      <span class="as-meta" id="audit-meta">Audit wird geladen…</span>
+    </div>
+    <div class="findings" id="findings-list">
+      <div class="skeleton" style="height:80px;"></div>
+      <div class="skeleton" style="height:80px;"></div>
     </div>
 
     <!-- Quests -->
@@ -1144,6 +1193,7 @@ async function init() {
   $('sound-btn').textContent = soundOn ? '🔊' : '🔇';
   renderQuests(); renderAchievements(); // instant, local
   renderFromCache();                    // instant, cached GitHub data
+  loadSelfAudit();                      // local audit/latest.json
   await checkSiteStatus();
   await loadAll();                      // fresh GitHub data
   renderHud();
@@ -1151,10 +1201,74 @@ async function init() {
 
 async function refreshAll() {
   showToast('🔄 Aktualisiere…');
+  loadSelfAudit();
   await checkSiteStatus();
   await loadAll();
   renderHud();
   showToast('✅ Aktualisiert', 'success'); sfx('click');
+}
+
+/* ─── Self-Audit (liest audit/latest.json) ─────────────────────── */
+const SEV_ICON = { error: '❌', warn: '⚠️', info: '💡', ok: '✅' };
+async function loadSelfAudit() {
+  const list = $('findings-list'), meta = $('audit-meta'), badge = $('audit-badge');
+  // Versuche zuerst lokales File (gleicher Pfad wie hq.html, also Theme-Wurzel),
+  // dann GitHub Raw als Fallback (damit hq.html auch standalone funktioniert).
+  const tryUrls = [
+    new URL('audit/latest.json', location.href).href + '?t=' + Date.now(),
+    `https://raw.githubusercontent.com/${REPO}/main/audit/latest.json`,
+  ];
+  let data = null;
+  for (const u of tryUrls) {
+    try {
+      const r = await fetch(u, { cache: 'no-store' });
+      if (!r.ok) continue;
+      data = await r.json();
+      break;
+    } catch {}
+  }
+  if (!data || !Array.isArray(data.findings)) {
+    list.innerHTML = '<div class="empty">Noch kein Audit. <code>node scripts/self-audit.mjs</code> ausführen.</div>';
+    badge.textContent = '0';
+    meta.textContent = 'kein Audit gefunden';
+    return;
+  }
+  const c = data.counts || {};
+  $('audit-chip-err').textContent  = `❌ ${c.error || 0}`;
+  $('audit-chip-warn').textContent = `⚠️ ${c.warn  || 0}`;
+  $('audit-chip-info').textContent = `💡 ${c.info  || 0}`;
+  $('audit-chip-ok').textContent   = `✅ ${c.ok    || 0}`;
+  badge.textContent = String(data.findings.length);
+  meta.textContent = `Stand ${humanDate(data.generatedAt)} · Commit ${data.commit || '–'}`;
+
+  // Sortierung: error → warn → info → ok
+  const order = { error: 0, warn: 1, info: 2, ok: 3 };
+  const sorted = [...data.findings].sort((a, b) => (order[a.severity] ?? 9) - (order[b.severity] ?? 9));
+  list.innerHTML = sorted.map(f => {
+    const sev = f.severity || 'info';
+    const icon = SEV_ICON[sev] || '•';
+    const issueQ = encodeURIComponent(`is:issue ${f.id}`);
+    const newIssueTitle = encodeURIComponent(`[audit] ${f.title}`);
+    const newIssueBody  = encodeURIComponent(
+      `**Finding-ID:** \`${f.id}\`\n**Schweregrad:** ${sev}\n**Bereich:** ${f.area || '–'}\n\n` +
+      `**Detail:** ${f.detail || '–'}\n\n**Vorschlag:** ${f.suggestion || '–'}\n\n` +
+      `_Automatisch erzeugt vom Self-Audit (${data.commit || '–'})._`
+    );
+    return `
+      <div class="finding sev-${sev}" data-id="${escHtml(f.id)}">
+        <div class="finding-head">
+          <span>${icon}</span>
+          <div class="finding-title">${escHtml(f.title)}</div>
+          <span class="finding-area">${escHtml(f.area || 'general')}</span>
+        </div>
+        ${f.detail ? `<div class="finding-detail">${escHtml(f.detail)}</div>` : ''}
+        ${f.suggestion ? `<div class="finding-sugg"><strong>Vorschlag:</strong> ${escHtml(f.suggestion)}</div>` : ''}
+        <div class="finding-actions">
+          <a class="btn" href="https://github.com/${REPO}/issues?q=${issueQ}" target="_blank" rel="noopener">🔎 Vorhandene Issues</a>
+          <a class="btn btn-primary" href="https://github.com/${REPO}/issues/new?title=${newIssueTitle}&body=${newIssueBody}&labels=audit" target="_blank" rel="noopener">📝 Als Issue anlegen</a>
+        </div>
+      </div>`;
+  }).join('');
 }
 
 /* ─── Wiring ───────────────────────────────────────────────────── */

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,34 @@
 # Scripts
 
+## `self-audit.mjs` — Statischer Selbstcheck
+
+Sammelt schreibfrei Health-Findings (DSGVO-Reste, REST-Routen-Drift, fehlende
+Admin-Routen, Stack-Size, console-Rauschen, TODOs, Tests, Index-Drift,
+Backup-Müll) und schreibt sie nach `audit/latest.json`.
+
+Das HQ-Dashboard (`hq.html` → Sektion **🔧 Selbstcheck**) liest dieselbe Datei
+und zeigt jedes Finding mit Schweregrad, Detail und Vorschlag — pro Eintrag
+kannst du daraus per Klick ein GitHub-Issue anlegen.
+
+### Ausführen
+
+```bash
+node scripts/self-audit.mjs            # schreibt audit/latest.json
+node scripts/self-audit.mjs --print    # gibt JSON zusätzlich auf stdout aus
+```
+
+Keine externen Abhängigkeiten, Node 18+. Idempotent — `audit/latest.json`
+wird bei jedem Lauf vollständig überschrieben, sodass Diffs lesbar bleiben.
+
+### Self-Improvement Loop
+
+1. `node scripts/self-audit.mjs` → erzeugt Findings
+2. HQ-Dashboard zeigt jeden Eintrag mit „📝 Als Issue anlegen"-Button
+3. KI-Worker oder Mensch beheben einzelne Findings als kleine PRs
+4. Du mergst (Zustimmung) oder schließt (Ablehnung) — fertig
+
+---
+
 ## `localize-demo-images.mjs` — Demo-Bilder lokal hosten
 
 Lädt alle externen Demo-Bilder (Pexels/Unsplash) aus `app.js` herunter, legt sie

--- a/scripts/self-audit.mjs
+++ b/scripts/self-audit.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Eventbörse — Self-Audit
+ *
+ * Statische, schreibfreie Health-Checks über das Repo. Schreibt das Ergebnis
+ * nach audit/latest.json — das HQ-Dashboard (hq.html) liest die Datei und
+ * zeigt jedes Finding mit Status + Vorschlag. Approve/Ablehnen läuft über
+ * GitHub: jeder Vorschlag wird vom KI-Worker als PR aufgemacht, der Nutzer
+ * mergt oder schliesst ihn.
+ *
+ * Aufruf:
+ *   node scripts/self-audit.mjs            # schreibt audit/latest.json
+ *   node scripts/self-audit.mjs --print    # zusätzlich JSON auf stdout
+ *
+ * Keine externen Abhängigkeiten, läuft auf Node 18+.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const rel = p => path.relative(ROOT, p);
+const read = p => fs.readFileSync(path.join(ROOT, p), 'utf8');
+const exists = p => fs.existsSync(path.join(ROOT, p));
+const lines = s => s.split(/\r?\n/).length;
+const byteSize = p => fs.statSync(path.join(ROOT, p)).size;
+
+const findings = [];
+const add = (f) => findings.push({
+  id: f.id,
+  title: f.title,
+  area: f.area || 'general',
+  severity: f.severity || 'info',   // ok | info | warn | error
+  status: f.status || 'open',       // open | review | fixed
+  detail: f.detail || '',
+  suggestion: f.suggestion || '',
+  evidence: f.evidence || null,
+});
+
+/* ─── 1. DSGVO: analytics.php muss inerte No-Op sein ─────────────── */
+try {
+  const src = read('analytics.php');
+  const writesIP = /\$_SERVER\[.REMOTE_ADDR.\]|file_put_contents|fopen|fwrite/.test(src);
+  const declaredInert = /DEAKTIVIERT|inerte? No-?Op|return;\s*$/i.test(src);
+  if (writesIP) add({
+    id: 'dsgvo-analytics-active',
+    title: 'analytics.php verarbeitet wieder personenbezogene Daten',
+    area: 'security',
+    severity: 'error',
+    detail: 'Datei enthält wieder IP-/Logging-Aufrufe. Verstösst gegen Datenschutzerklärung.',
+    suggestion: 'analytics.php auf No-Op zurücksetzen oder Datei komplett löschen.',
+  }); else if (declaredInert) add({
+    id: 'dsgvo-analytics-inert',
+    title: 'analytics.php ist inert (kein Tracking)',
+    area: 'security',
+    severity: 'ok',
+    status: 'fixed',
+    detail: 'Keine Verarbeitung personenbezogener Daten — kann nach Deploy-Verifikation gelöscht werden.',
+    suggestion: 'Datei nach Live-Verifikation entfernen (chore-PR).',
+  });
+} catch { /* file gone is fine */ }
+
+/* ─── 2. WordPress REST-Routen zählen + mit Vault abgleichen ─────── */
+try {
+  const fns = read('functions.php');
+  const routes = (fns.match(/register_rest_route\s*\(/g) || []).length;
+  const ctx = exists('vault/AI-Gedaechtnis/Claude-Kontext.md') ? read('vault/AI-Gedaechtnis/Claude-Kontext.md') : '';
+  const m = ctx.match(/\((\d+)\s*Route-Registrierungen/);
+  const documented = m ? parseInt(m[1], 10) : null;
+  if (documented !== null && documented !== routes) add({
+    id: 'docs-routes-drift',
+    title: `Vault-Doku zählt ${documented} REST-Routen, Code hat ${routes}`,
+    area: 'docs',
+    severity: 'info',
+    detail: 'vault/AI-Gedaechtnis/Claude-Kontext.md weicht von functions.php ab.',
+    suggestion: `In Claude-Kontext.md auf „${routes} Route-Registrierungen" aktualisieren.`,
+    evidence: { documented, actual: routes },
+  });
+  // 3. Vault erwähnt Admin-Moderationsrouten, die im Code fehlen
+  if (!/admin\/listings|my-listing-moderation/.test(fns)) {
+    const bugs = exists('vault/Roadmap/Bekannte-Bugs.md') ? read('vault/Roadmap/Bekannte-Bugs.md') : '';
+    if (/admin\/listings|my-listing-moderation/.test(bugs)) add({
+      id: 'route-admin-mod-missing',
+      title: 'Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code',
+      area: 'backend',
+      severity: 'warn',
+      detail: '`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.',
+      suggestion: 'Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.',
+    });
+  }
+} catch {}
+
+/* ─── 4. Datei-Stack-Size Warnungen ──────────────────────────────── */
+const sizeCheck = (file, warnLines, errLines) => {
+  if (!exists(file)) return;
+  const n = lines(read(file));
+  if (n >= errLines) add({
+    id: `size-${file}`,
+    title: `${file} ist mit ${n} Zeilen sehr gross`,
+    area: 'maintainability',
+    severity: 'warn',
+    detail: 'Monolith — Splitting in Module würde Lesbarkeit und Hot-Reload deutlich verbessern.',
+    suggestion: 'Inkrementell Module rausziehen (z. B. router, api, board, chat). Nicht in einem Schritt.',
+    evidence: { lines: n, threshold: errLines },
+  });
+  else if (n >= warnLines) add({
+    id: `size-${file}-watch`,
+    title: `${file} wächst (${n} Zeilen)`,
+    area: 'maintainability',
+    severity: 'info',
+    detail: 'Wachsendes Monolith-Risiko, noch nicht kritisch.',
+    suggestion: 'Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.',
+    evidence: { lines: n, threshold: warnLines },
+  });
+};
+sizeCheck('app.js', 20000, 30000);
+sizeCheck('functions.php', 6000, 10000);
+sizeCheck('styles.css', 12000, 20000);
+
+/* ─── 5. console.* in Produktions-JS ─────────────────────────────── */
+try {
+  const js = read('app.js');
+  const consoleCalls = (js.match(/console\.(log|warn|debug|info)\(/g) || []).length;
+  if (consoleCalls > 0) add({
+    id: 'console-noise',
+    title: `${consoleCalls} console.*-Aufrufe in app.js`,
+    area: 'cleanup',
+    severity: consoleCalls > 50 ? 'warn' : 'info',
+    detail: 'Aufrufe landen in der Browser-Konsole der Nutzer. Für Production wäre ein Debug-Flag sauberer.',
+    suggestion: 'Kosmetik: console-Aufrufe hinter einen `EB_DEBUG`-Flag stellen oder in production strippen.',
+    evidence: { count: consoleCalls },
+  });
+} catch {}
+
+/* ─── 6. TODO / FIXME Marker ─────────────────────────────────────── */
+try {
+  const out = execSync('grep -rInE "TODO|FIXME|HACK|XXX" --include=*.js --include=*.php --include=*.html --include=*.css . 2>/dev/null || true', { cwd: ROOT }).toString();
+  const todos = out.trim() ? out.trim().split('\n').length : 0;
+  if (todos > 0) add({
+    id: 'open-todos',
+    title: `${todos} offene TODO/FIXME-Marker im Code`,
+    area: 'cleanup',
+    severity: 'info',
+    detail: 'Sammlung an Notizen, die noch nicht in Bekannte-Bugs.md überführt wurden.',
+    suggestion: 'Beim nächsten Sweep abklären: erledigt → entfernen, sonst in vault/Roadmap/Bekannte-Bugs.md überführen.',
+    evidence: { count: todos },
+  });
+} catch {}
+
+/* ─── 7. Automatisierte Tests vorhanden? ─────────────────────────── */
+const hasTests = ['tests', 'test', '__tests__'].some(d => exists(d))
+              || (exists('package.json') && /"(jest|vitest|playwright|mocha|cypress)"/.test(read('package.json')));
+if (!hasTests) add({
+  id: 'no-tests',
+  title: 'Keine automatisierten Tests im Repo',
+  area: 'quality',
+  severity: 'warn',
+  detail: 'Bekannte Schwäche aus CLAUDE.md. Ein paar Smoke-Tests gegen die SPA wären schon viel wert.',
+  suggestion: 'Playwright-Smoke-Suite für browse/detail/board/chat (regression-Schutz P0).',
+});
+
+/* ─── 8. Service Worker registriert? ─────────────────────────────── */
+if (exists('sw.js')) {
+  try {
+    const sw = read('sw.js');
+    if (!/self\.addEventListener\(['"]install/.test(sw)) add({
+      id: 'sw-incomplete',
+      title: 'Service Worker ohne install-Handler',
+      area: 'pwa',
+      severity: 'info',
+      detail: 'sw.js existiert, aber install-Lifecycle scheint unvollständig.',
+      suggestion: 'Optional — bei PWA-Push-Roadmap mit ausbauen.',
+    });
+  } catch {}
+}
+
+/* ─── 9. Index-Drift: index.html aus app-shell.html generiert? ───── */
+try {
+  if (exists('app-shell.html') && exists('index.html') && exists('build-index-html.sh')) {
+    const shell = read('app-shell.html');
+    const idx = read('index.html');
+    if (!idx.includes(shell.slice(200, 800))) add({
+      id: 'index-html-drift',
+      title: 'index.html scheint nicht aus app-shell.html neu gebaut',
+      area: 'build',
+      severity: 'warn',
+      detail: 'Lokale Dev-Shell weicht von der kanonischen app-shell.html ab.',
+      suggestion: '`./build-index-html.sh` ausführen und commiten.',
+    });
+  }
+} catch {}
+
+/* ─── 10. Git-Hygiene: ungetrackte Bak-Dateien? ──────────────────── */
+try {
+  const out = execSync('git ls-files --others --exclude-standard 2>/dev/null || true', { cwd: ROOT }).toString().trim();
+  const baks = out.split('\n').filter(l => /\.(bak|orig|tmp|old)$/.test(l));
+  if (baks.length) add({
+    id: 'stale-bak-files',
+    title: `${baks.length} ungetrackte Backup-/Temp-Dateien im Working Tree`,
+    area: 'cleanup',
+    severity: 'info',
+    detail: baks.slice(0, 5).join(', '),
+    suggestion: 'Entweder löschen oder ins .gitignore aufnehmen.',
+  });
+} catch {}
+
+/* ─── Meta + Output ──────────────────────────────────────────────── */
+let head = null;
+try { head = execSync('git rev-parse --short HEAD', { cwd: ROOT }).toString().trim(); } catch {}
+
+const counts = {
+  total: findings.length,
+  error: findings.filter(f => f.severity === 'error').length,
+  warn:  findings.filter(f => f.severity === 'warn').length,
+  info:  findings.filter(f => f.severity === 'info').length,
+  ok:    findings.filter(f => f.severity === 'ok').length,
+};
+
+const result = {
+  schema: 'eb-self-audit/v1',
+  generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  commit: head,
+  counts,
+  findings,
+};
+
+const outDir = path.join(ROOT, 'audit');
+fs.mkdirSync(outDir, { recursive: true });
+const outPath = path.join(outDir, 'latest.json');
+fs.writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n');
+process.stdout.write(`✔ self-audit: ${counts.total} Findings (err:${counts.error} warn:${counts.warn} info:${counts.info} ok:${counts.ok}) → ${rel(outPath)}\n`);
+if (process.argv.includes('--print')) process.stdout.write(JSON.stringify(result, null, 2) + '\n');

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -20,7 +20,7 @@
 | Was | Details |
 |-----|---------|
 | Frontend | `app.js` 21.093 Zeilen, Vanilla JS SPA |
-| Backend | `functions.php` 7.294 Zeilen, WordPress REST API (81 Route-Registrierungen) |
+| Backend | `functions.php` 7.553 Zeilen, WordPress REST API (82 Route-Registrierungen) |
 | Styling | `styles.css` 14.716 Zeilen, mobile-first |
 | Hosting | IONOS/Shared WordPress Hosting, automatisches Deployment via GitHub Actions + SFTP |
 | Auth | Login/Register + 2FA (OTP per E-Mail) + WebAuthn/Passkeys |


### PR DESCRIPTION
Erster Baustein für den **selbst-verbessernden Code**: ein statischer Audit-Lauf erkennt Findings, das HQ-Dashboard zeigt sie übersichtlich — pro Eintrag legt ein Klick ein vorbefülltes Issue an. Approve/Ablehnen läuft danach klassisch über PR-Merge.

## Was drin ist

- **`scripts/self-audit.mjs`** — schreibfreier Health-Sweep ohne Abhängigkeiten (Node 18+, idempotent):
  - DSGVO: `analytics.php` darf keine PII verarbeiten
  - REST-Routen-Drift zwischen Vault-Doku und `functions.php`
  - Fehlende Admin-Moderationsrouten, die im Vault dokumentiert sind
  - Stack-Size-Wachstum (`app.js`, `functions.php`, `styles.css`)
  - `console.*`-Rauschen in Produktions-JS
  - Offene `TODO/FIXME`-Marker
  - Fehlende automatisierte Tests
  - Service-Worker-Vollständigkeit
  - `index.html` vs. `app-shell.html`-Drift
  - Vergessene `.bak/.tmp/.orig`-Dateien
- **`audit/latest.json`** — versioniertes JSON-Output, damit Diffs lesbar sind. Erster realer Lauf: **7 Findings** (0 err / 2 warn / 4 info / 1 ok).
- **`hq.html`** — neue Sektion **🔧 Selbstcheck** direkt vor den Quests. Lädt `audit/latest.json` lokal mit GitHub-Raw als Fallback. Findings werden nach Schweregrad sortiert (error → warn → info → ok). Jeder Eintrag hat zwei Buttons:
  - **🔎 Vorhandene Issues** — sucht in GitHub nach der Finding-ID
  - **📝 Als Issue anlegen** — öffnet GitHub-Issue-Form mit Title/Body/Label vorbefüllt
- **`vault/AI-Gedaechtnis/Claude-Kontext.md`** — direkter Loop-Schluss: das Drift-Finding hat die Doku selbst gefixt (81→82 Routen, 7.294→7.553 Zeilen). Damit ist `findings.length` 8 → 7 gegangen.
- **`scripts/README.md`** — Loop-Workflow dokumentiert.

## Wie der Self-Improvement-Loop funktioniert

1. `node scripts/self-audit.mjs` → schreibt `audit/latest.json`
2. HQ-Dashboard zeigt jeden Eintrag mit Vorschlag + Issue-Button
3. KI-Worker oder Mensch behebt einzelne Findings als kleine PRs
4. **Du mergst (= Zustimmung) oder schließt (= Ablehnung)** — fertig

## Aktuelle Findings (zur Info)

| Sev   | Bereich      | Finding |
|-------|--------------|---------|
| ⚠️ warn  | backend      | Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code |
| ⚠️ warn  | quality      | Keine automatisierten Tests im Repo |
| 💡 info  | maintainability | `app.js` wächst (21 501 Zeilen) |
| 💡 info  | maintainability | `functions.php` wächst (7 553 Zeilen) |
| 💡 info  | maintainability | `styles.css` wächst (15 078 Zeilen) |
| 💡 info  | cleanup      | 17 `console.*`-Aufrufe in `app.js` |
| ✅ ok    | security     | `analytics.php` ist inert (kein Tracking) |

## Was nicht drin ist (bewusst)

- Keine CI-Anbindung (`.github/workflows/`) — kann als nächster Schritt rein, sobald der Loop sich im Alltag bewährt
- Keine automatischen Fix-PRs — der Self-Audit sammelt nur Befunde, das Beheben bleibt expliziter Schritt (Guardrails P0 aus `Current-Sprint.md`)
- Keine Änderung an `app.js`/`functions.php` — diese PR ist rein additiv und betrifft keinen Produktions-Code-Pfad


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqrHsRhgC2SwMdoGS8fKX6)_