### PR TITLE
Fix: id-token-Berechtigung für Verbesserungs-Bot (OIDC)

### DIFF
--- a/.github/workflows/claude-improve.yml
+++ b/.github/workflows/claude-improve.yml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # claude-code-action@v1 exchanges an OIDC token for its GitHub credentials
+  id-token: write
+  actions: read
 
 concurrency:
   group: claude-improve


### PR DESCRIPTION
## 🐛 Bugfix für die Verbesserungs-Routine

Der erste Testlauf des Verbesserungs-Bots schlug nach 24 s fehl:

> `Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?`

`anthropics/claude-code-action@v1` tauscht ein OIDC-Token gegen seine GitHub-Credentials und braucht dafür `id-token: write` (+ `actions: read`) in den Workflow-Permissions. Beides ergänzt — Ein-Zeilen-Fix in `claude-improve.yml`, sonst nichts.

Nach dem Merge starte ich den Testlauf erneut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvLwjRAC4Fu6UC5BPMh7wy)_