### PR TITLE
Autonomer Bugscan: 3 Bugfixes + 1 Policy-Frage

### DIFF
--- a/app.js
+++ b/app.js
@@ -4682,6 +4682,8 @@ function _sendOfflineBeacon() {
 var _inactivityTimer = null;
 var _lastActivity = 0;
 var _INACTIVITY_MS = 15 * 60 * 1000;
+var _INACTIVITY_EVENTS = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
+var _inactivityAttached = false;
 
 function _touchActivity() {
   _lastActivity = Date.now();
@@ -4696,22 +4698,32 @@ function _checkInactivity() {
   }
 }
 
+function _onInactivityVisibility() {
+  if (!document.hidden) _checkInactivity();
+}
+
 function _startInactivityWatch() {
   _touchActivity();
-  var events = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
-  events.forEach(function(evt) {
-    document.addEventListener(evt, _touchActivity, { passive: true });
-  });
-  // Check every 30 s (aligns with heartbeat)
+  if (!_inactivityAttached) {
+    _INACTIVITY_EVENTS.forEach(function(evt) {
+      document.addEventListener(evt, _touchActivity, { passive: true });
+    });
+    document.addEventListener('visibilitychange', _onInactivityVisibility);
+    _inactivityAttached = true;
+  }
+  if (_inactivityTimer) clearInterval(_inactivityTimer);
   _inactivityTimer = setInterval(_checkInactivity, 30000);
-  // Also check when Safari un-freezes the tab
-  document.addEventListener('visibilitychange', function() {
-    if (!document.hidden) _checkInactivity();
-  });
 }
 
 function _stopInactivityWatch() {
   if (_inactivityTimer) { clearInterval(_inactivityTimer); _inactivityTimer = null; }
+  if (_inactivityAttached) {
+    _INACTIVITY_EVENTS.forEach(function(evt) {
+      document.removeEventListener(evt, _touchActivity);
+    });
+    document.removeEventListener('visibilitychange', _onInactivityVisibility);
+    _inactivityAttached = false;
+  }
 }
 
 // ──── Update chat header online/offline status ────

--- a/app.js
+++ b/app.js
@@ -12095,12 +12095,17 @@ document.addEventListener('click', (e) => {
 });
 
 // ========== TOAST ==========
+var _toastTimer = null;
 function showToast(message, icon = 'check_circle') {
   const toast = document.getElementById('toast');
   document.getElementById('toastMessage').textContent = message;
   document.getElementById('toastIcon').textContent = icon;
   toast.classList.add('show');
-  setTimeout(() => toast.classList.remove('show'), 3000);
+  if (_toastTimer) clearTimeout(_toastTimer);
+  _toastTimer = setTimeout(function() {
+    toast.classList.remove('show');
+    _toastTimer = null;
+  }, 3000);
 }
 
 // ========== QA SUPPORT BOT (tokenfrei / muster-basiert) ==========

--- a/app.js
+++ b/app.js
@@ -5376,7 +5376,7 @@ function openChat(chatId) {
               delBtn = '<button class="msg-delete-btn" title="Für mich löschen" aria-label="Für mich löschen" onclick="hideMessageForMe(' + msg.id + ')"><span class="material-icons-round">delete</span></button>';
             }
           }
-          return '<div class="msg ' + cls + '">' + delBtn + _escHtml(msg.text || msg.content || '') + '<span class="msg-time">' + time + '</span></div>';
+          return '<div class="msg ' + cls + '">' + delBtn + _escHtml(msg.text || msg.content || '') + '<span class="msg-time">' + _escHtml(time) + '</span></div>';
         }
       }).join('');
       // Scroll to bottom after render


### PR DESCRIPTION
Autonomer Scan über `app.js` + `functions.php`. Jedes Finding als eigener Commit, damit du einzeln approven/reverten kannst.

---

## Findings & Fixes

### ✅ Fix 1 — XSS-Parität im Chat-Render (`app.js:5379`)
**Commit:** `3783fb8`

