### PR TITLE
HQ-Dashboard unter eventbörse.de/hq erreichbar machen

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -263,6 +263,17 @@ function eb_serve_theme_root_file() {
             'type'  => 'image/svg+xml; charset=UTF-8',
             'cache' => 'public, max-age=31536000, immutable',
         ),
+        // HQ-Dashboard: eventbörse.de/hq statt .../wp-content/themes/eventboerse/hq.html
+        '/hq' => array(
+            'file'  => 'hq.html',
+            'type'  => 'text/html; charset=UTF-8',
+            'cache' => 'no-cache, no-store, must-revalidate',
+        ),
+        '/hq/' => array(
+            'file'  => 'hq.html',
+            'type'  => 'text/html; charset=UTF-8',
+            'cache' => 'no-cache, no-store, must-revalidate',
+        ),
     );
 
     if ( ! isset( $files[ $path ] ) ) {


### PR DESCRIPTION
Bisher war das HQ-Dashboard nur unter `.../wp-content/themes/eventboerse/hq.html` erreichbar. Jetzt zusätzlich unter der kurzen URL `eventbörse.de/hq`.

## Umsetzung

Nutzt das bereits vorhandene Muster `eb_serve_theme_root_file()` in `functions.php` (bisher für `manifest.json`, `sw.js`, `favicon.svg` im Einsatz — Theme-Dateien am Origin-Root statt nur im Theme-Pfad ausliefern). `/hq` und `/hq/` liefern jetzt `hq.html` mit `text/html`-Content-Type und `no-cache`, da es sich um ein Live-Dashboard handelt.

Kein neuer Rewrite-Mechanismus, keine neue Abhängigkeit — nur ein weiterer Eintrag in der bestehenden Datei-Tabelle.

## Verifikation
- `php -l functions.php` → sauber
- Die alte URL (`.../wp-content/themes/eventboerse/hq.html`) bleibt unverändert erreichbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_