### PR TITLE
feat(hq): „Änderungen zur Freigabe" — Approve/Reject direkt im HQ

### DIFF
--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,11 +1,11 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-07-25T14:34:10Z",
+  "commit": "e4b56bf",
   "counts": {
-    "total": 7,
+    "total": 6,
     "error": 0,
-    "warn": 2,
+    "warn": 1,
     "info": 4,
     "ok": 1
   },
@@ -21,51 +21,41 @@
       "evidence": null
     },
     {
-      "id": "route-admin-mod-missing",
-      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
-      "area": "backend",
-      "severity": "warn",
-      "status": "open",
-      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
-      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
-      "evidence": null
-    },
-    {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (23892 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 23892,
         "threshold": 20000
       }
     },
     {
       "id": "size-functions.php-watch",
-      "title": "functions.php wächst (7718 Zeilen)",
+      "title": "functions.php wächst (7800 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 7718,
+        "lines": 7800,
         "threshold": 6000
       }
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16676 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16676,
         "threshold": 12000
       }
     },

--- a/hq.html
+++ b/hq.html
@@ -417,6 +417,51 @@
   }
   .finding-actions { display:flex; gap:.4rem; margin-top:.6rem; flex-wrap:wrap; }
 
+  /* ── Pull requests (Änderungen zur Freigabe) ── */
+  .pulls { display:grid; gap:.7rem; margin-bottom:2rem; }
+  .pull-card {
+    background:var(--surface); border:1px solid var(--border); border-radius:13px;
+    padding:.9rem 1rem; transition:border-color .2s, transform .15s; position:relative;
+  }
+  .pull-card:hover { border-color:var(--violet); }
+  .pull-card.ci-fail { border-color:rgba(239,68,68,.45); }
+  .pull-card.ci-pending { border-color:rgba(245,158,11,.4); }
+  .pull-card.ci-ok { border-color:rgba(34,197,94,.4); }
+  .pull-head { display:flex; align-items:center; gap:.5rem; margin-bottom:.45rem; flex-wrap:wrap; }
+  .pull-num { font-family:monospace; color:var(--cyan); font-weight:800; font-size:.82rem; }
+  .pull-title { flex:1; font-weight:700; font-size:.94rem; line-height:1.35; min-width:0; word-break:break-word; }
+  .pull-badge {
+    font-size:.62rem; padding:.14rem .5rem; border-radius:6px; font-weight:700;
+    letter-spacing:.04em; text-transform:uppercase; border:1px solid var(--border);
+    background:var(--surface2); color:var(--muted); white-space:nowrap;
+  }
+  .pull-badge.draft { background:rgba(148,163,184,.14); color:#cbd5e1; border-color:rgba(148,163,184,.35); }
+  .pull-badge.ready { background:rgba(124,58,237,.14); color:#c4b5fd; border-color:rgba(124,58,237,.45); }
+  .pull-badge.ci-ok { background:rgba(34,197,94,.12); color:#86efac; border-color:rgba(34,197,94,.45); }
+  .pull-badge.ci-fail { background:rgba(239,68,68,.14); color:#fca5a5; border-color:rgba(239,68,68,.5); }
+  .pull-badge.ci-pending { background:rgba(245,158,11,.14); color:#fcd34d; border-color:rgba(245,158,11,.45); }
+  .pull-meta { color:var(--muted); font-size:.74rem; margin-bottom:.5rem; }
+  .pull-summary {
+    font-size:.8rem; color:var(--text); opacity:.85; line-height:1.5; margin-bottom:.7rem;
+    max-height:5.4em; overflow:hidden; position:relative;
+  }
+  .pull-summary::after {
+    content:''; position:absolute; bottom:0; left:0; right:0; height:1.6em;
+    background:linear-gradient(to bottom, transparent, var(--surface)); pointer-events:none;
+  }
+  .pull-actions { display:flex; gap:.4rem; flex-wrap:wrap; }
+  .btn-approve {
+    background:linear-gradient(135deg, #22c55e, #16a34a); color:#04180a; border:none;
+    font-weight:800; padding:.4rem .85rem;
+  }
+  .btn-approve:hover:not(:disabled) { transform:translateY(-1px); box-shadow:var(--glow) rgba(34,197,94,.45); }
+  .btn-approve:disabled { opacity:.5; cursor:not-allowed; transform:none; box-shadow:none; }
+  .btn-reject {
+    background:rgba(239,68,68,.1); color:#fca5a5;
+    border:1px solid rgba(239,68,68,.5); font-weight:700; padding:.4rem .85rem;
+  }
+  .btn-reject:hover:not(:disabled) { background:rgba(239,68,68,.18); }
+
   @media (max-width: 720px) {
     .hud-stats { grid-template-columns: 1fr 1fr; }
     .release-top { flex-direction: column; gap: .3rem; }
@@ -538,6 +583,15 @@
     <div class="findings" id="findings-list">
       <div class="skeleton" style="height:80px;"></div>
       <div class="skeleton" style="height:80px;"></div>
+    </div>
+
+    <!-- Änderungen zur Freigabe (Draft-PRs) -->
+    <div class="section-header">
+      <div class="section-title">🟡 Änderungen zur Freigabe <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— zustimmen oder ablehnen</span></div>
+      <div class="section-badge" id="pulls-badge">–</div>
+    </div>
+    <div class="pulls" id="pulls-list">
+      <div class="skeleton" style="height:120px;"></div>
     </div>
 
     <!-- Quests -->
@@ -765,6 +819,54 @@ async function loadIssues() {
     state.issues = all.filter(i => !i.pull_request);
     cacheSet('issues', { issues: state.issues, pulls: state.pulls });
   } catch { const c = cacheGet('issues'); if (c) { state.issues = c.data.issues; state.pulls = c.data.pulls; } }
+}
+
+/* ─── Pull-Requests mit CI-Status (für „Änderungen zur Freigabe") ── */
+async function loadPulls() {
+  try {
+    const list = await gh('/pulls?state=open&per_page=30&sort=updated&direction=desc');
+    await Promise.all(list.map(async (pr) => {
+      const sha = pr.head && pr.head.sha;
+      if (!sha) { pr._ci = 'unknown'; return; }
+      // Combined commit status + check_runs — one may be empty depending on setup
+      try { const s = await gh(`/commits/${sha}/status`); pr._status = s && s.state; }
+      catch { pr._status = null; }
+      try { const cr = await gh(`/commits/${sha}/check-runs`); pr._checkRuns = (cr && cr.check_runs) || []; }
+      catch { pr._checkRuns = []; }
+      pr._ci = combinedCiState(pr);
+    }));
+    state.pullsDetailed = list;
+    cacheSet('pullsDetailed', list);
+  } catch {
+    const c = cacheGet('pullsDetailed'); if (c) state.pullsDetailed = c.data;
+  }
+}
+
+function combinedCiState(pr) {
+  const runs = pr._checkRuns || [];
+  if (runs.length) {
+    if (runs.some(r => r.status !== 'completed')) return 'pending';
+    if (runs.some(r => ['failure', 'cancelled', 'timed_out'].includes(r.conclusion))) return 'failure';
+    return 'success';
+  }
+  const s = pr._status;
+  if (s === 'success' || s === 'failure' || s === 'pending') return s;
+  return 'unknown';
+}
+
+function pullSummary(body) {
+  if (!body) return '';
+  const t = String(body)
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^#{1,6}\s.*$/gm, '')
+    .replace(/^[-*|>].*$/gm, '')
+    .replace(/[*_`~]/g, '')
+    .split('\n').map(l => l.trim()).filter(Boolean)
+    .slice(0, 3).join(' ');
+  return t.length > 280 ? t.slice(0, 277) + '…' : t;
 }
 
 /* ─── XP / Level / Streak ──────────────────────────────────────── */
@@ -1174,17 +1276,21 @@ function celebrateLevelUp(lvl, rank) {
 /* ─── Init / refresh ───────────────────────────────────────────── */
 function renderFromCache() {
   const c = cacheGet('commits'), r = cacheGet('runs'), i = cacheGet('issues'), tc = cacheGet('totalCommits');
+  const pd = cacheGet('pullsDetailed');
   if (c) state.commits = c.data; if (r) state.runs = r.data;
   if (i) { state.issues = i.data.issues || []; state.pulls = i.data.pulls || []; }
+  if (pd) state.pullsDetailed = pd.data;
   if (tc) state.totalCommits = tc.data;
   if (r) state.deploySuccessCount = state.runs.filter(x => /ionos-deploy\.yml$/.test(x.path || '') && x.conclusion === 'success').length;
   if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); }
+  if (pd) renderPulls();
 }
 
 async function loadAll() {
   try {
-    await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadTotalCommits()]);
+    await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadPulls(), loadTotalCommits()]);
     renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots();
+    renderPulls();
     renderQuests(); renderAchievements(); renderHud();
   } catch (e) {
     if (state.rateLimited) { $('releases-list').innerHTML = `<div class="err">⏳ ${escHtml(e.message)}</div>`; requirePat(); }
@@ -1275,6 +1381,124 @@ async function loadSelfAudit() {
   }).join('');
 }
 
+/* ─── Änderungen zur Freigabe (Draft-PRs) ──────────────────────── */
+function renderPulls() {
+  const list = $('pulls-list'), badge = $('pulls-badge');
+  const items = state.pullsDetailed || [];
+  if (!items.length) {
+    badge.textContent = '0';
+    list.innerHTML = '<div class="empty" style="padding:1rem;border:1px dashed var(--border);border-radius:12px;color:var(--muted);text-align:center;">✅ Keine offenen Änderungen — alles gemerged oder abgelehnt.</div>';
+    return;
+  }
+  badge.textContent = String(items.length);
+  list.innerHTML = items.map(pr => {
+    const ci = pr._ci || 'unknown';
+    const isDraft = !!pr.draft;
+    const canMerge = ci === 'success';
+    const ciBadge = ci === 'success' ? '<span class="pull-badge ci-ok">✅ CI grün</span>'
+      : ci === 'failure' ? '<span class="pull-badge ci-fail">❌ CI rot</span>'
+      : ci === 'pending' ? '<span class="pull-badge ci-pending">🔄 CI läuft</span>'
+      : '<span class="pull-badge ci-pending">⏳ CI unklar</span>';
+    const stateBadge = isDraft ? '<span class="pull-badge draft">Draft</span>' : '<span class="pull-badge ready">Bereit</span>';
+    const summary = pullSummary(pr.body);
+    const sha = (pr.head && pr.head.sha) || '';
+    const approveTitle = canMerge
+      ? 'Squash-Merge, danach deployt IONOS automatisch'
+      : ci === 'failure' ? 'CI ist rot — bitte zuerst PR-Ergebnis prüfen'
+      : 'CI läuft noch — bitte kurz warten';
+    return `
+      <div class="pull-card ci-${ci === 'unknown' ? 'pending' : ci}" data-pr="${pr.number}">
+        <div class="pull-head">
+          <span class="pull-num">#${pr.number}</span>
+          <div class="pull-title">${escHtml(pr.title || '')}</div>
+          ${stateBadge}
+          ${ciBadge}
+        </div>
+        <div class="pull-meta">${escHtml((pr.user && pr.user.login) || '')} · aktualisiert ${humanDate(pr.updated_at)}</div>
+        ${summary ? `<div class="pull-summary">${escHtml(summary)}</div>` : ''}
+        <div class="pull-actions">
+          <a class="btn" href="${escHtml(pr.html_url)}" target="_blank" rel="noopener">🔎 Details</a>
+          <button class="btn btn-approve" data-approve-pr="${pr.number}" data-approve-sha="${escHtml(sha)}" ${canMerge ? '' : 'disabled'} title="${escHtml(approveTitle)}">🟢 Zustimmen (Merge)</button>
+          <button class="btn btn-reject" data-reject-pr="${pr.number}">🔴 Ablehnen (Schließen)</button>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+async function refreshPulls() { await loadPulls(); renderPulls(); renderHud(); }
+
+async function approvePr(number, sha) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token nötig, um zu mergen', 'error'); sfx('error'); return; }
+  if (!confirm(`PR #${number} zustimmen und mergen?\n\nAblauf: Draft → Ready → Squash-Merge → Deploy nach IONOS läuft automatisch.`)) return;
+  const btn = document.querySelector(`[data-approve-pr="${number}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Merge läuft…'; }
+  try {
+    // 1) Draft aufheben, falls nötig (GraphQL: markPullRequestReadyForReview)
+    const gq = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: `query($o:String!,$n:String!,$p:Int!){repository(owner:$o,name:$n){pullRequest(number:$p){id isDraft}}}`,
+        variables: { o: REPO.split('/')[0], n: REPO.split('/')[1], p: number },
+      }),
+    }).then(r => r.json()).catch(() => null);
+    const pr = gq && gq.data && gq.data.repository && gq.data.repository.pullRequest;
+    if (pr && pr.isDraft) {
+      const ready = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${getPat()}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: `mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){pullRequest{id}}}`,
+          variables: { id: pr.id },
+        }),
+      }).then(r => r.json());
+      if (ready && ready.errors && ready.errors.length) {
+        throw new Error('Draft → Ready fehlgeschlagen: ' + ready.errors[0].message);
+      }
+    }
+    // 2) Squash-Merge
+    const mergeRes = await fetch(`https://api.github.com/repos/${REPO}/pulls/${number}/merge`, {
+      method: 'PUT',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ merge_method: 'squash', sha }),
+    });
+    if (!mergeRes.ok) {
+      const err = await mergeRes.json().catch(() => ({}));
+      throw new Error(err.message || `HTTP ${mergeRes.status}`);
+    }
+    showToast(`✅ PR #${number} gemerged — Deploy läuft`, 'success');
+    sfx('success');
+    if (typeof confettiBurst === 'function') confettiBurst(0.5, 0.5, 80);
+    setTimeout(refreshPulls, 3500);
+    setTimeout(refreshRuns, 8000);
+  } catch (e) {
+    showToast(`❌ Merge fehlgeschlagen: ${e.message}`, 'error');
+    sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '🟢 Zustimmen (Merge)'; }
+  }
+}
+
+async function rejectPr(number) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token nötig, um zu schließen', 'error'); sfx('error'); return; }
+  if (!confirm(`PR #${number} ablehnen und schließen? Kein Merge, kein Deploy.`)) return;
+  const btn = document.querySelector(`[data-reject-pr="${number}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Schließe…'; }
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${number}`, {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'closed' }),
+    });
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.message || `HTTP ${res.status}`); }
+    showToast(`🚫 PR #${number} geschlossen`, 'success'); sfx('click');
+    setTimeout(refreshPulls, 1500);
+  } catch (e) {
+    showToast(`❌ Schließen fehlgeschlagen: ${e.message}`, 'error');
+    sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '🔴 Ablehnen (Schließen)'; }
+  }
+}
+
 /* ─── Wiring ───────────────────────────────────────────────────── */
 $('auth-btn').addEventListener('click', checkAuth);
 $('auth-input').addEventListener('keydown', e => { if (e.key === 'Enter') checkAuth(); });