Der Erst-Render in `openChat` (Zeile 5379) hat `msg.time` **unescaped** ins `innerHTML` interpoliert. Der Poll-Tick nebenan (Zeile 4846) benutzte bereits `_escHtml(time)`. Damit umging der erste Render die XSS-Härtung vom 2026-06-26.

**Failure-Szenario:** Server-Response mit `time: "</span>``&lt;img src=x onerror=alert(1)&gt;``"` → beim ersten `openChat`-Aufruf feuert der Payload. Poll-Tick war schon safe.

**Fix:** Einzeiler — `time` → `_escHtml(time)`, konsistent zum Poll-Pfad.

- [ ] Approve
- [ ] Reject (`git revert 3783fb8`)

---

### ✅ Fix 2 — Listener-Leak bei Login/Logout-Zyklen (`app.js:4682–4728`)
**Commit:** `f8a1ed7`

`_startInactivityWatch` hat pro Aufruf 5 Document-Listener + 1 `visibilitychange`-Listener registriert. `_stopInactivityWatch` hat nur das `setInterval` gecleart — die Listener blieben. Nach mehreren Login→Logout→Login-Runden wachsen die Handler linear.

**Failure-Szenario:** User loggt sich 3× ein/aus → 15 aktive `mousemove`-Listener + 3 `visibilitychange`. Auf mobilen Geräten spürbarer Scroll-Overhead.

**Fix:** Handler-Referenzen als Modul-Vars, `_inactivityAttached`-Flag verhindert Doppel-Attach, `_stopInactivityWatch` entfernt jetzt auch die Listener.

- [ ] Approve
- [ ] Reject (`git revert f8a1ed7`)

---

### ✅ Fix 3 — Toast-Timer-Race (`app.js:12086–12097`)
**Commit:** `528f45e`

`showToast` hat den `setTimeout`-Handle verworfen. Wenn zwei Toasts innerhalb von 3 s feuern (z. B. „Anfrage gesendet" gefolgt von einem Fehler-Toast aus `respondToOffer`), räumt der ältere Timer die `.show`-Klasse vorzeitig ab — Toast Nr. 2 verschwindet nach z. B. 1 s statt 3 s.

**Failure-Szenario:** Reproduzierbar über Doppelklick-Flows im Board (Angebot senden → sofort Update-Fehler).

**Fix:** Timer-Handle in `_toastTimer` speichern, vor `setTimeout` mit `clearTimeout` löschen.

- [ ] Approve
- [ ] Reject (`git revert 528f45e`)

---

## ⚠️ Finding 4 — Policy-Frage, NICHT im Diff

`eb_listings_delete` (`functions.php:4163`) erlaubt Admin-Fallback via `eb_is_admin_user( $uid )`. `eb_listings_update` (`functions.php:4096`) blockt Admin dagegen mit `403`.

**Konsequenz:** Admin kann ein anstößiges Inserat **löschen**, aber ein einziges Wort im Titel nicht **korrigieren**. Passt nicht zur laufenden Admin-Moderations-Linie (Bild-Löschen für fremde Listings ist schon live seit 26-06).

**Nicht implementiert** — das ist keine Bug-Fix, sondern eine Sicherheits-Policy-Entscheidung. Braucht dein OK.

- [ ] **Approve Policy-Änderung:** Admin darf fremde Listings editieren. Ich baue's dann in Fix 4a (Update mit `eb_is_admin_user`-Fallback + Audit-Log).
- [ ] **Reject:** Delete-Path enger ziehen, sodass Admin auch nicht mehr löschen darf (harter Cut).
- [ ] **Später** — jetzt keine Änderung.

---

## Verifikation

- `node --check app.js` sauber
- Keine anderen Dateien angefasst
- Jedes Fix ist ein eigener, revertbarer Commit

## Was NICHT gescannt wurde

- CSS-Regressionen (nur wenn Bug-relevant)
- Stripe-E2E (braucht Live-WP-Server, siehe CLAUDE.md)
- Auth-Flows (Login/Register/OTP — braucht Live-Backend)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7ZiTCB86QTH6SZG1BAhw9)_