### PR TITLE
HQ: CSP erlaubt GitHub, Selbstcheck bleibt frisch

### DIFF
--- a/.github/workflows/tagesroutine.yml
+++ b/.github/workflows/tagesroutine.yml
@@ -1,8 +1,15 @@
-name: Tages-Demo-Feed
+name: Tagesroutine
 
-# Erzeugt taeglich frische Demo-Beitraege (scripts/demo-feed.mjs) und
-# committet sie nach main, wenn sich etwas geaendert hat. Der Push loest
-# den normalen IONOS-Deploy aus.
+# Haelt zwei erzeugte Dateien frisch und committet sie nach main, wenn sich
+# etwas geaendert hat. Der Push loest den normalen IONOS-Deploy aus.
+#
+#   assets/eb-demo-feed.json   frische Demo-Beitraege (scripts/demo-feed.mjs)
+#   audit/latest.json          Selbstcheck (scripts/self-audit.mjs)
+#
+# Warum der Selbstcheck dazugehoert: er lag zuletzt zwei Wochen still und
+# meldete "Keine automatisierten Tests", waehrend die Playwright-Suite laengst
+# stand. Ein Befund ueber einen alten Code-Stand ist schlimmer als keiner —
+# man handelt danach.
 #
 # Warum direkt nach main statt ueber einen PR: die Aenderung betrifft
 # ausschliesslich die erzeugte Datei assets/eb-demo-feed.json, der Generator
@@ -21,12 +28,12 @@ permissions:
   contents: write
 
 concurrency:
-  group: demo-feed
+  group: tagesroutine
   cancel-in-progress: false
 
 jobs:
   feed:
-    name: Demo-Feed erneuern
+    name: Demo-Feed und Selbstcheck erneuern
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,24 +50,29 @@ jobs:
       - name: Ehrlichkeit + Reproduzierbarkeit pruefen
         run: node scripts/demo-feed.mjs --check
 
+      - name: Selbstcheck erneuern
+        run: node scripts/self-audit.mjs
+
       - name: Committen, falls geaendert
         run: |
-          if git diff --quiet -- assets/eb-demo-feed.json; then
-            echo "Keine Aenderung — heutiger Feed steht bereits." >> "$GITHUB_STEP_SUMMARY"
+          if git diff --quiet -- assets/eb-demo-feed.json audit/latest.json; then
+            echo "Keine Aenderung — Feed und Selbstcheck sind aktuell." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           git config user.name  "Eventboerse Routine"
           git config user.email "noreply@users.noreply.github.com"
