### PR TITLE
docs(status): Vault-Snapshot 2026-07-24 — was läuft, was steht, was auf dich wartet

### DIFF
--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,12 +1,12 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-07-24T11:06:21Z",
+  "commit": "9b1b5ab",
   "counts": {
-    "total": 7,
+    "total": 8,
     "error": 0,
     "warn": 2,
-    "info": 4,
+    "info": 5,
     "ok": 1
   },
   "findings": [
@@ -21,6 +21,19 @@
       "evidence": null
     },
     {
+      "id": "docs-routes-drift",
+      "title": "Vault-Doku zählt 84 REST-Routen, Code hat 82",
+      "area": "docs",
+      "severity": "info",
+      "status": "open",
+      "detail": "vault/AI-Gedaechtnis/Claude-Kontext.md weicht von functions.php ab.",
+      "suggestion": "In Claude-Kontext.md auf „82 Route-Registrierungen\" aktualisieren.",
+      "evidence": {
+        "documented": 84,
+        "actual": 82
+      }
+    },
+    {
       "id": "route-admin-mod-missing",
       "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
       "area": "backend",
@@ -32,40 +45,40 @@
     },
     {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (23460 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 23460,
         "threshold": 20000
       }
     },
     {
       "id": "size-functions.php-watch",
-      "title": "functions.php wächst (7718 Zeilen)",
+      "title": "functions.php wächst (7737 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 7718,
+        "lines": 7737,
         "threshold": 6000
       }
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16676 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16676,
         "threshold": 12000
       }
     },

--- a/vault/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/AI-Gedaechtnis/Claude-Kontext.md
@@ -140,17 +140,30 @@ navigateTo('admin')         // Admin-Panel
 - **CI/Deploy:** Neuer Workflow `.github/workflows/security.yml` (php -l alle + node --check + Pattern-Scan, läuft bei Push/PR). Minifier-Versionen gepinnt (`terser@5.48.0`, `csso-cli@5.0.5`) — Ursache eines früheren Ausfalls (unpinned `npx` zog kaputtes terser-Release). `SECURITY.md` mit Responsible-Disclosure-Policy.
 - **Offen (User-Seite):** Postfach `security@eventbörse.de` einrichten; optional CDN-SRI/Self-Hosting (von CI-Umgebung nicht möglich, Outbound geblockt); strikte CSP ohne `'unsafe-inline'` würde Inline-Handler-Refactor erfordern (groß, bewusst zurückgestellt).
 
-## Stand 2026-06-26 — Admin-Bildmoderation & Security-Härtung (live auf main)
+## Stand 2026-07-24 — Auto-Routinen: was läuft, was nicht
 
