### PR TITLE
Auto-Routinen: Claude verbessert die Seite selbstständig + HQ-Übersicht

### DIFF
--- a/.github/workflows/claude-auto-audit.yml
+++ b/.github/workflows/claude-auto-audit.yml
@@ -1,8 +1,10 @@
 name: Claude Auto-Audit
 
 on:
-  # Cron deaktiviert 2026-05-31 — Auto-Audit-Reports überfluteten Issues-Liste.
-  # Manuelle Trigger über Actions → Run workflow weiterhin möglich.
+  schedule:
+    # Wöchentlich Montag 04:00 UTC. (Vorher täglich → Issues-Flut, deshalb auf
+    # wöchentlich reduziert statt komplett deaktiviert.)
+    - cron: '0 4 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -56,7 +58,7 @@ jobs:
             cat /tmp/audit-result.txt
             echo
             echo "---"
-            echo "*Generiert von [Claude Auto-Audit](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · Läuft täglich um 04:00 UTC*"
+            echo "*Generiert von [Claude Auto-Audit](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · Läuft wöchentlich montags um 04:00 UTC*"
           } > /tmp/issue-body.md
           gh issue create \
             --title "🤖 Claude Auto-Audit ${DATE}" \

--- a/.github/workflows/claude-improve.yml
+++ b/.github/workflows/claude-improve.yml
@@ -1,0 +1,149 @@
+name: Claude Verbesserungs-Routine
+
+# Autonome Verbesserungs-Routine: Claude setzt woechentlich EINE fokussierte
+# Optimierung um (rotierender Fokus) und oeffnet einen Draft-PR zum Review.
+# Merge nach main deployt automatisch via ionos-deploy.yml.
+
+on:
+  schedule:
+    # Montags 05:00 UTC
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      focus:
+        description: 'Fokus der Verbesserung'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - performance
+          - ux
+          - accessibility
+          - seo
+          - security
+          - code-quality
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: claude-improve
+  cancel-in-progress: false
+
+jobs:
+  improve:
+    name: Verbesserung umsetzen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: API-Key pruefen
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "::error title=ANTHROPIC_API_KEY fehlt::Bitte in Settings -> Secrets and variables -> Actions als 'ANTHROPIC_API_KEY' hinterlegen."
+            exit 1
+          fi
+          echo "API-Key vorhanden."
+
+      - name: Fokus bestimmen
+        id: focus
+        run: |
+          IN="${{ github.event.inputs.focus }}"
+          if [ -z "$IN" ] || [ "$IN" = "auto" ]; then
+            FOCI=(performance ux accessibility seo security code-quality)
+            WEEK=$(date +%V)
+            IDX=$(( 10#$WEEK % ${#FOCI[@]} ))
+            FOCUS="${FOCI[$IDX]}"
+          else
+            FOCUS="$IN"
+          fi
+          echo "focus=$FOCUS" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          echo "### Fokus dieser Routine: \`$FOCUS\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Claude setzt Verbesserung um
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--max-turns 50'
+          prompt: |
+            Du bist die automatische Verbesserungs-Routine fuer das Projekt "Eventboerse"
+            (deutscher Event-Marktplatz, Vanilla-JS-SPA + WordPress REST API).
+            Lies zuerst CLAUDE.md und den Ordner vault/ fuer Kontext, Praeferenzen und Roadmap.
+
+            AUFGABE - Fokus: **${{ steps.focus.outputs.focus }}**
+            Setze GENAU EINE fokussierte, in sich geschlossene Verbesserung in diesem Bereich um.
+
+            Bedeutung der Fokus-Bereiche:
+            - performance: Ladezeit/Runtime (Lazy-Loading, weniger Reflows, effizientere Loops/Selektoren, Caching, kleinere Payloads).
+            - ux: Bedienbarkeit/Politur (Fehlermeldungen, Leerzustaende, Fokus-States, Konsistenz, Mikro-Interaktionen).
+            - accessibility: A11y (ARIA-Labels, Tastatur-Navigation, Kontraste, alt-Texte, Fokus-Reihenfolge).
+            - seo: Meta-Tags, strukturierte Daten, semantisches HTML, Titel/Descriptions.
+            - security: Haertung (Input-Validierung, Escaping/XSS, sichere Defaults) - KEINE Auth-/Payment-Kernlogik umbauen.
+            - code-quality: kleine, sichere Refactorings OHNE Verhaltensaenderung (Duplikate, tote Pfade, Lesbarkeit).
+
+            HARTE REGELN:
+            - Kein neues Framework, keine neuen Abhaengigkeiten. Vanilla JS bleibt.
+            - Bestehendes Verhalten NICHT veraendern (ausser es ist der explizite Bugfix).
+            - Kleiner, gut reviewbarer Diff. Lieber eine saubere Sache als viele halbe.
+            - Nichts anfassen, was in CLAUDE.md/vault als "nicht anfassen" markiert ist.
+            - UI-Texte auf Deutsch, Code-Kommentare auf Englisch.
+            - Fuehre KEINE git-Befehle aus, erstelle KEINE Commits/Branches/PRs und pushe nichts.
+              Aendere nur Dateien im Arbeitsverzeichnis - den PR erstellt ein spaeterer Schritt.
+            - Wenn du im gewaehlten Bereich nichts sinnvoll und sicher verbessern kannst,
+              nimm KEINE Aenderung vor und schreibe das in die Zusammenfassung.
+
+            Zum Schluss: Schreibe eine kurze deutsche Zusammenfassung (Markdown: was, warum, welche Dateien)
+            in die Datei CLAUDE_SUMMARY.md im Repo-Wurzelverzeichnis.
+
+      - name: Zusammenfassung einlesen
+        id: summary
+        run: |
+          if [ -f CLAUDE_SUMMARY.md ]; then
+            {
+              echo "body<<SUMMARY_EOF"
+              cat CLAUDE_SUMMARY.md
+              echo "SUMMARY_EOF"
+            } >> "$GITHUB_OUTPUT"
+            rm -f CLAUDE_SUMMARY.md
+          else
+            echo "body=Automatische Verbesserung im Bereich \`${{ steps.focus.outputs.focus }}\`." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Draft-PR erstellen
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: claude/auto-${{ steps.focus.outputs.focus }}
+          delete-branch: true
+          draft: true
+          commit-message: "chore(auto): ${{ steps.focus.outputs.focus }}-Verbesserung durch Claude-Routine"
+          title: "🤖 Auto-Verbesserung: ${{ steps.focus.outputs.focus }} (${{ steps.focus.outputs.date }})"
+          labels: |
+            automated
+            claude-routine
+          body: |
+            ## 🤖 Automatische Verbesserungs-Routine
+            **Fokus:** `${{ steps.focus.outputs.focus }}` · ${{ steps.focus.outputs.date }}
+
+            ${{ steps.summary.outputs.body }}
+
+            ---
+            _Als **Draft** von der Claude-Verbesserungs-Routine erstellt. Bitte reviewen — Merge nach `main` deployt automatisch nach IONOS._
+
+      - name: Ergebnis
+        run: |
+          if [ -n "${{ steps.cpr.outputs.pull-request-number }}" ]; then
+            echo "✅ Draft-PR #${{ steps.cpr.outputs.pull-request-number }} — ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "ℹ️ Keine Aenderungen — kein PR erstellt." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -1,0 +1,27 @@
+name: Lighthouse Audit
+
+# Deterministische Qualitaetsmessung der Live-Seite: Performance, SEO,
+# Accessibility & Best-Practices. Braucht KEINEN API-Key.
+# Der oeffentliche Report-Link erscheint in der Job-Zusammenfassung.
+
+on:
+  schedule:
+    # Montags 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Live-Site messen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lighthouse ausfuehren
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            https://xn--eventbrse-57a.de/
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/hq.html
+++ b/hq.html
@@ -273,6 +273,7 @@
   .bot-dot.idle { background: var(--muted); } .bot-dot.running { background: var(--yellow); animation: pulse 1.5s infinite; }
   .bot-dot.success { background: var(--green); } .bot-dot.fail { background: var(--red); }
   .bot-last { font-size: .71rem; color: var(--muted); }
+  .bot-sched { font-size: .7rem; color: var(--cyan); font-weight: 600; display:flex; align-items:center; gap:.3rem; }
   .bot-actions { margin-top: auto; display: flex; gap: .4rem; flex-wrap: wrap; padding-top:.3rem; }
   .bot-btn {
     font-size: .74rem; padding: .35rem .75rem; border-radius: 8px; border: 1px solid var(--border);
@@ -508,10 +509,10 @@
     </div>
     <div class="achts" id="achts-grid"></div>
 
-    <!-- Bot Team -->
+    <!-- Routinen & Bot Team -->
     <div class="section-header">
-      <div class="section-title">🤖 Bot-Team</div>
-      <div class="section-badge">Deine Crew</div>
+      <div class="section-title">🤖 Routinen &amp; Bot-Team <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— arbeiten für dich</span></div>
+      <div class="section-badge">Auto-Verbesserung</div>
     </div>
     <div class="bots" id="bots-grid">
       <div class="skeleton" style="height:180px;"></div>
@@ -958,10 +959,12 @@ function renderLog() {
 
 /* ─── Bot Team ─────────────────────────────────────────────────── */
 const BOTS = [
-  { id: 'claude-dev', avatar: '🤖', name: 'Claude Dev-Bot', role: 'Analysiert Code mit Claude AI, findet Bugs & öffnet GitHub-Issues.', workflow: 'claude-auto-audit.yml', canTrigger: true, triggerLabel: '▶ Audit', logsLabel: '📋 Issues', logsUrl: `https://github.com/${REPO}/issues?q=label%3Aaudit` },
-  { id: 'monitor',    avatar: '👁️', name: 'Monitor-Bot',    role: 'Prüft die Live-Site alle 30 Min auf Erreichbarkeit. Öffnet Issues bei Ausfall.', workflow: 'site-monitor.yml', canTrigger: true, triggerLabel: '▶ Check', logsLabel: '📋 Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/site-monitor.yml` },
-  { id: 'deploy',     avatar: '🚀', name: 'Deploy-Bot',     role: 'Deployt bei jedem Push automatisch via SFTP zu IONOS.', workflow: 'ionos-deploy.yml', canTrigger: false, logsLabel: '📋 Deploy-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/ionos-deploy.yml` },
-  { id: 'rollback',   avatar: '⏪', name: 'Rollback-Bot',   role: 'Setzt die Live-Site auf einen beliebigen Commit zurück (Release-Verlauf).', workflow: 'hq-rollback.yml', canTrigger: false, logsLabel: '📋 Rollback-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-rollback.yml` },
+  { id: 'improve',    avatar: '✨', name: 'Verbesserungs-Bot', role: 'Setzt jede Woche EINE fokussierte Optimierung um und öffnet einen Draft-PR zum Review.', workflow: 'claude-improve.yml', schedule: '⏱️ Wöchentl. · Mo 05:00 · rotierender Fokus', canTrigger: true, triggerLabel: '▶ Verbessern', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=is%3Apr+label%3Aclaude-routine` },
+  { id: 'claude-dev', avatar: '🤖', name: 'Audit-Bot',        role: 'Analysiert den Code mit Claude, priorisiert Schwachstellen und öffnet Verbesserungs-Issues.', workflow: 'claude-auto-audit.yml', schedule: '⏱️ Wöchentl. · Mo 04:00', canTrigger: true, triggerLabel: '▶ Audit', logsLabel: '📋 Issues', logsUrl: `https://github.com/${REPO}/issues?q=label%3Aaudit` },
+  { id: 'lighthouse', avatar: '📊', name: 'Lighthouse-Bot',   role: 'Misst Performance, SEO, Accessibility & Best-Practices der Live-Seite.', workflow: 'lighthouse-audit.yml', schedule: '⏱️ Wöchentl. · Mo 06:00', canTrigger: true, triggerLabel: '▶ Messen', logsLabel: '📋 Reports', logsUrl: `https://github.com/${REPO}/actions/workflows/lighthouse-audit.yml` },
+  { id: 'monitor',    avatar: '👁️', name: 'Monitor-Bot',      role: 'Prüft die Live-Site alle 30 Min auf Erreichbarkeit. Öffnet Issues bei Ausfall.', workflow: 'site-monitor.yml', schedule: '⏱️ Alle 30 Min', canTrigger: true, triggerLabel: '▶ Check', logsLabel: '📋 Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/site-monitor.yml` },
+  { id: 'deploy',     avatar: '🚀', name: 'Deploy-Bot',       role: 'Deployt bei jedem Push automatisch via SFTP zu IONOS.', workflow: 'ionos-deploy.yml', schedule: '⚡ Bei jedem Push', canTrigger: false, logsLabel: '📋 Deploy-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/ionos-deploy.yml` },
+  { id: 'rollback',   avatar: '⏪', name: 'Rollback-Bot',     role: 'Setzt die Live-Site auf einen beliebigen Commit zurück (Release-Verlauf).', workflow: 'hq-rollback.yml', schedule: '🕹️ Manuell', canTrigger: false, logsLabel: '📋 Rollback-Logs', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-rollback.yml` },
 ];
 function renderBots() {
   const grid = $('bots-grid'); grid.innerHTML = '';
@@ -977,6 +980,7 @@ function renderBots() {
       <div class="bot-avatar">${bot.avatar}</div>
       <div class="bot-name">${bot.name}</div>
       <div class="bot-role">${bot.role}</div>
+      ${bot.schedule ? `<div class="bot-sched">${bot.schedule}</div>` : ''}
       <div class="bot-status-row"><div class="bot-dot ${dotCls}"></div><span style="color:var(--muted);">${statusTxt}</span></div>
       <div class="bot-last">${run ? 'Zuletzt: ' + humanDate(run.updated_at) + ' · #' + run.run_number : ''}</div>
       <div class="bot-actions">

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -126,6 +126,7 @@ navigateTo('admin')         // Admin-Panel
 ## Lernpunkte aus vergangenen Gesprächen
 
 - **`hq.html` = EventBörse HQ (Mission Control):** Eigenständiges, self-contained Dev-Command-Center über die GitHub-API. Gamifiziert (Level/XP, Streak, Quests = Roadmap, Achievements, Bot-Team, Aktivitäts-Log, Confetti/SFX). Kein Build-Schritt, kein Framework. Zugriff per `HQ_KEYS`, GitHub-PAT (sessionStorage) für Rollback/Bot-Trigger. Quests spiegeln die Sprint-Roadmap — beim Hinzufügen neuer Roadmap-Punkte auch das `QUESTS`-Array in `hq.html` pflegen. GitHub-Daten werden per stale-while-revalidate in `localStorage` gecacht (geringere Rate-Limit-Last).
+- **Auto-Routinen (GitHub Actions):** `claude-improve.yml` setzt wöchentlich (Mo 05:00 UTC, rotierender Fokus performance→ux→a11y→seo→security→code-quality) EINE fokussierte Verbesserung um und öffnet via `peter-evans/create-pull-request` einen **Draft-PR** (nutzt `anthropics/claude-code-action` + Secret `ANTHROPIC_API_KEY`). `lighthouse-audit.yml` misst wöchentlich Perf/SEO/A11y der Live-Seite (kein API-Key). `claude-auto-audit.yml` läuft wieder wöchentlich (Report-Issues). Alle im HQ unter „Routinen & Bot-Team" sichtbar/triggerbar (`BOTS`-Array). **Voraussetzungen:** Secret `ANTHROPIC_API_KEY` + Repo-Setting „Allow GitHub Actions to create and approve pull requests". Draft-PRs werden von `security.yml` (`node --check app.js`) + `pr-check.yml` geprüft, bevor sie mergebar sind; Merge nach `main` deployt automatisch.
 
 ## Stand 2026-06-26 — Admin-Bildmoderation & Security-Härtung (live auf main)
 


### PR DESCRIPTION
## 🤖 Autonome Verbesserungs-Routinen + HQ-Übersicht

Fügt geplante GitHub-Actions-**Routinen** hinzu, die die Seite laufend verbessern/optimieren — und macht sie im **HQ** sichtbar & triggerbar.

### Neue Routinen
| Routine | Zeitplan | Was sie tut |
|---|---|---|
| ✨ **`claude-improve.yml`** | wöchentl. Mo 05:00 UTC | Claude setzt **eine** fokussierte Verbesserung um (rotierend: Performance → UX → A11y → SEO → Security → Code-Qualität) und öffnet einen **Draft-PR**. Manuell mit wählbarem Fokus. |
| 📊 **`lighthouse-audit.yml`** | wöchentl. Mo 06:00 UTC | Misst Performance/SEO/A11y/Best-Practices der Live-Seite. **Kein API-Key nötig.** |
| 🤖 **`claude-auto-audit.yml`** | wöchentl. Mo 04:00 UTC | Wieder aktiviert (war deaktiviert): priorisierte Verbesserungs-Issues. |

### HQ
- Neue Sektion **„Routinen & Bot-Team"** listet alle 6 Routinen mit **Zeitplan**, Live-Status, Ergebnis-Links (PRs/Issues/Reports) und **Ein-Klick-Trigger**.

### Sicherheitsmodell (nichts geht ungeprüft live)
- Der Verbesserungs-Bot öffnet **Draft-PRs** — du reviewst & mergst. Merge nach `main` deployt automatisch.
- Strikte Guardrails im Prompt: keine neuen Abhängigkeiten, Vanilla JS bleibt, kleiner Diff, kein Verhaltenswechsel, nichts „nicht anfassen"-Markiertes.
- Jeder Draft-PR wird von `security.yml` (`node --check app.js`) + `pr-check.yml` geprüft, bevor er mergebar ist.

### ⚙️ Voraussetzungen (einmalig, user-seitig)
1. **Secret `ANTHROPIC_API_KEY`** unter *Settings → Secrets and variables → Actions* (wird bereits vom bestehenden Audit-Bot referenziert).
2. **Settings → Actions → General → Workflow permissions:** „**Allow GitHub Actions to create and approve pull requests**" aktivieren (sonst kann der Verbesserungs-Bot keinen PR öffnen).

> Hinweis: Zeitpläne & HQ-Trigger werden erst **nach dem Merge** aktiv (GitHub plant Workflows nur auf dem Default-Branch).

### ✅ Verifikation
- `hq.html` JS-Syntax OK, alle Element-IDs vorhanden.
- Alle drei Workflow-YAMLs valide.
- Berührt weder `app.js` noch PHP → `security.yml`/`pr-check.yml` bleiben grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvLwjRAC4Fu6UC5BPMh7wy)_