-          git add assets/eb-demo-feed.json
-          git commit -m "chore(feed): Demo-Beitraege fuer $(date -u +%Y-%m-%d)"
+          git add assets/eb-demo-feed.json audit/latest.json
+          git commit -m "chore(routine): Demo-Feed und Selbstcheck fuer $(date -u +%Y-%m-%d)"
           for i in 1 2 3 4; do
             git push origin HEAD:main && break
             sleep $((2 ** i))
             git pull --rebase origin main || true
           done
           {
-            echo "### Demo-Feed erneuert"
+            echo "### Tagesroutine gelaufen"
             node -e "const f=require('./assets/eb-demo-feed.json');
-              console.log('- Beitraege: '+f.posts.length);
+              console.log('- Demo-Beitraege: '+f.posts.length);
               console.log('- Aelteste/juengste: '+Math.max(...f.posts.map(p=>p.tageZurueck))+'/'+Math.min(...f.posts.map(p=>p.tageZurueck))+' Tage zurueck');"
+            node -e "const a=require('./audit/latest.json'); const c=a.counts||{};
+              console.log('- Selbstcheck: '+(a.findings||[]).length+' Befunde (err '+(c.error||0)+', warn '+(c.warn||0)+')');"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,11 @@ node scripts/connectors.mjs --check    # keine Geheimnisse, kein Zustand im Kata
 
 Der Katalog beschreibt **Möglichkeiten**, nie den Verbindungszustand — ob etwas
 verbunden ist, entscheidet ausschließlich eine echte Prüfung zur Laufzeit.
-Details: `vault/30-Betrieb/Verbindungen.md`.
+
+`eb_hq_csp_erweitern()` erlaubt `connect-src` GitHub **nur für die /hq-Antwort**.
+Ohne das blockiert die CSP jeden GitHub-Aufruf des HQ. Die **Tagesroutine**
+(`tagesroutine.yml`, 03:17 UTC) hält Demo-Feed und Selbstcheck
+(`audit/latest.json`) frisch. Details: `vault/30-Betrieb/Verbindungen.md`.
 
 ### Impuls-Strom messen
 
@@ -131,7 +135,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-99 Tests in 9 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+104 Tests in 9 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Barrierefreiheit (axe, beide

--- a/audit/latest.json
+++ b/audit/latest.json
@@ -1,12 +1,12 @@
 {
   "schema": "eb-self-audit/v1",
-  "generatedAt": "2026-07-19T12:25:32Z",
-  "commit": "3c58c41",
+  "generatedAt": "2026-08-03T07:22:43Z",
+  "commit": "7633937",
   "counts": {
-    "total": 7,
+    "total": 6,
     "error": 0,
-    "warn": 2,
-    "info": 4,
+    "warn": 0,
+    "info": 5,
     "ok": 1
   },
   "findings": [
@@ -21,75 +21,67 @@
       "evidence": null
     },
     {
-      "id": "route-admin-mod-missing",
-      "title": "Admin-Moderationsrouten im Vault dokumentiert, aber nicht im Code",
-      "area": "backend",
-      "severity": "warn",
-      "status": "open",
-      "detail": "`/admin/listings/{id}/hide` und `/my-listing-moderation` werden im Vault erwähnt, fehlen aber in functions.php.",
-      "suggestion": "Entweder die Routen wiederherstellen oder die Vault-Notiz korrigieren.",
-      "evidence": null
-    },
-    {
       "id": "size-app.js-watch",
-      "title": "app.js wächst (23055 Zeilen)",
+      "title": "app.js wächst (25013 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 23055,
+        "lines": 25013,
         "threshold": 20000
       }
     },
     {
       "id": "size-functions.php-watch",
-      "title": "functions.php wächst (7718 Zeilen)",
+      "title": "functions.php wächst (8396 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 7718,
+        "lines": 8396,
         "threshold": 6000
       }
     },
     {
       "id": "size-styles.css-watch",
-      "title": "styles.css wächst (16343 Zeilen)",
+      "title": "styles.css wächst (16893 Zeilen)",
       "area": "maintainability",
       "severity": "info",
       "status": "open",
       "detail": "Wachsendes Monolith-Risiko, noch nicht kritisch.",
       "suggestion": "Beim nächsten Feature prüfen, ob ein Teil als Modul ausgelagert werden kann.",
       "evidence": {
-        "lines": 16343,
+        "lines": 16893,
         "threshold": 12000
       }
     },
     {
       "id": "console-noise",
-      "title": "17 console.*-Aufrufe in app.js",
+      "title": "19 console.*-Aufrufe in app.js",
       "area": "cleanup",
       "severity": "info",
       "status": "open",
       "detail": "Aufrufe landen in der Browser-Konsole der Nutzer. Für Production wäre ein Debug-Flag sauberer.",
       "suggestion": "Kosmetik: console-Aufrufe hinter einen `EB_DEBUG`-Flag stellen oder in production strippen.",
       "evidence": {
-        "count": 17
+        "count": 19
       }
     },
     {
-      "id": "no-tests",
-      "title": "Keine automatisierten Tests im Repo",
-      "area": "quality",
-      "severity": "warn",
+      "id": "open-todos",
+      "title": "74 offene TODO/FIXME-Marker im Code",
+      "area": "cleanup",
+      "severity": "info",
       "status": "open",
-      "detail": "Bekannte Schwäche aus CLAUDE.md. Ein paar Smoke-Tests gegen die SPA wären schon viel wert.",
-      "suggestion": "Playwright-Smoke-Suite für browse/detail/board/chat (regression-Schutz P0).",
-      "evidence": null
+      "detail": "Sammlung an Notizen, die noch nicht in Bekannte-Bugs.md überführt wurden.",
+      "suggestion": "Beim nächsten Sweep abklären: erledigt → entfernen, sonst in vault/Roadmap/Bekannte-Bugs.md überführen.",
+      "evidence": {
+        "count": 74
+      }
     }
   ]
 }

