### PR TITLE
Planungs-Guide Ausbau: Chat-Verknüpfung + Budget-Tracking + Termin-Empfehlungen

### DIFF
--- a/app.js
+++ b/app.js
@@ -1500,6 +1500,22 @@ function _boardStatusBadgeHtml(listingId, extraClass) {
     '<span class="material-icons-round">' + st.info.icon + '</span>' + st.info.label + '</span>';
 }
 
+// Höchste Board-Phase über ALLE Inserate eines Anbieters (User-ID) —
+// für Kontexte, die den Partner kennen, aber kein konkretes Listing (Chat).
+function _boardStatusBadgeForProvider(userId, extraClass) {
+  if (userId == null || !Array.isArray(LISTINGS)) return '';
+  var bestHtml = '', bestIdx = -1;
+  LISTINGS.forEach(function(l) {
+    if (!l || !_sameUserId(_listingOwnerId(l), userId)) return;
+    var st = _boardStatusForListing(l.id);
+    if (st) {
+      var idx = EB_BOARD_STAGE_ORDER.indexOf(st.stage);
+      if (idx > bestIdx) { bestIdx = idx; bestHtml = _boardStatusBadgeHtml(l.id, extraClass); }
+    }
+  });
+  return bestHtml;
+}
+
 // ========== LISTING CARD RENDERER ==========
 function renderListingCard(listing) {
   const isFav = favorites.has(listing.id);
@@ -5393,6 +5409,24 @@ function openChat(chatId) {
 
       document.getElementById('chatAvatar').src = currentChat.avatar;
       document.getElementById('chatName').textContent = currentChat.name;
+      // Board-Verknüpfung im Chat-Header: plant man mit diesem Dienstleister
+      // bereits im Board, erscheint der Status (Im Plan/Kontaktiert/…) neben
+      // dem Namen — klickbar ins Board.
+      (function() {
+        var old = document.getElementById('chatBoardStatus');
+        if (old) old.remove();
+        var badge = _boardStatusBadgeForProvider(currentChat.otherId);
+        if (!badge) return;
+        var nameEl = document.getElementById('chatName');
+        if (!nameEl) return;
+        var wrap = document.createElement('span');
+        wrap.id = 'chatBoardStatus';
+        wrap.innerHTML = badge;
+        wrap.style.cursor = 'pointer';
+        wrap.title = 'Im Planungsboard öffnen';
+        wrap.onclick = function(e) { e.stopPropagation(); navigateTo('board'); };
+        nameEl.insertAdjacentElement('afterend', wrap);
+      })();
       // Fetch real online status
       _updateChatStatus(currentChat.otherId);
 
@@ -19360,6 +19394,37 @@ function _guideCardStageForCategory(project, cat) {
   return best >= 0 ? EB_BOARD_STAGE_ORDER[best] : null;
 }
 
+// Empfohlene Vorlaufzeiten (Wochen vor dem Event) — Text-Regeln zuerst
+// (spezifischer), dann Kategorie-Fallback. Steps ohne Regel bekommen
+// keinen Termin-Chip.
+var _GUIDE_LEAD_TEXT_RULES = [
+  [/standesamt/i, 26], [/kleid|anzug/i, 24], [/ringe/i, 20], [/honeymoon/i, 20],
+  [/einladung/i, 16], [/hotel/i, 12], [/torte|kuchen/i, 8], [/playlist/i, 6],
+  [/sitzordnung/i, 4], [/koordinator/i, 4], [/zeitplan|ablauf/i, 2],
+  [/tickets|anmeldung/i, 20], [/marketing/i, 24], [/sicherheitsdienst/i, 16],
+  [/agenda|programm/i, 6], [/budget/i, 30],
+];
+var _GUIDE_LEAD_CAT_WEEKS = {
+  location: 52, planung: 48, foto: 36, dj: 32, catering: 24, moderation: 20,
+  licht: 16, florist: 12, pyro: 12, deko: 8,
+};
+function _guideLeadWeeksFor(text, cat) {
+  for (var i = 0; i < _GUIDE_LEAD_TEXT_RULES.length; i++) {
+    if (_GUIDE_LEAD_TEXT_RULES[i][0].test(text || '')) return _GUIDE_LEAD_TEXT_RULES[i][1];
+  }
+  if (cat && _GUIDE_LEAD_CAT_WEEKS[cat]) return _GUIDE_LEAD_CAT_WEEKS[cat];
+  return null;
+}
+
+// Event-Datum des Projekts als Date (oder null).
+function _guideEventDate(project) {
+  if (!project || !project.date) return null;
+  var iso = (typeof _toIsoDate === 'function') ? _toIsoDate(project.date) : '';
+  if (!iso) return null;
+  var d = new Date(iso + 'T12:00:00');
+  return isNaN(d.getTime()) ? null : d;
+}
+
 // Geführte Steps mit Status aus Checkliste + Board-Karten ableiten.
 function _guideSteps(project) {
   if (!project) return [];
@@ -19368,6 +19433,8 @@ function _guideSteps(project) {
   (project.checklist || []).forEach(function(it) {
     if (it && it.text) doneMap[it.text.toLowerCase()] = !!it.done;
   });
+  var eventDate = _guideEventDate(project);
+  var now = new Date();
   return tmpl.map(function(text, i) {
     var cat = _guideCategoryFor(text);
     var cardStage = cat ? _guideCardStageForCategory(project, cat) : null;
@@ -19375,7 +19442,16 @@ function _guideSteps(project) {
     // dafür bereits fest gebucht/abgeschlossen ist.
     var done = doneMap[text.toLowerCase()] === true ||
       cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
-    return { idx: i, text: text, cat: cat, cardStage: cardStage, done: done };
+    // Empfohlene Deadline: Eventdatum minus Vorlaufzeit (nur mit Datum).
+    var deadline = null, overdue = false;
+    if (eventDate) {
+      var weeks = _guideLeadWeeksFor(text, cat);
+      if (weeks != null) {
+        deadline = new Date(eventDate.getTime() - weeks * 7 * 24 * 3600 * 1000);
+        overdue = !done && deadline < now;
+      }
+    }
+    return { idx: i, text: text, cat: cat, cardStage: cardStage, done: done, deadline: deadline, overdue: overdue };
   });
 }
 
@@ -19398,19 +19474,47 @@ function _renderBoardGuide(project) {
       var info = EB_BOARD_STAGE_INFO[s.cardStage];
       stageChip = '<span class="bguide-stage bsb-' + info.cls + '"><span class="material-icons-round">' + info.icon + '</span>' + info.label + '</span>';
     }
+    // Termin-Empfehlung: "bis TT.MM." aus Eventdatum + Vorlaufzeit;
+    // überfällige offene Steps werden rot markiert.
+    var deadlineChip = '';
+    if (!s.done && s.deadline) {
+      var dd = ('0' + s.deadline.getDate()).slice(-2) + '.' + ('0' + (s.deadline.getMonth() + 1)).slice(-2) + '.';
+      if (s.deadline.getFullYear() !== (new Date()).getFullYear()) dd += s.deadline.getFullYear();
+      deadlineChip = '<span class="bguide-deadline' + (s.overdue ? ' overdue' : '') + '" title="Empfohlen bis ' + dd + ' (Vorlaufzeit)">' +
+        '<span class="material-icons-round">' + (s.overdue ? 'notification_important' : 'schedule') + '</span> bis ' + dd + '</span>';
+    }
     var findBtn = (!s.done && s.cat)
       ? '<button type="button" class="bguide-find" onclick="_guideFindProviders(\'' + s.cat + '\')"><span class="material-icons-round">search</span> Finden</button>'
       : '';
     var safeText = _escHtml(s.text).replace(/'/g, "\\'");
-    return '<li class="bguide-step ' + state + '">' +
+    return '<li class="bguide-step ' + state + (s.overdue ? ' overdue' : '') + '">' +
       '<button type="button" class="bguide-check" onclick="_guideToggleStep(\'' + safeText + '\')" aria-label="' + (s.done ? 'Als offen markieren' : 'Als erledigt markieren') + '">' +
         '<span class="bguide-num">' + (s.idx + 1) + '</span>' +
         '<span class="material-icons-round bguide-state-icon">' + icon + '</span>' +
       '</button>' +
       '<span class="bguide-text">' + _escHtml(s.text) + '</span>' +
-      stageChip + findBtn +
+      deadlineChip + stageChip + findBtn +
     '</li>';
   }).join('');
+
+  // Budget-Tracking: verplant (Summe Karten-Preise) vs. Projekt-Budget.
+  var budgetHtml = '';
+  var planned = (project.cards || []).reduce(function(sum, c) {
+    return sum + (c && !isNaN(parseFloat(c.price)) ? parseFloat(c.price) : 0);
+  }, 0);
+  if (project.budget > 0 || planned > 0) {
+    var fmt = function(n) { return Math.round(n).toLocaleString('de-DE') + ' €'; };
+    var over = project.budget > 0 && planned > project.budget;
+    var bpct = project.budget > 0 ? Math.min(100, Math.round((planned / project.budget) * 100)) : 0;
+    budgetHtml = '<div class="bguide-budget' + (over ? ' over' : '') + '">' +
+      '<div class="bguide-budget-row">' +
+        '<span class="material-icons-round">account_balance_wallet</span>' +
+        '<span>' + fmt(planned) + (project.budget > 0 ? ' von ' + fmt(project.budget) + ' verplant' : ' verplant') + '</span>' +
+        (over ? '<span class="bguide-budget-warn"><span class="material-icons-round">warning</span> ' + fmt(planned - project.budget) + ' über Budget</span>' : '') +
+      '</div>' +
+      (project.budget > 0 ? '<div class="bguide-budget-bar-wrap"><div class="bguide-budget-bar" style="width:' + bpct + '%"></div></div>' : '') +
+    '</div>';
+  }
 
   return '<div class="bguide-wrap">' +
     '<div class="bguide-header">' +
@@ -19418,6 +19522,7 @@ function _renderBoardGuide(project) {
       '<div class="bguide-progress-label">' + doneCount + ' / ' + steps.length + ' Schritten</div>' +
       '<div class="bguide-progress-bar-wrap"><div class="bguide-progress-bar" style="width:' + pct + '%"></div></div>' +
     '</div>' +
+    budgetHtml +
     (currentIdx >= 0
       ? '<div class="bguide-current-hint"><span class="material-icons-round">arrow_forward</span> Nächster Schritt: <strong>' + _escHtml(steps[currentIdx].text) + '</strong></div>'
       : '<div class="bguide-current-hint bguide-all-done"><span class="material-icons-round">celebration</span> Alle Schritte erledigt — dein Event ist durchgeplant!</div>') +

--- a/styles.css
+++ b/styles.css
@@ -10830,6 +10830,76 @@ body.dark-mode .bpc-edit-btn:hover { background: var(--primary); border-color: v
 }
 .bguide-find:hover { background: var(--primary, #FF385C); color: #fff; }
 .bguide-find .material-icons-round { font-size: 15px; }
+
+/* Budget-Tracking im Guide */
+.bguide-budget {
+  margin: 10px 0 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+}
+.bguide-budget-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.bguide-budget-row .material-icons-round { font-size: 18px; color: var(--text-light); }
+.bguide-budget-warn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #dc2626;
+  font-weight: 800;
+}
+.bguide-budget-warn .material-icons-round { font-size: 16px; color: #dc2626; }
+.bguide-budget-bar-wrap {
+  height: 6px;
+  margin-top: 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  overflow: hidden;
+}
+.bguide-budget-bar {
+  height: 100%;
+  border-radius: 6px;
+  background: #16a34a;
+  transition: width .35s ease;
+}
+.bguide-budget.over .bguide-budget-bar { background: #dc2626; }
+
+/* Termin-Empfehlung pro Step */
+.bguide-deadline {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  border-radius: 20px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  color: var(--text-light);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.bguide-deadline .material-icons-round { font-size: 13px; }
+.bguide-deadline.overdue {
+  background: rgba(220,38,38,0.1);
+  border-color: rgba(220,38,38,0.4);
+  color: #dc2626;
+}
+.bguide-step.overdue .bguide-text { color: #dc2626; }
+
+/* Chat-Header: Board-Status neben dem Namen */
+#chatBoardStatus { margin-left: 8px; display: inline-flex; vertical-align: middle; }
+#chatBoardStatus .board-status-badge { font-size: 0.68rem; padding: 3px 9px; }
+@media (max-width: 480px) {
+  .bguide-deadline { margin-left: 62px; }
+}
 body.dark-mode .bguide-wrap { background: var(--bg); }
 @media (max-width: 480px) {
   .bguide-step { flex-wrap: wrap; }


### PR DESCRIPTION
Drei Ausbaustufen des Planungs-Guides (#70-Follow-up), rein additiv:

## 1) 💬 Chat-Verknüpfung
Plant man mit dem Chat-Partner bereits im Board, erscheint sein Status (**Im Plan / Kontaktiert / Angebot / Gebucht**) als Badge neben dem Namen im Chat-Header — klickbar → springt ins Board. (Höchste Phase über alle Inserate des Anbieters.)

## 2) 💰 Budget-Tracking im Guide
Der Guide-Header zeigt „X € von Y € verplant" (Summe der Board-Karten-Preise vs. Projekt-Budget) mit Fortschrittsbalken. Bei Überschreitung: roter Balken + Warn-Chip mit Differenzbetrag.

## 3) ⏰ Termin-Empfehlungen pro Step
Ist ein Event-Datum gesetzt, bekommt jeder offene Step einen „**bis TT.MM.**"-Chip aus empfohlener Vorlaufzeit (z. B. Location 52 Wochen, Fotograf 36, Einladungen 16, Standesamt 26, Zeitplan 2). Überfällige offene Steps werden rot markiert. Ohne Datum: keine Chips (kein Rauschen).

## Tests
- `node --check` + CI-Minify (terser@5.48.0) + Funktions-Guard ✓
- 7 Logik-Tests mit Stub-Daten (Deadline-Berechnung, Overdue-Grenzen, „done nie overdue", „ohne Datum keine Chips", Lead-Regeln, Budget-Summe) ✓
- Keine PHP-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_