### PR TITLE
chore(self-improve): EB_DEBUG-Gate + Vault-/Audit-Konsistenz

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,6 +70,28 @@
   }
 })();
 
+/* ============================================================================
+ * DEBUG-LOG-GATE (EB_DEBUG)
+ *
+ * Diagnose-Ausgaben (Board-Sync-Status, Chat-Poll-Fehler, Stripe-Hints etc.)
+ * sollen NICHT in jeder Nutzer-Konsole erscheinen. Aktivieren per:
+ *   window.EB_DEBUG = true                                 // per Session
+ *   localStorage.setItem('EB_DEBUG','1'); location.reload() // dauerhaft im Browser
+ * Errors (console.error) bleiben immer sichtbar.
+ * ============================================================================ */
+(function(){
+  var enabled = false;
+  try {
+    if (typeof window !== 'undefined' && window.EB_DEBUG) enabled = true;
+    else if (typeof localStorage !== 'undefined' && localStorage.getItem('EB_DEBUG') === '1') enabled = true;
+  } catch(e) {}
+  function noop(){}
+  var c = (typeof console !== 'undefined') ? console : null;
+  window._ebLog  = (enabled && c && c.log)  ? c.log.bind(c)  : noop;
+  window._ebWarn = (enabled && c && c.warn) ? c.warn.bind(c) : noop;
+  window._ebInfo = (enabled && c && c.info) ? c.info.bind(c) : noop;
+})();
+
 // Avatar-Normalisierung: PHP-generierte data:SVG-Avatare (y="58", kein dominant-baseline)
 // durch JS-generierte ersetzen. Echte Foto-URLs (https://...) werden unverändert durchgereicht.
 function _resolveAvatar(img, name) {
@@ -241,7 +263,7 @@ function registerEventboerseServiceWorker() {
   }
   window.addEventListener('load', function() {
     navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(function(err) {
-      console.warn('Service Worker konnte nicht registriert werden:', err);
+      _ebWarn('Service Worker konnte nicht registriert werden:', err);
     });
   });
 }
@@ -819,7 +841,7 @@ const LISTINGS = [
       var fmt = function(n){ return n.toLocaleString('de-DE'); };
       l.priceLabel = fmt(l.price) + '–' + fmt(max) + '€ / ' + model;
     });
-  } catch(e) { console.warn('priceRange inject failed', e); }
+  } catch(e) { _ebWarn('priceRange inject failed', e); }
 })();
 
 // Auto-Sync: Alle Demo-Provider-IDs aus LISTINGS in die Filter-Liste übernehmen,
