### PR TITLE
HQ: „Vorschläge zum Freigeben" — Zustimmen/Ablehnen direkt aus dem Dashboard

### DIFF
--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,11 +1,11 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-08-02T11:06:02Z",
+  "commit": "fecf34a",
   "counts": {
-    "total": 7,
+    "total": 5,
     "error": 0,
-    "warn": 2,
+    "warn": 0,
     "info": 4,
     "ok": 1
   },
@@ -21,75 +21,55 @@
       "evidence": null
     },
     {
-      "id": "route-admin-mod-missing",
-      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
-      "area": "backend",
-      "severity": "warn",
-      "status": "open",
-      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
-      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
-      "evidence": null
-    },
-    {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (25013 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 25013,
         "threshold": 20000
       }
     },
     {
       "id": "size-functions.php-watch",
-      "title": "functions.php wächst (7718 Zeilen)",
+      "title": "functions.php wächst (8277 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 7718,
+        "lines": 8277,
         "threshold": 6000
       }
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16893 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16893,
         "threshold": 12000
       }
     },
     {
       "id": "console-noise",
-      "title": "17 console.*-Aufrufe in app.js",
+      "title": "19 console.*-Aufrufe in app.js",
       "area": "cleanup",
       "severity": "info",
       "status": "open",
       "detail": "Aufrufe landen in der Browser-Konsole der Nutzer. Für Production wäre ein Debug-Flag sauberer.",
       "suggestion": "Kosmetik: console-Aufrufe hinter einen `EB_DEBUG`-Flag stellen oder in production strippen.",
       "evidence": {
-        "count": 17
+        "count": 19
       }
-    },
-    {
-      "id": "no-tests",
-      "title": "Keine automatisierten Tests im Repo",
-      "area": "quality",
-      "severity": "warn",
-      "status": "open",
-      "detail": "Bekannte Schwäche aus CLAUDE.md. Ein paar Smoke-Tests gegen die SPA wären schon viel wert.",
-      "suggestion": "Playwright-Smoke-Suite für browse/detail/board/chat (regression-Schutz P0).",
-      "evidence": null
     }
   ]
 }

--- a/hq.html
+++ b/hq.html
@@ -577,6 +577,15 @@
       <div class="skeleton" style="height:80px;"></div>
     </div>
 
+    <!-- Vorschläge zum Freigeben (offene PRs) -->
+    <div class="section-header">
+      <div class="section-title">✅ Vorschläge zum Freigeben <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— zustimmen oder ablehnen</span></div>
+      <div class="section-badge" id="proposals-badge">–</div>
+    </div>
+    <div class="findings" id="proposals-list">
+      <div class="skeleton" style="height:80px;"></div>
+    </div>
+
     <!-- Quests -->
     <div class="section-header">
       <div class="section-title">🎯 Quests <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— die Roadmap</span></div>
@@ -1215,14 +1224,14 @@ function renderFromCache() {
   if (i) { state.issues = i.data.issues || []; state.pulls = i.data.pulls || []; }
   if (tc) state.totalCommits = tc.data;
   if (r) state.deploySuccessCount = state.runs.filter(x => /ionos-deploy\.yml$/.test(x.path || '') && x.conclusion === 'success').length;
-  if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); }
+  if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); renderProposals(); }
 }
 
 async function loadAll() {
   try {
     await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadTotalCommits()]);
     renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots();