--- a/functions.php
+++ b/functions.php
@@ -343,6 +343,52 @@ function eb_serve_theme_root_file() {
  * (/wp-content/themes/…/hq.html) ist zusätzlich in .htaccess gesperrt — dort
  * liefert Apache aus, ohne PHP je zu fragen.
  */
+/**
+ * connect-src für die HQ-Antwort um GitHub erweitern.
+ *
+ * Das HQ ist die einzige Seite, die api.github.com braucht (Commits, Actions,
+ * Kontingent) und raw.githubusercontent.com als Fallback für den Selbstcheck.
+ * Ohne diesen Zusatz lässt der Browser die Anfragen gar nicht erst raus — im
+ * HQ sah das nach „Failed to fetch" auf neun von zehn Karten aus, obwohl
+ * weder Token noch Route schuld waren.
+ *
+ * Bewusst NUR hier: die öffentliche Seite spricht nie mit GitHub, und was sie
+ * nicht braucht, soll ihr auch nicht erlaubt sein.
+ *
+ * Der bereits gesetzte Header wird ausgelesen und erweitert, statt einen
+ * zweiten zu senden. Zwei CSP-Header werden vom Browser als Schnittmenge
+ * ausgewertet — der zusätzliche hätte also nichts erlaubt, sondern nur
+ * weiter eingeschränkt.
+ */
+function eb_hq_csp_erweitern() {
+    $zusatz = 'https://api.github.com https://raw.githubusercontent.com';
+
+    foreach ( headers_list() as $h ) {
+        if ( stripos( $h, 'Content-Security-Policy:' ) !== 0 ) {
+            continue;
+        }
+        $wert = trim( substr( $h, strlen( 'Content-Security-Policy:' ) ) );
+        if ( strpos( $wert, 'api.github.com' ) !== false ) {
+            return; // schon erlaubt
+        }
+
+        $treffer = 0;
+        $neu = preg_replace(
+            '/(^|;\s*)connect-src\s+([^;]*)/i',
+            '$1connect-src $2 ' . $zusatz,
+            $wert,
+            1,
+            $treffer
+        );
+        // Fehlt connect-src ganz, greift default-src — dann die Direktive
+        // ergänzen, statt stillschweigend nichts zu tun.
+        header( 'Content-Security-Policy: ' . ( $treffer ? $neu : $wert . "; connect-src 'self' " . $zusatz ), true );
+        return;
+    }
+
+    // Kein CSP-Header gesetzt (z. B. weil send_headers nicht lief): nichts zu tun.
+}
+
 function eb_serve_hq() {
     if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
         status_header( 404 );
@@ -358,6 +404,8 @@ function eb_serve_hq() {
         status_header( 404 );
         exit;
     }
+
+    eb_hq_csp_erweitern();
 
     status_header( 200 );
     header( 'Content-Type: text/html; charset=UTF-8' );

--- a/hq.html
+++ b/hq.html
@@ -1318,7 +1318,13 @@ async function loadSelfAudit() {
   $('audit-chip-info').textContent = `💡 ${c.info  || 0}`;
   $('audit-chip-ok').textContent   = `✅ ${c.ok    || 0}`;
   badge.textContent = String(data.findings.length);
-  meta.textContent = `Stand ${humanDate(data.generatedAt)} · Commit ${data.commit || '–'}`;
+  // Ein alter Selbstcheck beschreibt einen alten Code-Stand. Solange das nur
+  // als Datum dasteht, liest man die Befunde trotzdem als aktuell — genau so
+  // hielt sich „Keine automatisierten Tests" wochenlang, obwohl die Suite
+  // längst existierte. Ab einer Woche wird es benannt statt nur datiert.
+  const tageAlt = (Date.now() - Date.parse(data.generatedAt)) / 86400000;
+  meta.textContent = `Stand ${humanDate(data.generatedAt)} · Commit ${data.commit || '–'}`
+    + (tageAlt > 7 ? ` · ⚠️ ${Math.floor(tageAlt)} Tage alt — beschreibt einen älteren Code-Stand` : '');
 
   // Sortierung: error → warn → info → ok
   const order = { error: 0, warn: 1, info: 2, ok: 3 };

--- a/tests/e2e/csp-hq.php
+++ b/tests/e2e/csp-hq.php
@@ -1,0 +1,68 @@
+#!/usr/bin/env php
+<?php
+/**
+ * csp-hq.php — prüft die CSP-Erweiterung für /hq gegen die ECHTE Direktivenliste.
+ *
+ * Aufgerufen von tests/e2e/verbindungen.spec.js. Ohne diese Prüfung fällt erst
+ * auf der Live-Seite auf, wenn connect-src GitHub nicht erlaubt: die
+ * Playwright-Tests blockieren api.github.com absichtlich und sehen deshalb
+ * denselben „Failed to fetch" wie ein CSP-Verstoß.
+ *
+ * Gibt JSON auf stdout aus; Exit 1, sobald eine Zusicherung bricht.
+ */
+
+$src = file_get_contents(__DIR__ . '/../../functions.php');
+
+if (!preg_match('/\$csp_directives\s*=\s*array\((.*?)\n\s*\);/s', $src, $m)) {
+    fwrite(STDERR, "csp_directives nicht gefunden\n");
+    exit(1);
+}
+preg_match_all('/"([^"]+)"/', $m[1], $dm);
+$echteCsp = implode('; ', $dm[1]);
+
+if (!preg_match('/function eb_hq_csp_erweitern\(\)\s*\{.*?\n\}/s', $src, $fm)) {
+    fwrite(STDERR, "eb_hq_csp_erweitern() nicht gefunden\n");
+    exit(1);
+}
+
+// Im Namespace lösen headers_list()/header() auf die Testfassungen auf, ohne
+// die eingebauten Funktionen anzutasten.
+$GLOBALS['gesendet'] = [];
+$GLOBALS['aktuell']  = ['Content-Security-Policy: ' . $echteCsp];
+eval('namespace EBTest; '
+   . 'function headers_list(){ return $GLOBALS["aktuell"]; } '
+   . 'function header($h, $replace = true){ $GLOBALS["gesendet"][] = $h; } '
+   . $fm[0]);
+
+\EBTest\eb_hq_csp_erweitern();
+$neu = $GLOBALS['gesendet']
+    ? substr($GLOBALS['gesendet'][0], strlen('Content-Security-Policy: '))
+    : $echteCsp;
+
+// Zweiter Lauf auf dem Ergebnis: darf nichts mehr senden.
+$GLOBALS['aktuell']  = ['Content-Security-Policy: ' . $neu];
+$GLOBALS['gesendet'] = [];
+\EBTest\eb_hq_csp_erweitern();
+$idempotent = empty($GLOBALS['gesendet']);
+
+$richtwert = function (string $csp, string $direktive): string {
+    return preg_match('/(^|;\s*)' . preg_quote($direktive, '/') . '\s+([^;]*)/i', $csp, $t)
+        ? trim($t[2]) : '';
+};
+
+echo json_encode([
+    'vorher'          => $richtwert($echteCsp, 'connect-src'),
+    'nachher'         => $richtwert($neu, 'connect-src'),
+    'github'          => str_contains($neu, 'https://api.github.com'),
+    'raw'             => str_contains($neu, 'https://raw.githubusercontent.com'),
+    'stripe'          => str_contains($neu, 'https://api.stripe.com'),
+    'nominatim'       => str_contains($neu, 'https://nominatim.openstreetmap.org'),
+    'self'            => str_contains($neu, "connect-src 'self'"),
+    'scriptSrcGleich' => $richtwert($echteCsp, 'script-src') === $richtwert($neu, 'script-src'),
+    'imgSrcGleich'    => $richtwert($echteCsp, 'img-src') === $richtwert($neu, 'img-src'),
+    'einConnectSrc'   => preg_match_all('/connect-src/', $neu) === 1,
+    'gleicheAnzahl'   => count(explode(';', $neu)) === count(explode(';', $echteCsp)),
+    'idempotent'      => $idempotent,
+    // Was der öffentliche Header NICHT enthalten darf.
+    'oeffentlichOhneGithub' => !str_contains($echteCsp, 'api.github.com'),
+], JSON_UNESCAPED_SLASHES);

--- a/tests/e2e/verbindungen.spec.js
+++ b/tests/e2e/verbindungen.spec.js
@@ -103,6 +103,51 @@ test.describe('Datendateien erreichbar', () => {
   });
 });
 
+test.describe('CSP: HQ darf mit GitHub sprechen', () => {
+  // Der teuerste Fehler dieser Reihe. Route und Token waren in Ordnung, neun
+  // von zehn Karten meldeten trotzdem „Failed to fetch": connect-src erlaubte
+  // api.github.com nicht, der Browser ließ die Anfragen gar nicht erst raus.
+  //
+  // Die Playwright-Tests konnten das nicht finden — sie blockieren
+  // api.github.com absichtlich und sehen deshalb dasselbe Bild wie bei einem
+  // CSP-Verstoß. Deshalb wird hier der Header selbst gerechnet, in PHP, gegen
+  // die echte Direktivenliste aus functions.php.
+  const csp = JSON.parse(execFileSync('php', ['tests/e2e/csp-hq.php'], { cwd: ROOT, encoding: 'utf8' }));
+
+  test('connect-src erlaubt api.github.com für /hq', () => {
+    expect(csp.github, `connect-src nachher: ${csp.nachher}`).toBe(true);
+    expect(csp.raw, 'raw.githubusercontent.com ist der Fallback des Selbstchecks').toBe(true);
+  });
+
+  test('bestehende Quellen bleiben unangetastet', () => {
+    expect(csp.self).toBe(true);
+    expect(csp.stripe).toBe(true);
+    expect(csp.nominatim).toBe(true);
+    expect(csp.scriptSrcGleich, 'nur connect-src darf sich ändern').toBe(true);
+    expect(csp.imgSrcGleich).toBe(true);
+    expect(csp.gleicheAnzahl, 'keine Direktive dazu oder weg').toBe(true);
+  });
+
+  test('genau ein connect-src, mehrfach aufrufbar', () => {
+    // Zwei CSP-Header wertet der Browser als Schnittmenge — ein zweiter hätte
+    // nichts erlaubt, sondern weiter eingeschränkt.
+    expect(csp.einConnectSrc).toBe(true);
+    expect(csp.idempotent, 'erneuter Aufruf darf nichts erneut senden').toBe(true);
+  });
+
+  test('die öffentliche Seite bekommt GitHub NICHT erlaubt', () => {
+    // Was die Website nicht braucht, soll ihr auch nicht offenstehen.
+    expect(csp.oeffentlichOhneGithub, `öffentliches connect-src: ${csp.vorher}`).toBe(true);
+  });
+
+  test('Erweiterung hängt nur an der HQ-Auslieferung', () => {
+    const hq = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_serve_hq'));
+    expect(hq.slice(0, 1600), 'eb_serve_hq muss die Erweiterung aufrufen').toMatch(/eb_hq_csp_erweitern\(\)/);
+    // Kein globaler Hook — sonst gälte die Lockerung für jede Seite.
+    expect(FUNCTIONS).not.toMatch(/add_action\([^)]*eb_hq_csp_erweitern/);
+  });
+});
+
 test.describe('Connector-Katalog', () => {
   test('Katalog-Prüfung läuft sauber durch', () => {
     const out = execFileSync('node', ['scripts/connectors.mjs', '--check'], { cwd: ROOT, encoding: 'utf8' });

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,9 +63,9 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **26** |
-| Commits (30 Tage) | 77 |
-| Letzter Commit | `0303143 · HQ absichern und Verbindungszentrale bauen (3A, erste Ausbaustufe) (#90)` (2026-08-03) |
+| Commits (7 Tage) | **28** |
+| Commits (30 Tage) | 79 |
+| Letzter Commit | `7633937 · HQ: /assets/*.json und /audit/*.json ausliefern (#91)` (2026-08-03) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
@@ -73,13 +73,13 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
      33 styles.css
      23 index.html
      23 app-shell.html
-     11 functions.php
+     12 functions.php
 ```
 
 **Codegröße:**
 - `app.js` — 25.012 Zeilen
 - `styles.css` — 16.892 Zeilen
-- `functions.php` — 8.347 Zeilen
+- `functions.php` — 8.395 Zeilen
 - `app-shell.html` — 3.974 Zeilen
 
 ## Verwandt

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 99 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 104 Tests
 > in 9 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 99 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 104 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml
@@ -40,7 +40,7 @@ Keine Unit-Tests aktuell — Codebase ist hauptsächlich UI-Glue + REST-Wrapper,
 | `css-minify.spec.js` | Gegen **minifiziertes** CSS (csso-cli\@4.0.2 --no-restructure wie Deploy): Verlaufsschrift statisch + computed styles | Regression ae3f624 |
 | `design-system.spec.js` | Chips sichtbar; Konflikt-Ratsche (max. 56 Alt-Konflikte); Token-Eindeutigkeit | Klassenkollision .ai-suggestions |
 | `barrierefreiheit.spec.js` | axe-core WCAG AA, **beide Farbmodi** × 4 Seiten; Fokus; Dot-Labels | Stand 0 Verstöße halten (vorher 97 Nodes) |
-| `verbindungen.spec.js` | **HQ-Zugang** (keine Schlüssel im HTML, serverseitige `manage_options`-Prüfung, Theme-Pfad gesperrt, noindex) + **Connector-Katalog** (kein Zustand, alle 15 Fähigkeiten deklariert, Copilot-Kontingent ehrlich, keine Geheimnisse) + **Oberfläche** (ohne API-Antwort darf nichts „verbunden" zeigen) | Das HQ war faktisch offen; ein Katalog mit Status wäre eine Lüge in Dateiform |
+| `verbindungen.spec.js` | **HQ-Zugang** (keine Schlüssel im HTML, serverseitige `manage_options`-Prüfung, Theme-Pfad gesperrt, noindex) + **Connector-Katalog** (kein Zustand, alle 15 Fähigkeiten deklariert, Copilot-Kontingent ehrlich, keine Geheimnisse) + **Oberfläche** (ohne API-Antwort darf nichts „verbunden" zeigen) + **CSP** (`csp-hq.php` rechnet den Header in PHP durch — die JS-Tests blockieren GitHub selbst und sehen einen CSP-Verstoß als dasselbe Bild) | Das HQ war faktisch offen; ein Katalog mit Status wäre eine Lüge in Dateiform |
 | `zufluss.spec.js` | **Quarantäne-Tor** (5 Regeln einzeln, Injection innen erlaubt/außen verboten, Geheimnis-Import verweigert) + **Demo-Feed** (nichts wirkt frisch, reproduzierbar, Event-Vielfalt, gerenderte Zeitangaben) | Externer Zufluss ist die einzige Stelle, an der ungeprüfter Text ins System kommt |
 
 ```bash

--- a/vault/30-Betrieb/Verbindungen.md
+++ b/vault/30-Betrieb/Verbindungen.md
@@ -91,6 +91,33 @@ innerhalb des Zielordners landen. Geprüft gegen echte Angriffsmuster
 Sicherheitlich ändert sich nichts: die Dateien waren über den Theme-Pfad
 ohnehin öffentlich lesbar.
 
+## CSP: warum das HQ mit GitHub sprechen darf
+
+Neun von zehn Karten meldeten „Failed to fetch", obwohl Route und Token in
+Ordnung waren. Ursache: `connect-src` erlaubte `api.github.com` nicht — der
+Browser ließ die Anfragen gar nicht erst raus. Ein abgelehnter Token hätte
+401 mit JSON geliefert; „Failed to fetch" ohne Status ist die Signatur eines
+CSP-Verstoßes.
+
+`eb_hq_csp_erweitern()` liest den bereits gesetzten Header aus und ergänzt
+`connect-src` um `api.github.com` und `raw.githubusercontent.com` — **nur für
+die `/hq`-Antwort**. Die öffentliche Seite spricht nie mit GitHub, und was sie
+nicht braucht, soll ihr auch nicht offenstehen.
+
+Erweitert statt zusätzlich gesendet: zwei CSP-Header wertet der Browser als
+**Schnittmenge** aus. Ein zweiter Header hätte also nichts erlaubt, sondern nur
+weiter eingeschränkt.
+
+**Warum die Testsuite das nicht fand:** `verbindungen.spec.js` blockiert
+`api.github.com` absichtlich, um zu prüfen, dass dann nichts „verbunden"
+behauptet. Ein CSP-Verstoß sieht für den Test genauso aus. Deshalb rechnet
+`tests/e2e/csp-hq.php` den Header jetzt separat in PHP durch — gegen die echte
+Direktivenliste, mit Zusicherung, dass nur `connect-src` sich ändert.
+
+Die CSP wird ausschließlich in `functions.php` gesetzt; `.htaccess` setzt zwar
+andere Sicherheitsheader, aber keine CSP. Es gibt also keine zweite Stelle, die
+den Wert überschreiben könnte.
+
 ## Zwischengespeicherte Stände
 
 `renderFromCache()` zeigt sofort den letzten bekannten Stand, damit die Seite
@@ -102,6 +129,16 @@ sich wie der aktuelle.
 Jetzt trägt jeder aus dem Zwischenspeicher gerenderte Stand den Zusatz
 *zwischengespeichert*, bis `loadAll()` ihn durch echte Daten ersetzt. Ein alter
 Wert darf angezeigt werden — aber nicht als frischer.
+
+Dasselbe gilt für den Selbstcheck: `audit/latest.json` lag zwei Wochen still
+und meldete „Keine automatisierten Tests", während die Playwright-Suite längst
+stand. Ein Befund über einen alten Code-Stand ist schlimmer als keiner — man
+handelt danach. Zwei Änderungen:
+
+- die **Tagesroutine** (`tagesroutine.yml`, 03:17 UTC) erneuert den Selbstcheck
+  zusammen mit dem Demo-Feed und committet, wenn sich etwas geändert hat
+- ist der Stand älter als sieben Tage, schreibt das HQ es dazu, statt ihn nur
+  zu datieren
 
 ## Wo Geheimnisse liegen
 


### PR DESCRIPTION
## Der Befund war richtig

Neun von zehn Verbindungskarten meldeten „Failed to fetch", obwohl Route und Token in Ordnung waren. `connect-src` erlaubte `api.github.com` nicht — der Browser ließ die Anfragen gar nicht erst raus. Ein abgelehnter Token hätte 401 mit JSON geliefert; „Failed to fetch" ohne Status ist die Signatur eines CSP-Verstoßes.

Das erklärt lückenlos alles Weitere: den eingefrorenen SHA, „Letzter Deploy –", die stehengebliebene Commit-Zahl, alle sechs Bots auf „Noch kein Run". Und die Gegenprobe stimmt: `eventbörse.de` war die einzige grüne Karte — die einzige, die same-origin prüft.

## Die Behebung

`eb_hq_csp_erweitern()` liest den bereits gesetzten Header aus und ergänzt `connect-src` um `api.github.com` und `raw.githubusercontent.com` — **nur für die `/hq`-Antwort**. Die öffentliche Seite spricht nie mit GitHub, und was sie nicht braucht, soll ihr auch nicht offenstehen.

Erweitert statt zusätzlich gesendet: zwei CSP-Header wertet der Browser als **Schnittmenge** aus. Ein zweiter hätte nichts erlaubt, sondern nur weiter eingeschränkt.

**Der Vorbehalt ist ausgeräumt.** `.htaccess` setzt zwar andere Sicherheitsheader, aber keine CSP — es gibt keine zweite Stelle, die den Wert überschreiben könnte. Der Patch verpufft nicht.

Gegen die echte Direktivenliste durchgerechnet:

```
vorher   connect-src 'self' https://api.stripe.com https://m.stripe.network
                     https://nominatim.openstreetmap.org https://*.tile.openstreetmap.org
nachher  … + https://api.github.com https://raw.githubusercontent.com
```

## Warum die Testsuite das nicht fand

`verbindungen.spec.js` blockiert `api.github.com` **absichtlich**, um zu prüfen, dass dann nichts „verbunden" behauptet. Ein CSP-Verstoß sieht für diesen Test genauso aus — er konnte den Fehler nicht sehen, egal wie gründlich er war.

`tests/e2e/csp-hq.php` rechnet den Header deshalb separat in PHP durch: GitHub erlaubt · Stripe, Nominatim und `'self'` unverändert · `script-src` und `img-src` identisch · genau ein `connect-src` · mehrfach aufrufbar · und der **öffentliche** Header bekommt GitHub nicht.

## Selbstcheck bleibt frisch

`audit/latest.json` lag zwei Wochen still und meldete „Keine automatisierten Tests", während die Playwright-Suite längst stand. Das Skript erkennt Tests korrekt — die Datei war nur alt. Ein Befund über einen alten Code-Stand ist schlimmer als keiner: man handelt danach.

- neu erzeugt: **7 → 6 Befunde, keine Warnungen mehr**
- `demo-feed.yml` wird zur **Tagesroutine** und erneuert den Selbstcheck zusammen mit dem Demo-Feed, committet nur bei Änderung
- ist der Stand älter als sieben Tage, schreibt das HQ es dazu statt ihn nur zu datieren — dieselbe Regel wie beim Zwischenspeicher

## Zu den Nebenbefunden

**Token in `sessionStorage`** ist Absicht: pro Tab, weg beim Schließen, nie im Repo. Dass der authentifizierte Pfad dadurch nicht fremdgetestet werden kann, ist der Preis. Die Alternative wäre ein dauerhaft abgelegter Token — der Preis ist der bessere.

**Das Audit ist jetzt aktuell**, der überholte Befund verschwunden.

## Verifikation

- **104/104 Tests** (5 neue)
- CSP-Erweiterung in PHP gegen die echte Direktivenliste **ausgeführt**, nicht gelesen
- `php -l functions.php` sauber · `npm run gate` grün

## Was ich nicht prüfen kann

Ob der Live-Header nach dem Deploy tatsächlich `api.github.com` führt, sieht man erst auf dem Server. Miss es nach dem Merge nach — wenn es fehlt, liegt es doch an einer zweiten Header-Quelle und wandert nach `.htaccess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_