### PR TITLE
Planungsboard: geführter Planungs-Guide + Status-Verknüpfung + vollständige Listings

### DIFF
--- a/app.js
+++ b/app.js
@@ -1165,6 +1165,19 @@ async function loadDbListings() {
     if (data.listings && data.listings.length > 0) {
       _mergeDbListingsIntoCache(data.listings);
     }
+    // FIX: Server kappt bei 50/Seite — Folgeseiten nachladen, sonst fehlen
+    // Inserate ab dem 51. überall (Browse, Board-Picker, Map). Cap bei 10
+    // Seiten (500 Listings) als Sicherheitsnetz; Fehler einzelner Seiten
+    // brechen den Rest nicht ab.
+    var totalPages = Math.min(parseInt(data.pages, 10) || 1, 10);
+    for (var p = 2; p <= totalPages; p++) {
+      try {
+        var r2 = await fetch(_apiUrl('listings?per_page=50&page=' + p + '&_t=' + Date.now()), { credentials: 'same-origin', headers: _apiHeaders() });
+        if (!r2.ok) continue;
+        var d2 = await r2.json();
+        if (d2.listings && d2.listings.length > 0) _mergeDbListingsIntoCache(d2.listings);
+      } catch (pageErr) { /* Einzelseite fehlgeschlagen — Rest weiterladen */ }
+    }
     _applyImageBlocklist(LISTINGS); // vom Admin gelöschte Bilder auch hier ausblenden
     _dbListingsLoaded = true;
     try { renderHeroMarquees(); } catch (err) { console.error('Fehler beim Rendern der Hero-Marquee nach Daten-Ladung', err); }
@@ -1449,6 +1462,44 @@ function navigateTo(page, data, skipHistory) {
   try { _setPageMeta(page, data); } catch (e) { /* Meta optional */ }
 }
 
+// ========== BOARD-STATUS-VERKNÜPFUNG ==========
+// Zeigt überall (Browse-Karte, Detailseite, Provider-Profil), ob ein Inserat
+// bereits im eigenen Planungsboard steckt und in welcher Phase.
+var EB_BOARD_STAGE_INFO = {
+  geplant:       { label: 'Im Plan',      icon: 'assignment',      cls: 'geplant' },
+  kontaktiert:   { label: 'Kontaktiert',  icon: 'forum',           cls: 'kontaktiert' },
+  angebot:       { label: 'Angebot',      icon: 'request_quote',   cls: 'angebot' },
+  bestaetigt:    { label: 'Gebucht',      icon: 'event_available', cls: 'gebucht' },
+  abgeschlossen: { label: 'Abgeschlossen',icon: 'task_alt',        cls: 'abgeschlossen' }
+};
+var EB_BOARD_STAGE_ORDER = ['geplant', 'kontaktiert', 'angebot', 'bestaetigt', 'abgeschlossen'];
+
+// Höchste Board-Phase eines Inserats über ALLE Projekte des Nutzers.
+// Liefert null, wenn das Inserat in keinem Board steckt.
+function _boardStatusForListing(listingId) {
+  if (listingId == null || !Array.isArray(_boardProjects) || !_boardProjects.length) return null;
+  var best = -1;
+  _boardProjects.forEach(function(p) {
+    (p && Array.isArray(p.cards) ? p.cards : []).forEach(function(c) {
+      if (!c || c.listingId == null) return;
+      if (String(c.listingId) !== String(listingId)) return;
+      var idx = EB_BOARD_STAGE_ORDER.indexOf(c.stage);
+      if (idx > best) best = idx;
+    });
+  });
+  if (best < 0) return null;
+  var stage = EB_BOARD_STAGE_ORDER[best];
+  return { stage: stage, info: EB_BOARD_STAGE_INFO[stage] };
+}
+
+// Kleines Status-Badge-HTML (leer, wenn kein Board-Bezug).
+function _boardStatusBadgeHtml(listingId, extraClass) {
+  var st = _boardStatusForListing(listingId);
+  if (!st) return '';
+  return '<span class="board-status-badge bsb-' + st.info.cls + (extraClass ? ' ' + extraClass : '') + '" title="Dieser Dienstleister ist in deinem Planungsboard">' +
+    '<span class="material-icons-round">' + st.info.icon + '</span>' + st.info.label + '</span>';
+}
+
 // ========== LISTING CARD RENDERER ==========
 function renderListingCard(listing) {
   const isFav = favorites.has(listing.id);
@@ -1465,6 +1516,7 @@ function renderListingCard(listing) {
           <span class="material-icons-round">${isFav ? 'favorite' : 'favorite_border'}</span>
         </button>
         ${listing.badge ? '<span class="listing-badge">' + _escHtml(listing.badge) + '</span>' : ''}
+        ${_boardStatusBadgeHtml(listing.id, 'bsb-on-card')}
       </div>
       <div class="listing-card-body">
         <div class="listing-card-top">
@@ -3284,6 +3336,22 @@ function loadDetail(listingId) {
   var editBtn = document.getElementById('detailEditBtn');
   if (editBtn) editBtn.style.display = (currentUser && listing.providerId === currentUser.id) ? '' : 'none';
 
+  // Board-Status-Chip: zeigt, ob dieses Inserat schon im Planungsboard steckt
+  // (Im Plan / Kontaktiert / Angebot / Gebucht) — Verknüpfung Detail ↔ Board.
+  var existingBoardStatus = document.getElementById('detailBoardStatus');
+  if (existingBoardStatus) existingBoardStatus.remove();
+  var _detailBadgeHtml = _boardStatusBadgeHtml(listing.id);
+  if (_detailBadgeHtml) {
+    var statusWrap = document.createElement('span');
+    statusWrap.id = 'detailBoardStatus';
+    statusWrap.innerHTML = _detailBadgeHtml;
+    statusWrap.style.cursor = 'pointer';
+    statusWrap.title = 'Im Planungsboard öffnen';
+    statusWrap.onclick = function() { navigateTo('board'); };
+    var provRowStatus = document.querySelector('.detail-provider-row');
+    if (provRowStatus) provRowStatus.appendChild(statusWrap);
+  }
+
   // Admin delete button for listing
   var existingAdminDel = document.getElementById('detailAdminDeleteBtn');
   if (existingAdminDel) existingAdminDel.remove();
@@ -3579,6 +3647,19 @@ function loadProvider(providerId) {
   }
   badgesHtml += `<span class="ppc-badge"><span class="material-icons-round">schedule</span> Mitglied seit ${_escHtml(mainListing.providerSince)}</span>`;
   badgesHtml += '<span class="ppc-badge"><span class="material-icons-round">bolt</span> Antwortet schnell</span>';
+  // Board-Verknüpfung: höchste Phase über alle Inserate dieses Anbieters
+  (function() {
+    var bestBadge = '';
+    var bestIdx = -1;
+    providerListings.forEach(function(l) {
+      var st = l && _boardStatusForListing(l.id);
+      if (st) {
+        var idx = EB_BOARD_STAGE_ORDER.indexOf(st.stage);
+        if (idx > bestIdx) { bestIdx = idx; bestBadge = _boardStatusBadgeHtml(l.id); }
+      }
+    });
+    if (bestBadge) badgesHtml += bestBadge;
+  })();
   badgesEl.innerHTML = badgesHtml;
 
   // Bio with read-more
@@ -19233,6 +19314,159 @@ function _getProjectChecklist(project) {
   return saved.filter(function(it){ return it && it.text; });
 }
 
+// ========== PLANUNGS-GUIDE (geführte Steps) ==========
+// Macht aus den Checklisten-Templates einen geführten Assistenten:
+// geprüfte Steps in sinnvoller Reihenfolge, pro Step direkt passende
+// Dienstleister finden ("unterwegs die Hochzeit planen"). Rein additiv —
+// die bestehende freie Checkliste bleibt unverändert darunter.
+
+// Step-Text → Browse-Kategorie (Keys wie in AI_CATEGORIES / browseCategory).
+var _GUIDE_CAT_RULES = [
+  [/location|venue|gel[äa]nde|meetingraum|schloss|saal/i, 'location'],
+  [/fotograf|videograf|foto/i, 'foto'],
+  [/\bdj\b|band|musik|line-up|playlist/i, 'dj'],
+  [/catering|kuchen|torte|men[üu]|getr[äa]nke/i, 'catering'],
+  [/florist|blumen|brautstrau/i, 'florist'],
+  [/deko/i, 'deko'],
+  [/technik|licht|\bav\b|strom|b[üu]hne|livestream/i, 'licht'],
+  [/moderation|sprecher/i, 'moderation'],
+  [/koordinator|planer|komplettplanung/i, 'planung'],
+  [/feuerwerk|pyro/i, 'pyro'],
+];
+function _guideCategoryFor(text) {
+  for (var i = 0; i < _GUIDE_CAT_RULES.length; i++) {
+    if (_GUIDE_CAT_RULES[i][0].test(text || '')) return _GUIDE_CAT_RULES[i][1];
+  }
+  return null;
+}
+
+// Hat das Projekt schon einen Dienstleister dieser Kategorie im Board?
+// Liefert die höchste Karten-Phase (für "Kontaktiert/Gebucht"-Chip im Step).
+function _guideCardStageForCategory(project, cat) {
+  if (!project || !cat || !Array.isArray(project.cards)) return null;
+  var best = -1;
+  project.cards.forEach(function(c) {
+    if (!c) return;
+    var cardCat = null;
+    if (c.listingId != null) {
+      var l = (LISTINGS || []).find(function(x) { return x && String(x.id) === String(c.listingId); });
+      if (l) cardCat = l.category || _guideCategoryFor(l.categoryLabel || '');
+    }
+    if (!cardCat) cardCat = _guideCategoryFor(c.category || c.name || '');
+    if (cardCat !== cat) return;
+    var idx = EB_BOARD_STAGE_ORDER.indexOf(c.stage);
+    if (idx > best) best = idx;
+  });
+  return best >= 0 ? EB_BOARD_STAGE_ORDER[best] : null;
+}
+
+// Geführte Steps mit Status aus Checkliste + Board-Karten ableiten.
+function _guideSteps(project) {
+  if (!project) return [];
+  var tmpl = _CHECKLIST_TEMPLATES[project.template] || _CHECKLIST_TEMPLATES.custom;
+  var doneMap = {};
+  (project.checklist || []).forEach(function(it) {
+    if (it && it.text) doneMap[it.text.toLowerCase()] = !!it.done;
+  });
+  return tmpl.map(function(text, i) {
+    var cat = _guideCategoryFor(text);
+    var cardStage = cat ? _guideCardStageForCategory(project, cat) : null;
+    // Ein Step gilt als erledigt, wenn abgehakt ODER der Dienstleister
+    // dafür bereits fest gebucht/abgeschlossen ist.
+    var done = doneMap[text.toLowerCase()] === true ||
+      cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
+    return { idx: i, text: text, cat: cat, cardStage: cardStage, done: done };
+  });
+}
+
+function _renderBoardGuide(project) {
+  var steps = _guideSteps(project);
+  if (!steps.length) return '';
+  var doneCount = steps.filter(function(s) { return s.done; }).length;
+  var pct = Math.round((doneCount / steps.length) * 100);
+  var currentIdx = -1;
+  for (var i = 0; i < steps.length; i++) { if (!steps[i].done) { currentIdx = i; break; } }
+
+  var tmplLabels = { wedding: '💍 Hochzeit', birthday: '🎂 Geburtstag', corporate: '🏢 Firmenfeier', festival: '🎪 Festival', conference: '🎤 Konferenz', baptism: '⛪ Taufe/Feier', kids: '🎈 Kinderfest', private: '🏡 Privatfeier', custom: '✨ Event' };
+  var tmplLabel = tmplLabels[project.template] || tmplLabels.custom;
+
+  var stepsHtml = steps.map(function(s) {
+    var state = s.done ? 'done' : (s.idx === currentIdx ? 'current' : 'open');
+    var icon = s.done ? 'check_circle' : (state === 'current' ? 'radio_button_checked' : 'radio_button_unchecked');
+    var stageChip = '';
+    if (!s.done && s.cardStage) {
+      var info = EB_BOARD_STAGE_INFO[s.cardStage];
+      stageChip = '<span class="bguide-stage bsb-' + info.cls + '"><span class="material-icons-round">' + info.icon + '</span>' + info.label + '</span>';
+    }
+    var findBtn = (!s.done && s.cat)
+      ? '<button type="button" class="bguide-find" onclick="_guideFindProviders(\'' + s.cat + '\')"><span class="material-icons-round">search</span> Finden</button>'
+      : '';
+    var safeText = _escHtml(s.text).replace(/'/g, "\\'");
+    return '<li class="bguide-step ' + state + '">' +
+      '<button type="button" class="bguide-check" onclick="_guideToggleStep(\'' + safeText + '\')" aria-label="' + (s.done ? 'Als offen markieren' : 'Als erledigt markieren') + '">' +
+        '<span class="bguide-num">' + (s.idx + 1) + '</span>' +
+        '<span class="material-icons-round bguide-state-icon">' + icon + '</span>' +
+      '</button>' +
+      '<span class="bguide-text">' + _escHtml(s.text) + '</span>' +
+      stageChip + findBtn +
+    '</li>';
+  }).join('');
+
+  return '<div class="bguide-wrap">' +
+    '<div class="bguide-header">' +
+      '<div class="bguide-title"><span class="material-icons-round">route</span> Planungs-Guide <span class="bguide-tmpl">' + tmplLabel + '</span></div>' +
+      '<div class="bguide-progress-label">' + doneCount + ' / ' + steps.length + ' Schritten</div>' +
+      '<div class="bguide-progress-bar-wrap"><div class="bguide-progress-bar" style="width:' + pct + '%"></div></div>' +
+    '</div>' +
+    (currentIdx >= 0
+      ? '<div class="bguide-current-hint"><span class="material-icons-round">arrow_forward</span> Nächster Schritt: <strong>' + _escHtml(steps[currentIdx].text) + '</strong></div>'
+      : '<div class="bguide-current-hint bguide-all-done"><span class="material-icons-round">celebration</span> Alle Schritte erledigt — dein Event ist durchgeplant!</div>') +
+    '<ol class="bguide-list">' + stepsHtml + '</ol>' +
+  '</div>';
+}
+
+// Step-Aktion: passende Dienstleister für die Kategorie öffnen (Browse
+// mit vorgewähltem Kategorie-Filter) — von unterwegs direkt buchbar.
+function _guideFindProviders(cat) {
+  navigateTo('browse');
+  setTimeout(function() {
+    var sel = document.getElementById('browseCategory');
+    if (sel) sel.value = cat || '';
+    // Active-State der Kategorie-Buttons nachziehen (cat steckt im onclick,
+    // Mobile-Picker nutzt data-cat).
+    document.querySelectorAll('.cat-icon-btn').forEach(function(b) {
+      var m = (b.getAttribute('onclick') || '').match(/filterByCategory\(this,\s*'([^']*)'/);
+      b.classList.toggle('active', !!m && m[1] === (cat || ''));
+    });
+    document.querySelectorAll('.mobile-cat-option').forEach(function(o) {
+      o.classList.toggle('active', (o.getAttribute('data-cat') || '') === (cat || ''));
+    });
+    if (typeof filterListings === 'function') filterListings();
+    var grid = document.getElementById('browseGrid');
+    if (grid) grid.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, 350);
+}
+
+// Step abhaken/reaktivieren — synchron zur gespeicherten Checkliste
+// (gleicher Text = gleicher Eintrag), damit Guide und Checkliste nie
+// auseinanderlaufen.
+function _guideToggleStep(text) {
+  if (!_activeBoardId) return;
+  var project = _boardProjects.find(function(p) { return p.id === _activeBoardId; });
+  if (!project) return;
+  project.checklist = project.checklist || [];
+  var existing = project.checklist.find(function(it) {
+    return it && it.text && it.text.toLowerCase() === String(text).toLowerCase();
+  });
+  if (existing) {
+    existing.done = !existing.done;
+  } else {
+    project.checklist.push({ id: 'cli_guide_' + Date.now(), text: String(text), done: true, isTemplate: true });
+  }
+  _saveBoardProjects();
+  renderBoardChecklist();
+}
+
 function _getChecklistSuggestions(project) {
   // Template-Items, die noch NICHT in der gespeicherten Liste sind = Vorschläge.
   if (!project) return [];
@@ -19296,6 +19530,9 @@ function renderBoardChecklist() {
   }
 
   var html = '<div class="bcl-wrap">' +
+    // Geführter Planungs-Guide (Steps in geprüfter Reihenfolge, mit
+    // Dienstleister-Suche pro Schritt) — die freie Checkliste bleibt darunter.
+    _renderBoardGuide(project) +
     // Oben: Eingabe + Header
     '<div class="bcl-header">' +
       '<div class="bcl-title"><span class="material-icons-round">checklist</span> Planungs-Checkliste</div>' +
@@ -19395,7 +19632,9 @@ function openAddProviderModal(defaultStage) {
   var _baseList = (typeof _visibleListings === 'function')
     ? _visibleListings()
     : (typeof filterDemos === 'function' ? filterDemos(LISTINGS || []) : (LISTINGS || []));
-  var _listings = _baseList.filter(function(l){ return !_isSearchListing(l); }).slice(0, 30);
+  // Kein 30er-Cap mehr: sonst fehlen Inserate im Picker und die Suche darüber
+  // findet sie nie (sie filtert nur gerenderte Karten). 300 als Sicherheitsnetz.
+  var _listings = _baseList.filter(function(l){ return !_isSearchListing(l); }).slice(0, 300);
   var listingCardsHtml = _listings.map(function(l) {
     var img = l.image || l.providerImg || '';
     var price = l.priceLabel || (l.price ? ('ab ' + l.price + ' €') : '');

--- a/styles.css
+++ b/styles.css
@@ -3062,6 +3062,35 @@ body.dark-mode .ai-sug-chip:hover { background: rgba(255,56,92,0.15); }
   z-index: 5;
   box-shadow: var(--shadow-sm);
 }
+
+/* Board-Status-Badge: "Im Plan / Kontaktiert / Angebot / Gebucht" —
+   Verknüpfung Planungsboard ↔ Browse/Detail/Profil */
+.board-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+  white-space: nowrap;
+}
+.board-status-badge .material-icons-round { font-size: 14px; }
+.board-status-badge.bsb-geplant       { background: #3b82f6; }
+.board-status-badge.bsb-kontaktiert   { background: #f59e0b; }
+.board-status-badge.bsb-angebot       { background: #8b5cf6; }
+.board-status-badge.bsb-gebucht       { background: #16a34a; }
+.board-status-badge.bsb-abgeschlossen { background: #64748b; }
+/* Auf der Browse-Karte: unten links im Bild (Badge oben links bleibt frei) */
+.board-status-badge.bsb-on-card {
+  position: absolute;
+  bottom: 12px; left: 12px;
+  z-index: 5;
+}
+/* In der Detail-Provider-Zeile etwas größer + klickbar */
+#detailBoardStatus .board-status-badge { font-size: 0.8rem; padding: 6px 12px; }
 .listing-card-body { padding: 14px 6px 8px; }
 .listing-card-top {
   display: flex;
@@ -10660,6 +10689,153 @@ body.dark-mode .bpc-edit-btn:hover { background: var(--primary); border-color: v
 .board-checklist-view { padding: 20px 28px 60px; }
 .bcl-wrap { max-width: 640px; margin: 0 auto; }
 .bcl-header { margin-bottom: 20px; }
+
+/* ===== Planungs-Guide (geführte Steps im Board) ===== */
+.bguide-wrap {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 16px;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-sm);
+}
+.bguide-header { margin-bottom: 10px; }
+.bguide-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+  font-size: 1.05rem;
+}
+.bguide-title .material-icons-round { color: var(--primary, #FF385C); }
+.bguide-tmpl {
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2px 10px;
+}
+.bguide-progress-label {
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin: 6px 0 4px;
+}
+.bguide-progress-bar-wrap {
+  height: 8px;
+  border-radius: 6px;
+  background: var(--bg-alt);
+  overflow: hidden;
+}
+.bguide-progress-bar {
+  height: 100%;
+  border-radius: 6px;
+  background: linear-gradient(90deg, #FF385C, #8b5cf6);
+  transition: width .35s ease;
+}
+.bguide-current-hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  margin: 12px 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(255,56,92,0.07);
+  border: 1px dashed rgba(255,56,92,0.35);
+}
+.bguide-current-hint .material-icons-round { font-size: 18px; color: var(--primary, #FF385C); }
+.bguide-current-hint.bguide-all-done {
+  background: rgba(22,163,74,0.08);
+  border-color: rgba(22,163,74,0.35);
+}
+.bguide-current-hint.bguide-all-done .material-icons-round { color: #16a34a; }
+.bguide-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.bguide-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 6px;
+  border-bottom: 1px solid var(--border);
+  min-height: 44px; /* Touch-Target unterwegs */
+}
+.bguide-step:last-child { border-bottom: none; }
+.bguide-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  flex-shrink: 0;
+}
+.bguide-num {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  font-size: 0.72rem;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-light);
+}
+.bguide-state-icon { font-size: 20px; color: var(--text-light); }
+.bguide-step.done .bguide-state-icon { color: #16a34a; }
+.bguide-step.current .bguide-state-icon { color: var(--primary, #FF385C); }
+.bguide-step.done .bguide-text {
+  text-decoration: line-through;
+  color: var(--text-light);
+}
+.bguide-step.current .bguide-text { font-weight: 700; }
+.bguide-text { flex: 1; font-size: 0.92rem; min-width: 0; }
+.bguide-stage {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 20px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+.bguide-stage .material-icons-round { font-size: 13px; }
+.bguide-stage.bsb-geplant       { background: #3b82f6; }
+.bguide-stage.bsb-kontaktiert   { background: #f59e0b; }
+.bguide-stage.bsb-angebot       { background: #8b5cf6; }
+.bguide-stage.bsb-gebucht       { background: #16a34a; }
+.bguide-stage.bsb-abgeschlossen { background: #64748b; }
+.bguide-find {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--primary, #FF385C);
+  background: none;
+  color: var(--primary, #FF385C);
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all .15s ease;
+}
+.bguide-find:hover { background: var(--primary, #FF385C); color: #fff; }
+.bguide-find .material-icons-round { font-size: 15px; }
+body.dark-mode .bguide-wrap { background: var(--bg); }
+@media (max-width: 480px) {
+  .bguide-step { flex-wrap: wrap; }
+  .bguide-text { flex-basis: calc(100% - 70px); }
+  .bguide-stage, .bguide-find { margin-left: 62px; }
+}
 .bcl-title { display: flex; align-items: center; gap: 10px; font-size: 18px; font-weight: 700; color: var(--dark); margin-bottom: 10px; }
 .bcl-title .material-icons-round { font-size: 22px; color: var(--primary); }
 .bcl-progress-bar-wrap { height: 8px; border-radius: 8px; background: var(--border-light); overflow: hidden; margin-bottom: 6px; }

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -127,5 +127,17 @@ navigateTo('admin')         // Admin-Panel
 
 - **`hq.html` = EventBörse HQ (Mission Control):** Eigenständiges, self-contained Dev-Command-Center über die GitHub-API. Gamifiziert (Level/XP, Streak, Quests = Roadmap, Achievements, Bot-Team, Aktivitäts-Log, Confetti/SFX). Kein Build-Schritt, kein Framework. Zugriff per `HQ_KEYS`, GitHub-PAT (sessionStorage) für Rollback/Bot-Trigger. Quests spiegeln die Sprint-Roadmap — beim Hinzufügen neuer Roadmap-Punkte auch das `QUESTS`-Array in `hq.html` pflegen. GitHub-Daten werden per stale-while-revalidate in `localStorage` gecacht (geringere Rate-Limit-Last).
 
+## Stand 2026-06-26 — Admin-Bildmoderation & Security-Härtung (live auf main)
+
+- **Admin-Bildmoderation (umgesetzt):** Admins können einzelne Bilder löschen
+  - Detailseite: roter „Löschen"-Button pro Galerie-Bild (`adminDeleteListingImage`).
+  - Provider-Portfolio: Lösch-Overlay (`adminDeleteProfileImage`) + Lightbox-Button, dauerhaft sichtbar.
+  - Backend: `POST /admin/moderate-image` (nur Admin) entfernt Bild aus `eb_gallery` + allen Listings des Nutzers.
+  - **Persistente Blocklist** (`eb_demo_image_blocklist`, normalisierte Pfade) → wirkt auch für hardcodierte Demo-Listings (z. B. Blumenträume München, Pyroshock), reload-fest. Client: `window.EB_IMG_BLOCKLIST` via `eventboerseApi.imageBlocklist`, gefiltert in Demo-LISTINGS, `loadDbListings`, `loadProvider`.
+  - Damit ist der alte Sprint-P0 „Admin-Moderation gegen Code abgleichen" erledigt.
+- **Security (live):** XSS-Härtung (`_escHtml` encodet jetzt auch Quotes; Map-/Card-Render escapt); Brute-Force-Rate-Limiting verdrahtet (`includes/security/rate-limit.php` war vorher nie eingebunden) auf Login/OTP/Reset/Register mit Reset-on-Success; CSP `'unsafe-eval'` entfernt (Frontend nutzt kein eval, kein jQuery); WP-User-Enumeration gesperrt (`/wp/v2/users` + `?author=N`).
+- **CI/Deploy:** Neuer Workflow `.github/workflows/security.yml` (php -l alle + node --check + Pattern-Scan, läuft bei Push/PR). Minifier-Versionen gepinnt (`terser@5.48.0`, `csso-cli@5.0.5`) — Ursache eines früheren Ausfalls (unpinned `npx` zog kaputtes terser-Release). `SECURITY.md` mit Responsible-Disclosure-Policy.
+- **Offen (User-Seite):** Postfach `security@eventbörse.de` einrichten; optional CDN-SRI/Self-Hosting (von CI-Umgebung nicht möglich, Outbound geblockt); strikte CSP ohne `'unsafe-inline'` würde Inline-Handler-Refactor erfordern (groß, bewusst zurückgestellt).
+
 ---
-*Zuletzt aktualisiert: 2026-06-17*
+*Zuletzt aktualisiert: 2026-06-26*

--- a/vault/Roadmap/Current-Sprint.md
+++ b/vault/Roadmap/Current-Sprint.md
@@ -13,9 +13,12 @@
 - [ ] **Stripe Connect E2E im Testmodus finalisieren**
   - Dienstleister-Onboarding, Payment Intent, Webhook, Reconcile, Refund/Dispute-Pfad prüfen.
   - Keine echte Buchung ohne aktives Auszahlungskonto des Dienstleisters.
-- [ ] **Admin-Moderation gegen aktuellen Code abgleichen**
-  - Vault erwähnt ältere Moderationsrouten; `functions.php` registriert sie aktuell nicht.
-  - Prüfen, ob UI-Funktion noch vorhanden ist oder wiederhergestellt werden muss.
+- [x] **Admin-Moderation gegen aktuellen Code abgleichen** *(erledigt 2026-06-26, live)*
+  - Admin-Bild-Löschen umgesetzt: Detailseite (`adminDeleteListingImage`) + Provider-Portfolio/Lightbox (`adminDeleteProfileImage`).
+  - Backend `POST /admin/moderate-image` + persistente Blocklist (`eb_demo_image_blocklist`) → wirkt auch für hardcodierte Demo-Listings.
+- [x] **Security-Härtung** *(erledigt 2026-06-26, live)*
+  - XSS-Escaping (`_escHtml` inkl. Quotes), Brute-Force-Rate-Limiting (Login/OTP/Reset/Register), CSP ohne `'unsafe-eval'`, WP-User-Enumeration gesperrt, CDN gepinnt, CI-Security-Workflow + `SECURITY.md`.
+  - Offen (User): `security@eventbörse.de`-Postfach; optional CDN-SRI; CSP ohne `'unsafe-inline'` (Inline-Handler-Refactor).
 
 ## Nächste Prioritäten (P1)
 


### PR DESCRIPTION
Macht das Planungsboard zum echten Hochzeits-/Event-Planungswerkzeug (auch unterwegs), **rein additiv** — bestehende Flows unverändert.

## 1) Planungs-Guide (geführte Steps) 💍
Im Checklisten-Tab jedes Board-Projekts erscheint oben ein geführter Assistent:
- Nummerierte Steps in geprüfter Reihenfolge (aus den bestehenden Templates: Hochzeit, Geburtstag, Firmenfeier, …) mit Fortschrittsbalken und „Nächster Schritt"-Hinweis.
- Steps mit Kategorie-Bezug (Location/Fotograf/DJ/Catering/Floristik/Technik/…) haben einen **„Finden"-Button** → öffnet Browse mit vorgewähltem Kategorie-Filter.
- **Auto-Erledigt:** Ist der passende Dienstleister im Board gebucht/abgeschlossen, gilt der Step automatisch als erledigt. Offene Steps zeigen die Phase des verknüpften Dienstleisters als Chip (z. B. „Kontaktiert").
- Abhaken synchronisiert mit der bestehenden Checkliste (gleicher Text = gleicher Eintrag) — Guide und Checkliste laufen nie auseinander.

## 2) Board-Status überall sichtbar 🔗
Neue Badges **Im Plan / Kontaktiert / Angebot / Gebucht / Abgeschlossen** (höchste Karten-Phase über alle Projekte des Nutzers):
- Browse-Karten (im Bild unten links)
- Inserat-Detailseite (klickbar → springt ins Board)
- Provider-Profil (Badge-Zeile)

## 3) Fehlende Listings behoben 🐛 (2 Ursachen)
- `loadDbListings` lud nur Seite 1 — der Server kappt bei 50/Seite → **ab dem 51. Inserat fehlten Listings überall**. Jetzt werden Folgeseiten nachgeladen (Cap 10 Seiten = 500, fehler-tolerant pro Seite).
- Board-Picker kappte hart auf 30 Karten und die Picker-Suche filterte nur Gerendertes → Cap auf 300 angehoben.

## Tests
- `node --check` + CI-Minify (terser@5.48.0) + Funktions-Guard ✓
- Logik-Tests mit Stub-Daten: Status-Mapping (gebucht/kontaktiert/null), Kategorie-Erkennung aller Hochzeits-Steps, Auto-Done bei Buchung, Checklisten-Sync ✓
- Keine PHP-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_