-    renderQuests(); renderAchievements(); renderHud();
+    renderQuests(); renderAchievements(); renderHud(); renderProposals();
   } catch (e) {
     if (state.rateLimited) { $('releases-list').innerHTML = `<div class="err">⏳ ${escHtml(e.message)}</div>`; requirePat(); }
     else $('releases-list').innerHTML = `<div class="err">Fehler beim Laden: ${escHtml(e.message)}</div>`;
@@ -1247,6 +1256,95 @@ async function refreshAll() {
   await loadAll();
   renderHud();
   showToast('✅ Aktualisiert', 'success'); sfx('click');
+}
+
+/* ─── Vorschläge (offene PRs mit Zustimmen/Ablehnen) ───────────── */
+function renderProposals() {
+  const list = $('proposals-list'), badge = $('proposals-badge');
+  if (!list) return;
+  const pulls = (state.pulls || []).slice().sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+  badge.textContent = String(pulls.length);
+  if (!pulls.length) {
+    list.innerHTML = '<div class="empty">Keine offenen Vorschläge — alles verarbeitet.</div>';
+    return;
+  }
+  list.innerHTML = pulls.map(p => {
+    const num = p.number;
+    const draft = !!(p.draft || (p.pull_request && p.pull_request.draft));
+    const author = (p.user && p.user.login) || '–';
+    const labels = (p.labels || []).map(l => (l && l.name) || '').filter(Boolean);
+    const isRoutine = labels.some(n => /claude-routine|audit|routine/i.test(n));
+    const kind = isRoutine ? 'Bot-Routine' : (author.endsWith('[bot]') ? 'Bot' : 'Mensch');
+    const body = (p.body || '').replace(/\r/g, '').trim();
+    const preview = body ? (body.length > 260 ? body.slice(0, 260) + '…' : body) : '';
+    const age = humanDate(p.updated_at);
+    return `
+      <div class="finding sev-info" data-pr="${num}">
+        <div class="finding-head">
+          <span>${draft ? '📝' : '🔀'}</span>
+          <div class="finding-title">#${num} · ${escHtml(p.title || '')}</div>
+          <span class="finding-area">${escHtml(kind)}</span>
+        </div>
+        <div class="finding-detail">Von ${escHtml(author)} · Stand ${escHtml(age)}${draft ? ' · Draft' : ''}${labels.length ? ' · ' + escHtml(labels.join(', ')) : ''}</div>
+        ${preview ? `<div class="finding-sugg">${escHtml(preview)}</div>` : ''}
+        <div class="finding-actions">
+          <a class="btn" href="${p.html_url}" target="_blank" rel="noopener">🔎 Diff ansehen</a>
+          <button class="btn btn-primary" data-approve-pr="${num}">✅ Zustimmen &amp; Mergen</button>
+          <button class="btn" data-reject-pr="${num}">❌ Ablehnen</button>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+async function approvePr(num) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token nötig zum Mergen', 'error'); sfx('error'); return; }
+  const btn = document.querySelector(`[data-approve-pr="${num}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Merge…'; }
+  try {
+    const pr = await gh(`/pulls/${num}`);
+    if (pr.draft && pr.node_id) {
+      const g = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: 'mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id}){pullRequest{isDraft}}}',
+          variables: { id: pr.node_id },
+        }),
+      });
+      if (!g.ok) throw new Error('Draft → Bereit fehlgeschlagen (HTTP ' + g.status + ')');
+    }
+    const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${num}/merge`, {
+      method: 'PUT',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ merge_method: 'squash' }),
+    });
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.message || `HTTP ${res.status}`); }
+    showToast('✅ Zusammengeführt — Deploy startet.', 'success'); sfx('success');
+    setTimeout(async () => { await loadIssues(); renderProposals(); animateNum($('s-open'), state.issues.length + state.pulls.length); }, 1500);
+  } catch (e) {
+    showToast(`❌ Merge-Fehler: ${e.message}`, 'error'); sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '✅ Zustimmen & Mergen'; }
+  }
+}
+
+async function rejectPr(num) {
+  if (!getPat()) { requirePat(); showToast('⚠️ GitHub Token nötig zum Schließen', 'error'); sfx('error'); return; }
+  if (!confirm(`Vorschlag #${num} ablehnen (schließen ohne Merge)?`)) return;
+  const btn = document.querySelector(`[data-reject-pr="${num}"]`);
+  if (btn) { btn.disabled = true; btn.textContent = '🔄 Schließe…'; }
+  try {
+    const res = await fetch(`https://api.github.com/repos/${REPO}/pulls/${num}`, {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${getPat()}`, 'Accept': 'application/vnd.github+json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'closed' }),
+    });
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.message || `HTTP ${res.status}`); }
+    showToast('❌ Abgelehnt und geschlossen.', 'success'); sfx('click');
+    setTimeout(async () => { await loadIssues(); renderProposals(); animateNum($('s-open'), state.issues.length + state.pulls.length); }, 700);
+  } catch (e) {
+    showToast(`❌ Fehler: ${e.message}`, 'error'); sfx('error');
+    if (btn) { btn.disabled = false; btn.textContent = '❌ Ablehnen'; }
+  }
 }
 
 /* ─── Self-Audit (liest audit/latest.json) ─────────────────────── */
@@ -1337,6 +1435,8 @@ document.addEventListener('click', e => {
   const q = e.target.closest('[data-quest]'); if (q) { toggleQuest(q.dataset.quest); return; }
   const rb = e.target.closest('[data-rollback]'); if (rb) { openRollback(rb.dataset.rollback, rb.dataset.msg); return; }
   const tb = e.target.closest('[data-trigger]'); if (tb) { triggerBot(tb.dataset.trigger, tb.dataset.bot); return; }
+  const ap = e.target.closest('[data-approve-pr]'); if (ap) { approvePr(ap.dataset.approvePr); return; }
+  const rp = e.target.closest('[data-reject-pr]'); if (rp) { rejectPr(rp.dataset.rejectPr); return; }
 });
 
 // Keyboard shortcuts

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -7,7 +7,7 @@ tags: [layer/L0, domain/kern, share/internal, typ/messung]
 
 # ⚡ Impuls-Strom — der lebende Zustand
 
-> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-01**
+> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-02**
 > Nicht von Hand bearbeiten — jeder Lauf überschreibt die Datei.
 > Diese Notiz misst, was im Netz tatsächlich fließt. Die Ströme selbst
 > sind in [[00-Kern/Wissensstroeme]] beschrieben.
@@ -63,23 +63,23 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **21** |
-| Commits (30 Tage) | 71 |
-| Letzter Commit | `0a241fa · Fable-5-Strang zusammenführen: Testsuite, 22 Module, A11y auf null Verstöße (#85)` (2026-08-01) |
+| Commits (7 Tage) | **24** |
+| Commits (30 Tage) | 60 |
+| Letzter Commit | `fecf34a · HQ-Dashboard unter eventbörse.de/hq erreichbar machen (#88)` (2026-08-02) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
-39 app.js
-     33 styles.css
-     23 index.html
-     23 app-shell.html
+32 app.js
+     24 styles.css
+     17 index.html
+     17 app-shell.html
       9 functions.php
 ```
 
 **Codegröße:**
 - `app.js` — 25.012 Zeilen
 - `styles.css` — 16.892 Zeilen
-- `functions.php` — 8.265 Zeilen
+- `functions.php` — 8.276 Zeilen
 - `app-shell.html` — 3.974 Zeilen
 
 ## Verwandt

--- a/vault/50-Evolution/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/50-Evolution/AI-Gedaechtnis/Claude-Kontext.md
@@ -9,6 +9,26 @@ tags: [layer/L5, domain/evolution, share/internal]
 
 > Diese Datei ist die **erste Quelle** die Claude Code liest. Sie enthält alles Wichtige über Projekt, Präferenzen und offene Aufgaben.
 
+## Stand 2026-08-02 — HQ: „Vorschläge zum Freigeben" (Zustimmen/Ablehnen)
+
+Neue Sektion im HQ direkt unter dem Selbstcheck: alle offenen PRs werden
+mit Titel, Autor, Draft-Status, Labels und Body-Vorschau gelistet. Zwei
+Knöpfe pro Vorschlag:
+
+- **✅ Zustimmen & Mergen** — wandelt Draft in „ready", squasht + merged
+  über die GitHub-REST-API (mit dem im HQ hinterlegten PAT).
+- **❌ Ablehnen** — schließt die PR ohne Merge (mit Bestätigungsdialog).
+
+Ohne PAT: die Buttons öffnen den PAT-Dialog statt zu senden. Nach jeder
+Aktion wird die Liste + der Ticket-Zähler neu geladen. Damit ist der
+Kreis geschlossen: `claude-improve.yml` öffnet den Draft-PR, das HQ
+zeigt ihn, ein Klick reicht — kein Wechsel nach GitHub nötig.
+
+Wired: `renderProposals()` in `hq.html` läuft nach `renderFromCache()`
+und `loadAll()`. Event-Delegation liest `[data-approve-pr]` /
+`[data-reject-pr]`. Kein neuer Bot, kein neuer Endpoint — reine
+Verdrahtung existierender Bausteine.
+
 ## Stand 2026-08-01 — Fable-5-Auftrag umgesetzt (Testsuite, Audit, Module, Design, A11y)
 
 **Die fünf Auftragsschritte sind live auf main. Wichtigste neue Regeln:**


### PR DESCRIPTION
## Warum

Auftrag aus der Session: „Der Code soll sich eigenständig verbessern und mir zeigen was läuft, was nicht — und ich soll Änderungen einfach nur noch zustimmen/ablehnen."

Der `claude-improve.yml`-Bot öffnet bereits wöchentlich Draft-PRs. Aber bisher musste man dafür nach github.com wechseln. Diese PR schließt den Kreis.

## Was

Neue Sektion im HQ direkt unter dem Selbstcheck: **„✅ Vorschläge zum Freigeben"**.

- Listet alle offenen PRs mit Titel, Nummer, Autor, Draft-Status, Labels und Body-Vorschau.
- Zwei Aktionen pro Vorschlag:
  - **✅ Zustimmen & Mergen** — wandelt Draft → „ready" (GraphQL `markPullRequestReadyForReview`), squash-merged via REST.
  - **❌ Ablehnen** — schließt die PR ohne Merge (mit Bestätigungsdialog).
- Ohne GitHub-Token: die Knöpfe öffnen den bereits vorhandenen PAT-Dialog statt zu senden.
- Nach jeder Aktion: Liste + offene-Tickets-Zähler neu laden.

Kein neuer Bot, kein neuer Endpoint — reine Verdrahtung bestehender Bausteine (`state.pulls` war schon geladen, PAT-Flow existiert für Rollback/Trigger).

## Dateien

- `hq.html` — neue Section, `renderProposals()`, `approvePr()`, `rejectPr()`, Event-Delegation.
- `vault/50-Evolution/AI-Gedaechtnis/Claude-Kontext.md` — Änderung dokumentiert.
- `vault/00-Kern/Impuls-Strom.md` — automatisch aktualisiert.
- `audit/latest.json` — frischer Self-Audit-Lauf.

## Test-Plan

- [x] `npm run test:smoke` grün (24/24)
- [x] `npm run gate` grün (KB + Quarantäne + Demo-Feed + app.js-Sync)
- [x] hq.html im Headless-Browser geladen: keine JS-Errors, Section rendert (Skeleton bis GitHub-API antwortet), volle Seite screenshot-verifiziert.
- [ ] Nach Merge: Live-Verifikation, dass die Merge/Close-Aktionen mit echtem PAT funktionieren.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvpqU8jSgjUMWQszH1GwwW)_