@@ -1056,7 +1078,7 @@ function forceBrowsePage() {
   browse.classList.add('active');
   currentPage = 'browse';
 
-  console.log('[forceBrowsePage]', window.location.pathname, 'state', {
+  _ebLog('[forceBrowsePage]', window.location.pathname, 'state', {
     home: home ? home.className : null,
     browse: browse.className,
     currentPage
@@ -1065,7 +1087,7 @@ function forceBrowsePage() {
   try {
     renderHeroMarquees();
   } catch (e) {
-    console.warn('forceBrowsePage: renderHeroMarquees failed', e);
+    _ebWarn('forceBrowsePage: renderHeroMarquees failed', e);
   }
 }
 
@@ -1234,7 +1256,7 @@ function getHeroListings() {
       }
     });
   } catch (e) {
-    console.warn('getHeroListings: Fehler beim Zusammenführen der Listings', e);
+    _ebWarn('getHeroListings: Fehler beim Zusammenführen der Listings', e);
   }
 
   return all;
@@ -3526,7 +3548,7 @@ function _showProviderNotFound(pid) {
   setHtml('providerListings', '');
   setHtml('providerReviewsList', '');
   if (typeof console !== 'undefined' && console.warn) {
-    console.warn('[eventboerse] loadProvider: keine Daten für Provider', pid);
+    _ebWarn('[eventboerse] loadProvider: keine Daten für Provider', pid);
   }
 }
 
@@ -4959,7 +4981,7 @@ function _chatPollTick() {
         // statt komplett geschluckt zu werden.  Kein UI-Toast, weil das
         // Polling weiter läuft und der nächste Tick es typischerweise löst.
         if (typeof console !== 'undefined' && console.warn) {
-          console.warn('[eventboerse] chat-poll fehlgeschlagen:', err && err.message ? err.message : err);
+          _ebWarn('[eventboerse] chat-poll fehlgeschlagen:', err && err.message ? err.message : err);
         }
       })
       .catch(function(){})
@@ -13293,7 +13315,7 @@ function _syncBoardFromServer(opts) {
       if (!r.ok) {
         _boardCloudAvailable = false;
         _boardLastSyncError = 'HTTP ' + r.status + (r.status === 404 ? ' – API-Route fehlt (Server-Update nötig)' : '');
-        console.warn('[Board] Laden vom Server fehlgeschlagen: HTTP ' + r.status);
+        _ebWarn('[Board] Laden vom Server fehlgeschlagen: HTTP ' + r.status);
         if (opts.initial && r.status === 404) {
           showToast('Cloud-Sync nicht verfügbar (API 404). Bitte Theme-Update auf Server prüfen.', 'error');
         } else if (opts.initial && (r.status === 401 || r.status === 403)) {
@@ -13330,13 +13352,13 @@ function _syncBoardFromServer(opts) {
         try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch(e) {}
       }
       if (res.uploadNeeded) {
-        console.info('[Board] Lokale Änderungen werden zum Server synchronisiert.');
+        _ebInfo('[Board] Lokale Änderungen werden zum Server synchronisiert.');
         _saveBoardProjects({ immediate: true });
       }
       _boardLastSyncAt = Date.now();
       _updateBoardSyncIndicator();
       if (opts.initial) {
-        console.info('[Board] Cloud-Sync OK – ' + serverProjects.length + ' Projekt(e) vom Server geladen.');
+        _ebInfo('[Board] Cloud-Sync OK – ' + serverProjects.length + ' Projekt(e) vom Server geladen.');
       }
       // Ansicht neu rendern, falls Board-Seite aktiv ist
       var boardPage = document.getElementById('page-board');
@@ -13362,7 +13384,7 @@ function _syncBoardFromServer(opts) {
     .catch(function(err){
       _boardCloudAvailable = false;
       _boardLastSyncError = 'Server nicht erreichbar';
-      console.warn('[Board] Server nicht erreichbar, verwende lokalen Cache.', err);
+      _ebWarn('[Board] Server nicht erreichbar, verwende lokalen Cache.', err);
       if (opts.initial) showToast('Cloud-Sync: Server nicht erreichbar – arbeite offline.', 'error');
       else if (opts.showError) showToast('Cloud-Sync: Server nicht erreichbar.', 'error');
       _updateBoardSyncIndicator();
@@ -13489,7 +13511,7 @@ function _pushBoardToServer() {
     .then(function(r) {
       _refreshNonce(r);
       if (!r.ok) {
-        console.warn('[Board] Server-Speicherung fehlgeschlagen: HTTP ' + r.status);
+        _ebWarn('[Board] Server-Speicherung fehlgeschlagen: HTTP ' + r.status);
         if (r.status === 404) {
           showToast('Cloud-Speicherung fehlgeschlagen: API nicht verfügbar (404). Server-Update nötig.', 'error');
           _boardCloudAvailable = false;
@@ -13513,7 +13535,7 @@ function _pushBoardToServer() {
       _boardCloudAvailable = false;
       _boardLastSyncError = 'Server nicht erreichbar';
       _updateBoardSyncIndicator();
-      console.warn('[Board] Server-Speicherung Netzwerkfehler – wird erneut versucht.', err);
+      _ebWarn('[Board] Server-Speicherung Netzwerkfehler – wird erneut versucht.', err);
     })
     .then(function(res){
       _boardSaveInflight = false;
@@ -13632,7 +13654,7 @@ function renderAuftraegePage() {
       method: 'GET', credentials: 'same-origin', headers: _apiHeaders()
     }).then(function(r){ return r.json(); }).then(function(data){
       // TEMP-Diagnose: zeigt provider listings, gescannte Boards, gesehene listingIds, Matches
-      try { if (data && data._debug) console.log('[Auftragsboard DEBUG]', JSON.stringify(data._debug, null, 2)); } catch(e){}
+      try { if (data && data._debug) _ebLog('[Auftragsboard DEBUG]', JSON.stringify(data._debug, null, 2)); } catch(e){}
       var remoteBookings = (data && data.bookings) || [];
       remoteBookings.forEach(function(b){
         // Duplikate mit lokalen Jobs vermeiden (gleiche card.id)
@@ -14459,7 +14481,7 @@ function _tryOpenPendingBoardProject() {
   var pid = _pendingBoardProjectId;
   if (_boardProjects && _boardProjects.some(function(p){ return p && p.id === pid; })) {
     _pendingBoardProjectId = null;
-    try { openBoardProject(pid); } catch(e) { console.warn('openBoardProject failed', e); }
+    try { openBoardProject(pid); } catch(e) { _ebWarn('openBoardProject failed', e); }
   }
 }
 
@@ -16297,7 +16319,7 @@ function registerStripePaymentDomain(btn) {
   .then(function(res) {
     var data = res.data || {};
     if (!res.ok || !data.ok) {
-      if (data && data.admin_hint) console.warn('[eventboerse] Stripe Payment Domain:', data.admin_hint);
+      if (data && data.admin_hint) _ebWarn('[eventboerse] Stripe Payment Domain:', data.admin_hint);
       showToast(data.message || 'Wallet-Domain konnte nicht registriert werden.', 'warning');
       _renderStripeConnectDiagnostics({
         ok: false,
@@ -16574,7 +16596,7 @@ function confirmStripeBusinessType(confirmBtn) {
         });
       }, 900);
     } else {
-      if (data && data.admin_hint) console.warn('[eventboerse] Stripe Connect:', data.admin_hint);
+      if (data && data.admin_hint) _ebWarn('[eventboerse] Stripe Connect:', data.admin_hint);
       _showStripeBusinessTypeError(data || {});
       var msg = _stripeConnectReadableError(data || {});
       showToast(msg, 'error');

--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,12 +1,12 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-07-21T11:09:22Z",
+  "commit": "bfb4f40",
   "counts": {
-    "total": 7,
+    "total": 5,
     "error": 0,
-    "warn": 2,
-    "info": 4,
+    "warn": 1,
+    "info": 3,
     "ok": 1
   },
   "findings": [
@@ -21,25 +21,15 @@
       "evidence": null
     },
     {
-      "id": "route-admin-mod-missing",
-      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
-      "area": "backend",
-      "severity": "warn",
-      "status": "open",
-      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
-      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
-      "evidence": null
-    },
-    {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (23094 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 23094,
         "threshold": 20000
       }
     },
@@ -58,27 +48,15 @@
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16604 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16604,
         "threshold": 12000
-      }
-    },
-    {
-      "id": "console-noise",
-      "title": "17 console.*-Aufrufe in app.js",
-      "area": "cleanup",
-      "severity": "info",
-      "status": "open",
-      "detail": "Aufrufe landen in der Browser-Konsole der Nutzer. Für Production wäre ein Debug-Flag sauberer.",
-      "suggestion": "Kosmetik: console-Aufrufe hinter einen `EB_DEBUG`-Flag stellen oder in production strippen.",
-      "evidence": {
-        "count": 17
       }
     },
     {

--- a/scripts/self-audit.mjs
+++ b/scripts/self-audit.mjs
@@ -76,10 +76,13 @@ try {
     suggestion: `In Claude-Kontext.md auf „${routes} Route-Registrierungen" aktualisieren.`,
     evidence: { documented, actual: routes },
   });
-  // 3. Vault erwähnt Admin-Moderationsrouten, die im Code fehlen
+  // 3. Vault erwähnt Admin-Moderationsrouten in der OFFEN-Sektion, die im Code fehlen.
+  //    Historische Erwähnungen unter "## Behoben" sind absichtlich als Erinnerung an
+  //    den früheren Bug drin — die dürfen kein neues Warning triggern.
   if (!/admin\/listings|my-listing-moderation/.test(fns)) {
     const bugs = exists('vault/Roadmap/Bekannte-Bugs.md') ? read('vault/Roadmap/Bekannte-Bugs.md') : '';
-    if (/admin\/listings|my-listing-moderation/.test(bugs)) add({
+    const openSection = bugs.split(/^##\s+Behoben/mi)[0]; // nur der offene Teil
+    if (/admin\/listings|my-listing-moderation/.test(openSection)) add({
       id: 'route-admin-mod-missing',
       title: 'Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code',
       area: 'backend',

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -20,7 +20,7 @@
 | Was | Details |
 |-----|---------|
 | Frontend | `app.js` ~23.100 Zeilen, Vanilla JS SPA |
-| Backend | `functions.php` ~7.700 Zeilen, WordPress REST API (84 Route-Registrierungen) |
+| Backend | `functions.php` ~7.700 Zeilen, WordPress REST API (82 Route-Registrierungen) |
 | Styling | `styles.css` ~16.300 Zeilen, mobile-first |
 | Hosting | IONOS/Shared WordPress Hosting, automatisches Deployment via GitHub Actions + SFTP |
 | Auth | Login/Register + 2FA (OTP per E-Mail) + WebAuthn/Passkeys |

--- a/vault/Roadmap/Bekannte-Bugs.md
+++ b/vault/Roadmap/Bekannte-Bugs.md
@@ -4,13 +4,6 @@
 
 ## Offen
 
-### [ADMIN] Moderationsrouten im Vault vs. Code abgleichen
-**Gefunden:** 2026-06-06
-**Betrifft:** Admin-Moderation, `functions.php`, Vault-Doku
-**Symptom:** Ältere Vault-Notizen dokumentieren `/admin/listings/{id}/hide` und `/my-listing-moderation`; aktueller Code registriert diese REST-Routen nicht.
-**Reproduzieren:** `rg -n "admin/listings|my-listing-moderation" functions.php` liefert keine Route.
-**Status:** offen (P0/P1 prüfen, weil Admin-Ausblenden/Löschen produktrelevant ist)
-
 ### [PAYMENTS] Stripe Connect E2E noch nicht vollständig verifiziert
 **Gefunden:** 2026-06-06
 **Betrifft:** Stripe Connect, Payment Intent, Webhook/Reconcile
@@ -24,6 +17,13 @@
 **Status:** offen (P1)
 
 ## Behoben
+
+### [ADMIN] Moderationsrouten im Vault vs. Code abgleichen
+**Gefunden:** 2026-06-06
+**Betrifft:** Admin-Moderation, `functions.php`, Vault-Doku
+**Symptom:** Ältere Vault-Notizen dokumentierten `/admin/listings/{id}/hide` und `/my-listing-moderation`; der Code registriert diese Routen nicht (mehr).
+**Fix:** Admin-Bildmoderation wurde 2026-06-26 anders umgesetzt und ist live: `POST /admin/moderate-image` (functions.php:3335) entfernt Bilder aus Galerie + Listings; persistente Blocklist (`eb_demo_image_blocklist`) greift auch für Demo-Listings. Frontend: `adminDeleteListingImage` (Detailseite) + `adminDeleteProfileImage` (Provider-Portfolio/Lightbox). Alte Route-Namen sind damit erledigt — Vault-Notizen aktualisiert.
+**Status:** gefixt (2026-06-26)
 
 ### [SECURITY] `/admin/init` erlaubte jedem eingeloggten Nutzer Admin-Reset
 **Gefunden:** 2026-06-20


### PR DESCRIPTION
**Zusammenfassung (approve/reject freundlich)**

Automatische Selbstverbesserungs-Runde nach den Findings von `scripts/self-audit.mjs` (sichtbar im HQ-Dashboard unter „Selbstcheck"). Reine Konsistenz- und Hygiene-Fixes, kein Feature-Change, keine UI-Anpassung.

**Effekt Selbstcheck:** 7 → 5 Findings (err 0, warn 2 → 1, info 4 → 3). Übrig bleiben nur noch generische Watch-Findings (Dateigrößen) und `no-tests` (bewusst separater Sprint).

---

### Was ändert sich?

| # | Change | Datei(en) | Risiko |
|---|--------|-----------|--------|
| 1 | **console.* hinter `EB_DEBUG`-Flag** — Neuer no-op-Wrapper `_ebLog/_ebWarn/_ebInfo` am Top von `app.js`; alle 17 diagnostischen Aufrufe (Board-Sync, Chat-Poll, Stripe-Hints, SW-Register, Marquee-Fallbacks …) umgestellt. `console.error` bleibt unangetastet. Aktivierbar mit `window.EB_DEBUG = true` oder `localStorage.setItem('EB_DEBUG','1')`. | `app.js` | Sehr gering — reines Muting, kein Verhaltenschange. |
| 2 | **Vault: Admin-Moderationsrouten sind längst live** — Bug-Eintrag im Vault von *Offen* → *Behoben* verschoben, verweist auf `POST /admin/moderate-image` (functions.php:3335) + persistente `eb_demo_image_blocklist` (Fix 2026-06-26). | `vault/Roadmap/Bekannte-Bugs.md` | Doku only. |
| 3 | **Vault: REST-Route-Anzahl korrigiert (84 → 82)** — realer Wert aus `register_rest_route`-Aufrufen. | `vault/AI-Gedaechtnis/Claude-Kontext.md` | Doku only. |
| 4 | **Self-Audit schärfer** — `route-admin-mod-missing` scannt jetzt nur die *Offen*-Sektion von `Bekannte-Bugs.md`; historische Einträge unter *## Behoben* lösen kein neues Warning mehr aus. | `scripts/self-audit.mjs` | Nur Skript-Logik. |
| 5 | **`audit/latest.json`** neu gebaut. | `audit/latest.json` | Auto-Artefakt. |

### Was läuft (verifiziert)

- `node --check app.js` → OK.
- `node scripts/self-audit.mjs` → **5 Findings, 0 Errors, 1 Warn, 3 Infos, 1 OK**.
- Verbleibende Findings sind alle „later / nicht in dieser PR":
  - `dsgvo-analytics-inert` (OK, `analytics.php` kann nach Deploy-Verifikation gelöscht werden — bewusst separat).
  - `size-app.js/functions.php/styles.css-watch` (Info, Monolith-Warnung ohne akuten Handlungsbedarf).
  - `no-tests` (Warn, ist P1-Sprint-Punkt — verdient eigene PR).

### Was NICHT läuft / bewusst ausgelassen

- **`analytics.php` löschen** — braucht kurz Live-Deploy-Verifikation, mache ich in einer eigenen kleinen PR wenn du's grün gibst.
- **Playwright-Smoke-Suite** (`no-tests`) — echter Aufwand, kein Kosmetik-Fix; das ist eine eigene Sprint-Runde (Roadmap P1 Regressionsschutz).
- **Monolith-Splitting** (`app.js` 23k Zeilen, `styles.css` 16k Zeilen) — sinnvoll nur beim nächsten Feature, nicht in einer chore-PR.

### Rollback

Falls irgendwas komisch aussieht: einfach diese PR schließen — `main` bleibt unangetastet, deploy triggert erst nach Merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaFtcRDzPPTkNvkX4duYue)_