### PR TITLE
HQ: /assets/*.json und /audit/*.json ausliefern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-94 Tests in 9 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+99 Tests in 9 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Barrierefreiheit (axe, beide

--- a/functions.php
+++ b/functions.php
@@ -273,6 +273,43 @@ function eb_serve_theme_root_file() {
         return;
     }
 
+    // Datendateien des Themes unter kurzem Pfad: /assets/*.json, /audit/*.json.
+    //
+    // Das HQ läuft unter /hq (und /hq/…), nicht im Theme-Verzeichnis. Ein
+    // relativer Pfad zeigt von dort ins Leere — genau daran scheiterten
+    // Connector-Katalog, Wissensbasis und Selbstcheck.
+    //
+    // Bewusst eng gehalten:
+    //   · nur .json — Skripte und Stile laden bereits über ihren Theme-Pfad,
+    //     eine zweite Route dafür wäre Angriffsfläche ohne Nutzen
+    //   · nur diese beiden Ordner, keine freie Pfadangabe
+    //   · der Dateiname darf keinen Schrägstrich enthalten, und der aufgelöste
+    //     Pfad MUSS im Zielordner liegen. Ohne die zweite Prüfung wäre ein
+    //     Ausbruch nach oben einen Versuch wert
+    //
+    // $path stammt aus parse_url() und ist NICHT dekodiert — %2f bleibt %2f
+    // und fällt schon durch den Zeichensatz des Musters.
+    // Der Dateiname beginnt mit einem Buchstaben oder einer Ziffer — eine
+    // Punktdatei hat in einer öffentlichen Route nichts zu suchen.
+    if ( preg_match( '#^/(assets|audit)/([A-Za-z0-9][A-Za-z0-9._-]*\.json)$#', $path, $m ) ) {
+        $basis = realpath( get_template_directory() . '/' . $m[1] );
+        $ziel  = $basis ? realpath( $basis . '/' . $m[2] ) : false;
+
+        if ( ! $basis || ! $ziel || strpos( $ziel, $basis . DIRECTORY_SEPARATOR ) !== 0 || ! is_file( $ziel ) ) {
+            status_header( 404 );
+            nocache_headers();
+            exit;
+        }
+
+        status_header( 200 );
+        header( 'Content-Type: application/json; charset=UTF-8' );
+        header( 'X-Content-Type-Options: nosniff' );
+        // Kurz genug, dass ein neuer Katalog schnell durchkommt.
+        header( 'Cache-Control: public, max-age=300, must-revalidate' );
+        readfile( $ziel );
+        exit;
+    }
+
     if ( ! isset( $files[ $path ] ) ) {
         return;
     }

--- a/hq.html
+++ b/hq.html
@@ -686,7 +686,7 @@ const SITE_URL = 'https://xn--eventbrse-57a.de/';
 const ROLLBACK_WORKFLOW = 'hq-rollback.yml';
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-const state = { commits: [], runs: [], issues: [], pulls: [], totalCommits: 0, siteUp: null, deploySuccessCount: 0 };
+const state = { commits: [], runs: [], issues: [], pulls: [], totalCommits: 0, siteUp: null, deploySuccessCount: 0, ausCache: false };
 const $ = id => document.getElementById(id);
 
 /* ─── Zugang ───────────────────────────────────────────────────────
@@ -718,6 +718,18 @@ function requirePat() {
   $('pat-notice').style.display = 'flex';
   $('pat-input').focus();
   $('pat-notice').scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+/* ─── Datendateien des Themes ──────────────────────────────────────
+   assets/ und audit/ liegen im Theme-Verzeichnis, das HQ läuft aber unter
+   /hq — bei Tieflinks sogar unter /hq/connections/github. Ein relativer
+   Pfad zeigt von dort jedes Mal woandershin, deshalb wird er absolut
+   aufgelöst. functions.php bedient /assets/*.json und /audit/*.json.
+
+   Ausnahme: wird die Datei direkt geöffnet (…/hq.html, auch file://),
+   liegen die Ordner tatsächlich daneben — dann bleibt es relativ.        */
+function hqAsset(pfad) {
+  return /\.html?$/i.test(location.pathname) ? pfad : '/' + pfad;
 }
 
 /* ─── localStorage cache (stale-while-revalidate) ──────────────── */