@@ -1300,6 +1524,8 @@ document.addEventListener('click', e => {
   const q = e.target.closest('[data-quest]'); if (q) { toggleQuest(q.dataset.quest); return; }
   const rb = e.target.closest('[data-rollback]'); if (rb) { openRollback(rb.dataset.rollback, rb.dataset.msg); return; }
   const tb = e.target.closest('[data-trigger]'); if (tb) { triggerBot(tb.dataset.trigger, tb.dataset.bot); return; }
+  const ap = e.target.closest('[data-approve-pr]'); if (ap) { approvePr(Number(ap.dataset.approvePr), ap.dataset.approveSha); return; }
+  const rj = e.target.closest('[data-reject-pr]'); if (rj) { rejectPr(Number(rj.dataset.rejectPr)); return; }
 });
 
 // Keyboard shortcuts

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -9,6 +9,26 @@ tags: [layer/L5, domain/evolution, share/internal]
 
 > Ziel: Die beste und funktionalste Eventplattform für jedermann
 
+## Zuletzt abgeschlossen (2026-07-25, Abend-Nachtrag)
+
+- [x] **HQ: „Änderungen zur Freigabe" — Approve/Reject direkt aus dem Dashboard**
+  - Neue Sektion in `hq.html` zwischen Selbstcheck und Quests: listet alle offenen
+    Draft-PRs mit CI-Status (grün/rot/gelb), letztem Update, Kurzbeschreibung.
+  - **🟢 Zustimmen (Merge)** löst Draft-Ready-Umschaltung (GraphQL
+    `markPullRequestReadyForReview`) + Squash-Merge (REST) aus — Deploy nach IONOS
+    läuft danach automatisch via `ionos-deploy.yml`. Button ist **disabled** solange
+    CI nicht grün ist (Schutz gegen versehentliche rote Merges).
+  - **🔴 Ablehnen (Schließen)** schließt den PR ohne Merge (`PATCH state=closed`).
+  - PAT wird wie bisher aus `sessionStorage.hq_pat` gelesen (`repo`+`workflow`-Scope
+    reicht — Konto-Owner). Ohne PAT: Buttons zeigen Fehler + Fokus zurück auf PAT-Eingabe.
+  - Datenfluss: `loadPulls()` liefert `/pulls?state=open`, dann parallel je PR
+    `/commits/{sha}/status` + `/commits/{sha}/check-runs` (kombiniert in
+    `combinedCiState()`). Ergebnis wird stale-while-revalidate gecacht wie die
+    anderen HQ-Daten.
+  - **Warum:** Bis eben lagen 4 Draft-PRs (#74, #76, #77, #78) auf `main` und
+    warteten — sichtbar war nur ein Zähler „Offene Tickets 4". Ab jetzt zeigt HQ
+    jede Änderung als Karte mit One-Klick-Entscheidung.
+
 ## Zuletzt abgeschlossen (2026-07-25, Nachtrag)
 
 - [x] **Gebührenmodell wirtschaftlich korrigiert: Stripe-Gebühr trägt der Dienstleister**


### PR DESCRIPTION
## Was läuft, was nicht — Kurzstand vor Merge

Du hast in der Routine gefragt: *„Der Code soll sich verbessern und mir zeigen was läuft, was nicht, damit ich Änderungen nur noch zustimmen/ablehnen muss."*

Die Infrastruktur dafür existierte schon (`claude-improve.yml` erzeugt Draft-PRs, `hq.html` = Mission Control), aber **im HQ waren die offenen PRs nur ein Zähler** ("Offene Tickets 4"). Diese PR schließt die Lücke.

## Der Fund vor dem Fix

- **4 Draft-PRs seit 4–5 Tagen ungereviewt** — alle CI-grün, alle nur auf dich wartend:
  - `#78` Vault-Snapshot 2026-07-24 · CI ✅
  - `#77` Playwright-Smoke-Suite · CI ✅
  - `#76` EB_DEBUG-Gate + Vault-Konsistenz · CI ✅
  - `#74` `analytics.php` löschen + Vault-Route-Count · CI ✅
- `#46` liegt seit **Juni 9** — großes Release-Paket, wahrscheinlich überholt (bitte separat prüfen).
- **`claude-improve.yml` (wöchentliche Auto-Verbesserung) ist seit ~5 Wochen kaputt** — laut PR #78 hat der `ANTHROPIC_API_KEY` im Repo-Secret kein Guthaben mehr (`400: credit balance too low`). Session-basierte Selbstverbesserung (wie diese hier) übernimmt gerade die Arbeit.
- Self-Audit: **6 Findings (0 err · 1 warn · 4 info · 1 ok)**, alle offenen sind durch die anderen PRs adressiert.

## Was diese PR ändert (nur HQ, kein Live-App-Verhalten)

Neue Sektion **„🟡 Änderungen zur Freigabe"** in `hq.html`, direkt zwischen Selbstcheck und Quests. Jede offene PR wird als Karte gerendert:

| Element | Verhalten |
|---------|-----------|
| **CI-Badge** | ✅ grün / ❌ rot / 🔄 gelb — kombiniert aus `/commits/{sha}/status` + `/commits/{sha}/check-runs` |
| **Draft/Ready-Badge** | zeigt aktuellen Status |
| **Kurzbeschreibung** | erste 3 Nicht-Header-Zeilen des PR-Bodys, Markdown gestrippt |
| **🟢 Zustimmen (Merge)** | GraphQL `markPullRequestReadyForReview` → Squash-Merge → Deploy nach IONOS läuft automatisch. **Disabled solange CI nicht grün ist.** |
| **🔴 Ablehnen (Schließen)** | `PATCH state=closed` — kein Merge, kein Deploy |
| **🔎 Details** | Link zur PR auf GitHub, falls du doch reinschauen willst |

PAT wird wie bisher aus `sessionStorage.hq_pat` gelesen (`repo`+`workflow`-Scope, wie es das PAT-Notice-Panel schon dokumentiert).

## Was ändert sich nicht

- **`main` unangetastet** — deploy triggert erst nach Merge, und diese PR ist Draft.
- **App-Verhalten** — `app.js`/`functions.php`/`styles.css` nicht angefasst. Nur `hq.html` + Vault-Doku + Audit-Snapshot.
- **Live-Site & Deploy** — SFTP schaut auf Theme-Assets, `hq.html` liegt zwar mit im Theme, aber ändert nur das Dev-Dashboard.
- **Sicherheit** — beide Buttons erfordern PAT + `confirm()`; Merge wird zusätzlich durch CI-Grün-Gate abgesichert.

## Verifikation

- `node --check` implizit über `security.yml` (läuft bei diesem PR mit).
- JS-Syntax im inline `<script>` von `hq.html`: OK (via `new Function()`-Roundtrip).
- `node scripts/self-audit.mjs` → **6 Findings**, unverändert (dieser Feature-PR ist HQ-only, taucht nicht im Audit auf).

## Zustimmen / Ablehnen

- **Zustimmen (Merge):** HQ zeigt ab jetzt jede Draft-PR mit Approve/Reject-Buttons — genau das, was du in der Routine gefragt hast.
- **Ablehnen (Close):** Nichts passiert. `main` bleibt wie sie ist, HQ zeigt weiter nur den Ticket-Zähler.

## Nach dem Merge — meine Empfehlung für die 4 offenen PRs

1. `#77` (Playwright-Suite) **zuerst** — schafft Regression-Schutz für die anderen Merges.
2. `#74` (analytics.php-Cleanup) — trivial, unblockt Audit-Rauschen.
3. `#76` (EB_DEBUG-Gate) — kosmetisch, gering.
4. `#78` (Vault-Snapshot) — reine Doku, kann als letztes.
5. `#46` — bitte separat entscheiden (rebase vs. close), zu alt für Auto-Merge.

Für die kaputte `claude-improve.yml`-Routine: entweder Anthropic-Konto füllen oder Session-basierte Selbstverbesserung (wie hier) als primären Weg akzeptieren und den wöchentlichen Workflow disablen — dann fällt der Rot-Marker im HQ weg.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rq6mDTG5zwozgkAKDojTC6)_