### PR TITLE
Fix: Verbesserungs-Bot — Modell pinnen + echte Fehler sichtbar machen

### DIFF
--- a/.github/workflows/claude-improve.yml
+++ b/.github/workflows/claude-improve.yml
@@ -75,7 +75,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--max-turns 50'
+          # Pin the model: the action's default resolves to the 1M-context
+          # variant (opus-4-8[1m]), which not every API tier can access and
+          # then fails instantly. Plain opus-4-8 works on standard tiers.
+          claude_args: '--model claude-opus-4-8 --max-turns 50'
+          show_full_output: 'true'
           prompt: |
             Du bist die automatische Verbesserungs-Routine fuer das Projekt "Eventboerse"
             (deutscher Event-Marktplatz, Vanilla-JS-SPA + WordPress REST API).
@@ -105,6 +109,27 @@ jobs:
 
             Zum Schluss: Schreibe eine kurze deutsche Zusammenfassung (Markdown: was, warum, welche Dateien)
             in die Datei CLAUDE_SUMMARY.md im Repo-Wurzelverzeichnis.
+
+      # claude-code-action reports step success even when the Claude run
+      # errored internally (is_error in the execution log). Fail loudly so
+      # the HQ shows red instead of a silent no-op run.
+      - name: Claude-Ergebnis pruefen
+        run: |
+          OUT=/home/runner/work/_temp/claude-execution-output.json
+          if [ ! -f "$OUT" ]; then
+            echo "::warning::Kein Execution-Log gefunden — Pruefung uebersprungen."
+            exit 0
+          fi
+          python3 - "$OUT" <<'PY'
+          import json, sys
+          data = json.load(open(sys.argv[1]))
+          entries = data if isinstance(data, list) else [data]
+          results = [e for e in entries if isinstance(e, dict) and e.get("type") == "result"]
+          if any(e.get("is_error") for e in results):
+            print("::error title=Claude-Lauf fehlgeschlagen::Der Claude-Schritt endete mit is_error=true. Details im Schritt 'Claude setzt Verbesserung um' (show_full_output aktiv).")
+            sys.exit(1)
+          print("Claude-Lauf OK")
+          PY
 
       - name: Zusammenfassung einlesen
         id: summary


### PR DESCRIPTION
## 🐛 Zweiter Bugfix für die Verbesserungs-Routine

Testlauf #2 war „grün", tat aber nichts: Die Action wählte als Default das Modell **`claude-opus-4-8[1m]`** (1M-Kontext-Beta). Der erste API-Call schlug sofort fehl (`is_error: true`, 190 ms, 0 $) — vermutlich fehlt dem API-Key/Tier der Zugriff auf die 1M-Beta. Die Action meldete den Schritt trotzdem als Erfolg → stiller No-Op.

**Fixes (nur `claude-improve.yml`):**
1. `--model claude-opus-4-8` explizit gepinnt (Standard-Variante ohne 1M-Beta)
2. `show_full_output: true` — echte Fehlermeldungen landen künftig im Log
3. Neuer Guard-Schritt „Claude-Ergebnis prüfen": parst das Execution-Log und lässt den Job **rot** werden, wenn Claude intern fehlschlägt — kein stilles Grün mehr (auch im HQ korrekt sichtbar)

Nach dem Merge starte ich Testlauf #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvLwjRAC4Fu6UC5BPMh7wy)_