@@ -991,7 +1003,11 @@ function renderCommits() {
   const commits = state.commits;
   if (!commits.length) { $('releases-list').innerHTML = '<div class="err">Keine Commits ladbar</div>'; return; }
   const short = commits[0].sha.slice(0, 7);
-  $('header-sha').textContent = `main @ ${short}`;
+  // Aus dem Zwischenspeicher gerenderte Stände sind womöglich Tage alt. Ohne
+  // Kennzeichnung liest man einen fremden SHA als den aktuellen — genau das
+  // ist hier passiert („main @ 97d7eff", während main längst weiter war).
+  // Ein veralteter Wert darf angezeigt werden, aber nicht als frischer.
+  $('header-sha').textContent = `main @ ${short}` + (state.ausCache ? ' · zwischengespeichert' : '');
   $('commits-badge').textContent = `${state.totalCommits || commits.length} Commits`;
 
   const list = $('releases-list'); list.innerHTML = '';
@@ -1231,12 +1247,16 @@ function renderFromCache() {
   if (i) { state.issues = i.data.issues || []; state.pulls = i.data.pulls || []; }
   if (tc) state.totalCommits = tc.data;
   if (r) state.deploySuccessCount = state.runs.filter(x => /ionos-deploy\.yml$/.test(x.path || '') && x.conclusion === 'success').length;
+  // Alles hier stammt aus dem Zwischenspeicher — bis loadAll() frische
+  // Daten bringt, wird das auch so ausgewiesen.
+  state.ausCache = true;
   if (c || r) { renderHud(); renderQuests(); renderAchievements(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderQuickActions(); }
 }
 
 async function loadAll() {
   try {
     await Promise.all([loadCommits(), loadRuns(), loadIssues(), loadTotalCommits()]);
+    state.ausCache = false;   // ab hier sind die Daten nachweislich frisch
     renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots();
     renderQuests(); renderAchievements(); renderHud();
   } catch (e) {
@@ -1274,7 +1294,7 @@ async function loadSelfAudit() {
   // Versuche zuerst lokales File (gleicher Pfad wie hq.html, also Theme-Wurzel),
   // dann GitHub Raw als Fallback (damit hq.html auch standalone funktioniert).
   const tryUrls = [
-    new URL('audit/latest.json', location.href).href + '?t=' + Date.now(),
+    hqAsset('audit/latest.json') + '?t=' + Date.now(),
     `https://raw.githubusercontent.com/${REPO}/main/audit/latest.json`,
   ];
   let data = null;
@@ -1460,7 +1480,7 @@ const CONN_PRUEFUNG = {
 
   async eventboerse() {
     // Gleiche Herkunft — echter Statuscode, keine opake Antwort.
-    const res = await fetch('assets/eb-knowledge.json', { cache: 'no-store' });
+    const res = await fetch(hqAsset('assets/eb-knowledge.json'), { cache: 'no-store' });
     if (!res.ok) return { status: 'fehler', fehler: `Wissensbasis antwortete ${res.status}`, details: [] };
     const kb = await res.json();
     return {
@@ -1636,7 +1656,7 @@ function connTiefenlink() {
 
 async function initConnections() {
   try {
-    const res = await fetch('assets/eb-connectors.json', { cache: 'no-store' });
+    const res = await fetch(hqAsset('assets/eb-connectors.json'), { cache: 'no-store' });
     connKatalog = await res.json();
   } catch {
     $('conns-grid').innerHTML = '<div class="conn-warn">Connector-Katalog nicht ladbar.</div>';
@@ -1754,7 +1774,7 @@ window.addEventListener('DOMContentLoaded', init);
   var KB = null, speakOn = false, rec = null, listening = false;
   var esc = function (t) { var d = document.createElement('div'); d.textContent = String(t == null ? '' : t); return d.innerHTML; };
 
-  fetch('assets/eb-knowledge.json', { cache: 'no-store' })
+  fetch(hqAsset('assets/eb-knowledge.json'), { cache: 'no-store' })
     .then(function (r) { return r.ok ? r.json() : null; })
     .then(function (k) { KB = (k && Array.isArray(k.entries)) ? k : null;
       hintEl.textContent = KB ? (KB.entries.length + ' Wissens-Abschnitte geladen · Antworten nur aus freigegebenem Wissen')

--- a/tests/e2e/verbindungen.spec.js
+++ b/tests/e2e/verbindungen.spec.js
@@ -47,6 +47,62 @@ test.describe('HQ-Zugang', () => {
   });
 });
 
+test.describe('Datendateien erreichbar', () => {
+  // Der konkrete Ausfall: das HQ läuft unter /hq, die Datendateien liegen im
+  // Theme. Ein relativer fetch zeigte von dort ins Leere — der Katalog kam nie
+  // an („Connector-Katalog nicht ladbar"). Bei Tieflinks wie
+  // /hq/connections/github wäre es noch eine Ebene daneben gelandet.
+  test('HQ holt Datendateien über absolute Pfade', () => {
+    expect(HQ, 'hqAsset() löst assets/ und audit/ absolut auf').toMatch(/function hqAsset/);
+    // Kein roher relativer fetch auf die Datenordner mehr.
+    expect(HQ).not.toMatch(/fetch\(\s*['"]assets\//);
+    expect(HQ).not.toMatch(/new URL\(\s*['"]audit\//);
+  });
+
+  test('functions.php liefert /assets/*.json und /audit/*.json aus', () => {
+    expect(FUNCTIONS).toMatch(/\^\/\(assets\|audit\)\//);
+    const block = FUNCTIONS.slice(FUNCTIONS.indexOf("'#^/(assets|audit)/"));
+    // Nur JSON — für Skripte und Stile gibt es den Theme-Pfad.
+    expect(block.slice(0, 200)).toMatch(/\\\.json/);
+    // Ausbruch nach oben muss am aufgelösten Pfad scheitern, nicht nur am Muster.
+    expect(block.slice(0, 900)).toMatch(/realpath/);
+    expect(block.slice(0, 900)).toMatch(/strpos\(\s*\$ziel/);
+    expect(block.slice(0, 900)).toMatch(/X-Content-Type-Options/);
+  });
+
+  test('Route ist auf die zwei Ordner und .json begrenzt', () => {
+    const m = FUNCTIONS.match(/preg_match\(\s*'(#\^\/\(assets\|audit\)\/[^']+#)'/);
+    expect(m, 'Muster nicht gefunden').toBeTruthy();
+    const re = new RegExp(m[1].slice(1, -1));
+    expect(re.test('/assets/eb-connectors.json')).toBe(true);
+    expect(re.test('/audit/latest.json')).toBe(true);
+    // Was nicht durchkommen darf:
+    expect(re.test('/assets/../wp-config.php'), 'Verzeichniswechsel').toBe(false);
+    expect(re.test('/assets/js/app.js'), 'Unterordner').toBe(false);
+    expect(re.test('/assets/evil.php'), 'anderes Format').toBe(false);
+    expect(re.test('/vault/geheim.json'), 'fremder Ordner').toBe(false);
+  });
+
+  test('audit/latest.json existiert und wird ausgeliefert', () => {
+    // Wurde einmal als „nie erzeugt" abgetan — die Datei liegt seit dem
+    // 1. August im Repo, sie war nur nicht erreichbar.
+    const p = path.join(ROOT, 'audit', 'latest.json');
+    expect(fs.existsSync(p), 'audit/latest.json fehlt').toBe(true);
+    JSON.parse(fs.readFileSync(p, 'utf8'));
+    const deploy = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'ionos-deploy.yml'), 'utf8');
+    expect(deploy, 'audit/ darf nicht vom Deploy ausgeschlossen sein').not.toMatch(/-x '\^audit\//);
+  });
+
+  test('zwischengespeicherter Stand wird als solcher gekennzeichnet', () => {
+    // Der Header zeigte einen alten Commit-SHA, als wäre er der aktuelle:
+    // renderFromCache() schreibt ihn, und wenn der frische Abruf scheitert
+    // (ohne Token greift GitHubs Limit), bleibt er unmarkiert stehen.
+    expect(HQ).toMatch(/state\.ausCache\s*=\s*true/);
+    expect(HQ).toMatch(/state\.ausCache\s*=\s*false/);
+    expect(HQ).toMatch(/zwischengespeichert/);
+  });
+});
+
 test.describe('Connector-Katalog', () => {
   test('Katalog-Prüfung läuft sauber durch', () => {
     const out = execFileSync('node', ['scripts/connectors.mjs', '--check'], { cwd: ROOT, encoding: 'utf8' });

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,9 +63,9 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **24** |
-| Commits (30 Tage) | 75 |
-| Letzter Commit | `fecf34a · HQ-Dashboard unter eventbörse.de/hq erreichbar machen (#88)` (2026-08-02) |
+| Commits (7 Tage) | **26** |
+| Commits (30 Tage) | 77 |
+| Letzter Commit | `0303143 · HQ absichern und Verbindungszentrale bauen (3A, erste Ausbaustufe) (#90)` (2026-08-03) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
@@ -73,13 +73,13 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
      33 styles.css
      23 index.html
      23 app-shell.html
-     10 functions.php
+     11 functions.php
 ```
 
 **Codegröße:**
 - `app.js` — 25.012 Zeilen
 - `styles.css` — 16.892 Zeilen
-- `functions.php` — 8.310 Zeilen
+- `functions.php` — 8.347 Zeilen
 - `app-shell.html` — 3.974 Zeilen
 
 ## Verwandt

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 94 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 99 Tests
 > in 9 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 94 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 99 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Verbindungen.md
+++ b/vault/30-Betrieb/Verbindungen.md
@@ -69,6 +69,40 @@ Der direkte Theme-Pfad `/wp-content/themes/…/hq.html` ist zusätzlich in
 `.htaccess` gesperrt: dort liefert Apache aus, ohne PHP je zu fragen — ohne die
 Sperre wäre die Rechteprüfung schlicht umgehbar.
 
+## Datendateien unter kurzem Pfad
+
+Das HQ läuft unter `/hq`, die Datendateien liegen im Theme-Verzeichnis. Ein
+relativer `fetch` zeigt von dort ins Leere — daran scheiterten Connector-Katalog,
+Wissensbasis und Selbstcheck gleichzeitig („Connector-Katalog nicht ladbar").
+Bei einem Tieflink wie `/hq/connections/github` wäre es sogar eine Ebene weiter
+danebengegangen.
+
+Zwei Hälften, beide nötig:
+
+- `functions.php` bedient `/assets/*.json` und `/audit/*.json`
+- `hqAsset()` in `hq.html` löst die Pfade absolut auf (relativ nur, wenn die
+  Datei direkt als `…/hq.html` geöffnet wird — lokal und über `file://`)
+
+Die Route ist bewusst eng: nur diese zwei Ordner, nur `.json`, kein
+Schrägstrich im Dateinamen, kein führender Punkt, und `realpath()` muss
+innerhalb des Zielordners landen. Geprüft gegen echte Angriffsmuster
+(`../`, `..%2f`, `....//`, Unterordner, `.php`, fremde Ordner) — alle abgewiesen.
+
+Sicherheitlich ändert sich nichts: die Dateien waren über den Theme-Pfad
+ohnehin öffentlich lesbar.
+
+## Zwischengespeicherte Stände
+
+`renderFromCache()` zeigt sofort den letzten bekannten Stand, damit die Seite
+nicht leer startet. Scheitert danach der frische Abruf — ohne GitHub-Token
+greift das Limit bei 60 Anfragen pro Stunde —, blieb der alte Wert **unmarkiert**
+stehen. Im Header stand dann ein Commit-SHA, der längst überholt war, und las
+sich wie der aktuelle.
+
+Jetzt trägt jeder aus dem Zwischenspeicher gerenderte Stand den Zusatz
+*zwischengespeichert*, bis `loadAll()` ihn durch echte Daten ersetzt. Ein alter
+Wert darf angezeigt werden — aber nicht als frischer.
+
 ## Wo Geheimnisse liegen
 
 | Ablage | Was | Erreichbar für |


### PR DESCRIPTION
Das HQ läuft unter `/hq`, seine Datendateien liegen im Theme-Verzeichnis. Ein relativer `fetch` zeigte von dort ins Leere — Connector-Katalog, Wissensbasis und Selbstcheck fielen gleichzeitig aus („Connector-Katalog nicht ladbar").

## Zwei Hälften, beide nötig

**`functions.php`** bedient `/assets/*.json` und `/audit/*.json`.

**`hqAsset()` in `hq.html`** löst die Pfade absolut auf. Ohne diesen Teil wäre der Fix unvollständig: bei einem Tieflink wie `/hq/connections/github` hätte ein relativer Pfad auf `/hq/connections/assets/…` gezeigt — eine Ebene weiter daneben. Relativ bleibt es nur, wenn die Datei direkt als `…/hq.html` geöffnet wird (lokal und über `file://`).

## Die Route ist eng gehalten

Nur diese zwei Ordner · nur `.json` · kein Schrägstrich im Dateinamen · kein führender Punkt · `realpath()` muss innerhalb des Zielordners landen.

Gegen echte Angriffsmuster ausgeführt geprüft (nicht nur gelesen):

| Eingabe | Ergebnis |
|---|---|
| `/assets/eb-connectors.json` | 200 (12 742 B) |
| `/assets/eb-knowledge.json` | 200 (58 370 B) |
| `/assets/eb-demo-feed.json` | 200 (6 478 B) |
| `/audit/latest.json` | 200 (3 209 B) |
| `/assets/eb-connectors.json?v=123` | 200 |
| `/assets/../wp-config.php` | abgewiesen |
| `/assets/..%2f..%2fwp-config.php` | abgewiesen |
| `/assets/....//wp-config.php` | abgewiesen |
| `/assets/js/app.js` | abgewiesen |
| `/assets/evil.php` | abgewiesen |
| `/assets/.env.json` | abgewiesen |
| `/vault/…json` | abgewiesen |

Sicherheitlich ändert sich nichts: die Dateien waren über den Theme-Pfad ohnehin öffentlich lesbar.

## Zwei Korrekturen an der Fehlerbeschreibung

**`audit/latest.json` wurde als „nie erzeugt" eingeordnet — das stimmt nicht.** Die Datei liegt seit dem 1. August im Repo (3 209 B) und ist auch nicht vom Deploy ausgeschlossen. Sie war nur nicht erreichbar, aus genau demselben Grund. Dieselbe Route behebt es, ein zweiter Durchgang ist nicht nötig.

**Der falsche Commit-SHA im Header ist nicht kosmetisch.** `renderFromCache()` zeigt sofort den letzten bekannten Stand, damit die Seite nicht leer startet. Scheitert danach der frische Abruf — ohne Token greift GitHubs Limit bei 60 Anfragen pro Stunde —, blieb der alte Wert **unmarkiert** stehen und las sich wie der aktuelle. Das ist dieselbe Ehrlichkeitslücke, die dieses Projekt sonst überall schließt. Jetzt trägt jeder zwischengespeicherte Stand den Zusatz *zwischengespeichert*, bis echte Daten ihn ersetzen.

## Verifikation

- **99/99 Tests** (5 neue): Route auf zwei Ordner und `.json` begrenzt, HQ löst absolut auf, `audit/latest.json` existiert und wird mitdeployt, zwischengespeicherte Stände sind gekennzeichnet
- Route-Logik in PHP gegen das echte Theme-Verzeichnis ausgeführt, nicht nur gelesen
- Seite geladen: Katalog kommt an (10 Karten), Selbstcheck kommt an (7 Befunde), keine Page-Errors
- `php -l functions.php` sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_