-- **Admin-Bildmoderation (umgesetzt):** Admins können einzelne Bilder löschen
-  - Detailseite: roter „Löschen"-Button pro Galerie-Bild (`adminDeleteListingImage`).
-  - Provider-Portfolio: Lösch-Overlay (`adminDeleteProfileImage`) + Lightbox-Button, dauerhaft sichtbar.
-  - Backend: `POST /admin/moderate-image` (nur Admin) entfernt Bild aus `eb_gallery` + allen Listings des Nutzers.
-  - **Persistente Blocklist** (`eb_demo_image_blocklist`, normalisierte Pfade) → wirkt auch für hardcodierte Demo-Listings (z. B. Blumenträume München, Pyroshock), reload-fest. Client: `window.EB_IMG_BLOCKLIST` via `eventboerseApi.imageBlocklist`, gefiltert in Demo-LISTINGS, `loadDbListings`, `loadProvider`.
-  - Damit ist der alte Sprint-P0 „Admin-Moderation gegen Code abgleichen" erledigt.
-- **Security (live):** XSS-Härtung (`_escHtml` encodet jetzt auch Quotes; Map-/Card-Render escapt); Brute-Force-Rate-Limiting verdrahtet (`includes/security/rate-limit.php` war vorher nie eingebunden) auf Login/OTP/Reset/Register mit Reset-on-Success; CSP `'unsafe-eval'` entfernt (Frontend nutzt kein eval, kein jQuery); WP-User-Enumeration gesperrt (`/wp/v2/users` + `?author=N`).
-- **CI/Deploy:** Neuer Workflow `.github/workflows/security.yml` (php -l alle + node --check + Pattern-Scan, läuft bei Push/PR). Minifier-Versionen gepinnt (`terser@5.48.0`, `csso-cli@5.0.5`) — Ursache eines früheren Ausfalls (unpinned `npx` zog kaputtes terser-Release). `SECURITY.md` mit Responsible-Disclosure-Policy.
-- **Offen (User-Seite):** Postfach `security@eventbörse.de` einrichten; optional CDN-SRI/Self-Hosting (von CI-Umgebung nicht möglich, Outbound geblockt); strikte CSP ohne `'unsafe-inline'` würde Inline-Handler-Refactor erfordern (groß, bewusst zurückgestellt).
+**Läuft ✅**
+- `ionos-deploy.yml` — jeder Push auf `main` deployt via SFTP (letzter Erfolg: 2026-07-24 05:24 UTC).
+- `site-monitor.yml` — Keep-Alive stündlich grün.
+- `security.yml`, `pr-check.yml` — greifen bei PRs.
+- **Session-basierte Selbstverbesserung (Claude-Code-Sessions wie diese)** — hat in den letzten Tagen die Draft-PRs #74/#76/#77 erzeugt.
+
+**Steht ❌ (blockiert seit ~5 Wochen — Ursache: fehlendes API-Guthaben)**
+- `claude-auto-audit.yml` — letzte 3 Läufe (Jul 20, Jul 13, Jun 1) alle rot. Fehler: `Your credit balance is too low to access the Anthropic API` (`ANTHROPIC_API_KEY` ohne Guthaben).
+- `claude-improve.yml` — letzte 3 Läufe (Jul 20, Jul 13, Jul 9) alle rot. Gleiche Ursache (`terminal_reason=api_error`, `input_tokens=0`).
+
+**Nutzer-Action nötig:** Anthropic-Konto aufladen ODER Repo-Secret `ANTHROPIC_API_KEY` auf einen neuen Key mit Guthaben umstellen. Alternative: die Auto-Routinen bewusst pausieren, weil die Session-basierte Selbstverbesserung dieselbe Rolle inzwischen abdeckt.
+
+**Offene Draft-PRs zum Zustimmen/Ablehnen (Approve-Reject-Flow)**
+- **#77** Playwright-Smoke-Suite (Regressionsschutz P0, 6 Tests, kein Live-Verhalten).
+- **#76** `EB_DEBUG`-Gate + Vault-/Audit-Konsistenz (17 `console.*`-Aufrufe hinter Debug-Flag, Doku-Fix).
+- **#74** `analytics.php` löschen + Vault-Route-Count 84→82 (reine Hygiene).
+- **#46** Großes Release-Paket (Juni 9, still open) — Admin-Moderation + Stripe Refunds/Disputes + Web-Push + PWA + JSON-LD + Routing-Fix. **Prüfen, ob Inhalte in der Zwischenzeit anderweitig gemerged wurden.**
+
+**Aktueller Self-Audit (`node scripts/self-audit.mjs`)**
+- 8 Findings: 0 Errors, 2 Warnings, 5 Info, 1 OK.
+- Warns: `route-admin-mod-missing` (Vault-Notiz vs Code), `no-tests` (adressiert durch PR #77).
+- Infos: `docs-routes-drift` (84→82, adressiert durch PR #74/#76), `console-noise` (17 Aufrufe, adressiert durch PR #76), `size-*-watch` (Monolith-Wachstum: app.js 23460, functions.php 7737, styles.css 16676 Zeilen).
 
 ---
-*Zuletzt aktualisiert: 2026-06-26*
+*Zuletzt aktualisiert: 2026-07-24*


### PR DESCRIPTION
## Was ich gemacht habe

Kurze Selbstinventur der Auto-Verbesserungs-Infrastruktur, weil du wissen wolltest **was läuft, was nicht, wie** — und ob überhaupt noch etwas „von selbst" passiert.

**Nur Doku-Update im Vault + fresh Self-Audit** — kein Live-Verhalten, kein Deploy-Impact (SFTP schaut nur auf Theme-Assets, `vault/` + `audit/` sind nicht in der Deploy-Payload).

## Der wichtigste Fund 🔴

**Beide GitHub-Actions-basierten Auto-Routinen sind seit ~5 Wochen kaputt — und niemand hat's gesehen.**

| Workflow | Letzte 3 Läufe | Fehler |
|----------|---------------|--------|
| `claude-improve.yml` (wöchentlich Mo 05:00 UTC) | Jul 20 ❌ · Jul 13 ❌ · Jul 9 ❌ | `terminal_reason: api_error`, `input_tokens: 0` |
| `claude-auto-audit.yml` (wöchentlich Mo 04:00 UTC) | Jul 20 ❌ · Jul 13 ❌ · Jun 1 ❌ | `API-Fehler 400: Your credit balance is too low to access the Anthropic API` |

**Ursache:** Der `ANTHROPIC_API_KEY` im Repo-Secret hat kein Guthaben mehr. Beide Workflows zünden zwar, aber Claude bekommt sofort ein 400 zurück und die Step endet mit `is_error=true` (Fix im Workflow, dass der Schritt jetzt tatsächlich rot wird statt still zu no-op'en, ist schon eingebaut — hat aber niemand gesehen weil das HQ-Dashboard offenbar nicht aktiv beobachtet wird).

**Deine Optionen:**
1. **Aufladen** — Anthropic-Konto füllen ODER Repo-Secret `ANTHROPIC_API_KEY` auf einen neuen Key mit Guthaben umstellen. Ab dann tickt die wöchentliche Auto-Verbesserung wieder.
2. **Bewusst pausieren** — die Session-basierte Selbstverbesserung (Claude-Code-Sessions wie diese hier) macht inzwischen dieselbe Arbeit — sie hat in den letzten Tagen die Draft-PRs #74, #76, #77 erzeugt.

## Was gerade läuft ✅

- `ionos-deploy.yml` — jeder Push auf `main` deployt sauber via SFTP (letzter Erfolg: 2026-07-24 05:24 UTC nach Commit `9b1b5ab`).
- `site-monitor.yml` — Keep-Alive stündlich grün.
- `security.yml`, `pr-check.yml` — greifen bei jedem PR.
- **Session-basierte Selbstverbesserung** — funktioniert, produziert reviewfertige Draft-PRs.

## Was auf deine Zustimmung wartet 🟡

Vier offene Draft-PRs im Approve/Reject-Format:

| PR | Was | Risiko |
|----|-----|--------|
| **#77** | Playwright-Smoke-Suite (6 Tests: browse/detail/board/feed/favoriten laden + Selbstbuchungs-Guard). Erledigt den `no-tests`-Warn. | Sehr gering (Dev-Infra, kein Live-Impact) |
| **#76** | 17 `console.*` hinter `EB_DEBUG`-Flag + Vault-Konsistenz-Fixes. | Sehr gering (reine Kosmetik) |
| **#74** | `analytics.php` löschen (seit `2026-06-20` inerte No-Op) + Vault-Route-Count 84→82. | Sehr gering (nur Datei-Cleanup) |
| **#46** | Großes Release-Paket vom **Juni 9** — Admin-Moderation + Stripe Refunds/Disputes + Web-Push + PWA + JSON-LD. **Prüfen ob Inhalte inzwischen schon gemerged wurden**, sonst rebasen oder schließen. |  Möglicherweise überholt |

## Aktueller Self-Audit

`node scripts/self-audit.mjs` → **8 Findings, 0 Errors, 2 Warns, 5 Info, 1 OK**. Die zwei Warns (`route-admin-mod-missing`, `no-tests`) sind beide durch offene PRs adressiert.

## Zustimmen / Ablehnen

- **Zustimmen (Merge):** Vault-Kontext ist auf dem heutigen Stand — die nächste Claude-Session sieht sofort was gerade offen ist und muss nicht wieder alles neu ausgraben. Duplizierte 2026-06-26-Sektion im Vault ist bereinigt.
- **Ablehnen (Close):** nichts passiert, `main` bleibt unangetastet. Der Fund zu den kaputten Auto-Routinen bleibt trotzdem in dieser PR-Beschreibung dokumentiert.

## Diff

- `vault/AI-Gedaechtnis/Claude-Kontext.md` (+35 Zeilen, -21 Zeilen) — neue „Stand 2026-07-24"-Sektion ersetzt duplizierte 2026-06-26-Sektion.
- `audit/latest.json` — auf heutigen Commit (`9b1b5ab`) neu erzeugt (8 Findings statt 7 vom Jul 19 — `docs-routes-drift` ist neu).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YG6U54R7zAkyYEhDPFDAU9)_