### PR TITLE
docs(vault): Projekt-Gedächtnis 2026-06-26 (Admin-Moderation & Security)

### DIFF
--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -127,5 +127,17 @@ navigateTo('admin')         // Admin-Panel
 
 - **`hq.html` = EventBörse HQ (Mission Control):** Eigenständiges, self-contained Dev-Command-Center über die GitHub-API. Gamifiziert (Level/XP, Streak, Quests = Roadmap, Achievements, Bot-Team, Aktivitäts-Log, Confetti/SFX). Kein Build-Schritt, kein Framework. Zugriff per `HQ_KEYS`, GitHub-PAT (sessionStorage) für Rollback/Bot-Trigger. Quests spiegeln die Sprint-Roadmap — beim Hinzufügen neuer Roadmap-Punkte auch das `QUESTS`-Array in `hq.html` pflegen. GitHub-Daten werden per stale-while-revalidate in `localStorage` gecacht (geringere Rate-Limit-Last).
 
+## Stand 2026-06-26 — Admin-Bildmoderation & Security-Härtung (live auf main)
+
+- **Admin-Bildmoderation (umgesetzt):** Admins können einzelne Bilder löschen
+  - Detailseite: roter „Löschen"-Button pro Galerie-Bild (`adminDeleteListingImage`).
+  - Provider-Portfolio: Lösch-Overlay (`adminDeleteProfileImage`) + Lightbox-Button, dauerhaft sichtbar.
+  - Backend: `POST /admin/moderate-image` (nur Admin) entfernt Bild aus `eb_gallery` + allen Listings des Nutzers.
+  - **Persistente Blocklist** (`eb_demo_image_blocklist`, normalisierte Pfade) → wirkt auch für hardcodierte Demo-Listings (z. B. Blumenträume München, Pyroshock), reload-fest. Client: `window.EB_IMG_BLOCKLIST` via `eventboerseApi.imageBlocklist`, gefiltert in Demo-LISTINGS, `loadDbListings`, `loadProvider`.
+  - Damit ist der alte Sprint-P0 „Admin-Moderation gegen Code abgleichen" erledigt.
+- **Security (live):** XSS-Härtung (`_escHtml` encodet jetzt auch Quotes; Map-/Card-Render escapt); Brute-Force-Rate-Limiting verdrahtet (`includes/security/rate-limit.php` war vorher nie eingebunden) auf Login/OTP/Reset/Register mit Reset-on-Success; CSP `'unsafe-eval'` entfernt (Frontend nutzt kein eval, kein jQuery); WP-User-Enumeration gesperrt (`/wp/v2/users` + `?author=N`).
+- **CI/Deploy:** Neuer Workflow `.github/workflows/security.yml` (php -l alle + node --check + Pattern-Scan, läuft bei Push/PR). Minifier-Versionen gepinnt (`terser@5.48.0`, `csso-cli@5.0.5`) — Ursache eines früheren Ausfalls (unpinned `npx` zog kaputtes terser-Release). `SECURITY.md` mit Responsible-Disclosure-Policy.
+- **Offen (User-Seite):** Postfach `security@eventbörse.de` einrichten; optional CDN-SRI/Self-Hosting (von CI-Umgebung nicht möglich, Outbound geblockt); strikte CSP ohne `'unsafe-inline'` würde Inline-Handler-Refactor erfordern (groß, bewusst zurückgestellt).
+
 ---
-*Zuletzt aktualisiert: 2026-06-17*
+*Zuletzt aktualisiert: 2026-06-26*

--- a/vault/Roadmap/Current-Sprint.md
+++ b/vault/Roadmap/Current-Sprint.md
@@ -13,9 +13,12 @@
 - [ ] **Stripe Connect E2E im Testmodus finalisieren**
   - Dienstleister-Onboarding, Payment Intent, Webhook, Reconcile, Refund/Dispute-Pfad prüfen.
   - Keine echte Buchung ohne aktives Auszahlungskonto des Dienstleisters.
-- [ ] **Admin-Moderation gegen aktuellen Code abgleichen**
-  - Vault erwähnt ältere Moderationsrouten; `functions.php` registriert sie aktuell nicht.
-  - Prüfen, ob UI-Funktion noch vorhanden ist oder wiederhergestellt werden muss.
+- [x] **Admin-Moderation gegen aktuellen Code abgleichen** *(erledigt 2026-06-26, live)*
+  - Admin-Bild-Löschen umgesetzt: Detailseite (`adminDeleteListingImage`) + Provider-Portfolio/Lightbox (`adminDeleteProfileImage`).
+  - Backend `POST /admin/moderate-image` + persistente Blocklist (`eb_demo_image_blocklist`) → wirkt auch für hardcodierte Demo-Listings.
+- [x] **Security-Härtung** *(erledigt 2026-06-26, live)*
+  - XSS-Escaping (`_escHtml` inkl. Quotes), Brute-Force-Rate-Limiting (Login/OTP/Reset/Register), CSP ohne `'unsafe-eval'`, WP-User-Enumeration gesperrt, CDN gepinnt, CI-Security-Workflow + `SECURITY.md`.
+  - Offen (User): `security@eventbörse.de`-Postfach; optional CDN-SRI; CSP ohne `'unsafe-inline'` (Inline-Handler-Refactor).
 
 ## Nächste Prioritäten (P1)
 


### PR DESCRIPTION
Reine Doku-Aktualisierung des versionierten Vaults (CLAUDE.md-Konvention) — kein Code, kein Deploy-Effekt (`vault/` ist vom SFTP-Deploy ausgeschlossen).

- `Claude-Kontext.md`: Stand 2026-06-26 (Admin-Bildmoderation, Security-Härtung, CI/Deploy).
- `Current-Sprint.md`: P0 „Admin-Moderation abgleichen" + Security-Härtung als erledigt markiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_