### PR TITLE
chore(audit): Self-Audit-Snapshot auf HEAD refreshen

### DIFF
--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,11 +1,11 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-07-28T11:08:37Z",
+  "commit": "ed0a13b",
   "counts": {
-    "total": 7,
+    "total": 6,
     "error": 0,
-    "warn": 2,
+    "warn": 1,
     "info": 4,
     "ok": 1
   },
@@ -21,51 +21,41 @@
       "evidence": null
     },
     {
-      "id": "route-admin-mod-missing",
-      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
-      "area": "backend",
-      "severity": "warn",
-      "status": "open",
-      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
-      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
-      "evidence": null
-    },
-    {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (23930 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 23930,
         "threshold": 20000
       }
     },
     {
       "id": "size-functions.php-watch",
-      "title": "functions.php wächst (7718 Zeilen)",
+      "title": "functions.php wächst (8266 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 7718,
+        "lines": 8266,
         "threshold": 6000
       }
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16676 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16676,
         "threshold": 12000
       }
     },


### PR DESCRIPTION
## Was läuft, was nicht — Statusmeldung aus der Routine

Diese scheduled Session hat den **Selbstverbesserungs-Pipeline-Status** überprüft (dein Auftrag: „Code soll sich selbst verbessern und zeigen was läuft/nicht — ich sag nur ja/nein"). Ergebnis: die Pipeline **läuft**, aber deine Approve/Reject-Queue **staut sich**.

## Diese PR

Nur ein Refresh von `audit/latest.json` — frischer Lauf von `node scripts/self-audit.mjs` gegen HEAD (`ed0a13b`). **6 Findings statt 7**: `route-admin-mod-missing` fällt weg, weil die Vault-Notiz zu Admin-Moderationsrouten inzwischen korrigiert ist.

| Vorher (2026-07-19, Commit 3c58c41) | Nachher (2026-07-28, Commit ed0a13b) |
|---|---|
| 7 Findings, 0 err · 2 warn · 4 info · 1 ok | 6 Findings, 0 err · **1 warn** · 4 info · 1 ok |

Der verbleibende Warn (`no-tests`) ist durch offenen **PR #77** (Playwright-Smoke-Suite) adressiert.

## Der eigentliche Fund (kein Code-Change, gehört aber in dein Sichtfeld)

**7 offene Draft-PRs warten auf dich** — alle Claude-generierte Selbstverbesserungen, alle mit klarem Approve/Reject-Format:

| PR | Was | Deine Ask direkt? |
|---|---|---|
| **#79** | Approve/Reject-Buttons direkt im HQ | **Ja — löst genau diese Anfrage** |
| #81 | Self-Audit-Skript repariert + 5 neue Checks | Meta-Fix |
| #80 | Vault-Pfade im Self-Audit (Vorgänger von #81) | Obsolet zugunsten #81 |
| #78 | Status-Snapshot vom 24.07. (Doku) | Doku |
| #77 | Playwright-Smoke-Suite (erledigt no-tests-Warn) | Nein, aber Sprint-P0 |
| #76 | EB_DEBUG-Flag (17 console.* ausgeblendet) | Nein, Kosmetik |
| #74 | analytics.php löschen (tote No-Op) | Nein, Cleanup |
| #46 | Großes Release-Paket vom 9. Juni | Wahrscheinlich überholt |

**Kaputt (dein Handeln nötig):** `.github/workflows/claude-improve.yml` (wöchentliche Auto-Verbesserung, Mo 05:00 UTC) schlägt seit ~5 Wochen fehl. Grund: `ANTHROPIC_API_KEY` im Repo-Secret hat kein Guthaben mehr (`400: credit balance too low`). Session-basierte Runden wie diese kompensieren, aber die vollautomatische Runde ist offline bis das Secret erneuert wird.

## Test-Plan
- [ ] `node scripts/self-audit.mjs` läuft, Exit 0, schreibt `audit/latest.json`
- [ ] HQ-Dashboard (`hq.html` → Selbstcheck-Sektion) zeigt die 6 neuen Findings

## Nicht-Ziele
- Kein SPA/API-Verhalten geändert
- Keine neuen Dependencies
- Kein Deploy-Impact (nur `audit/latest.json`, nicht Teil der Theme-SFTP-Payload)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiSYtqa2g8c8GeNuAfnznu)_