### PR TITLE
OpenRouter-Key ohne Limit korrekt behandeln

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,9 @@ Farbmodi), Design-System, CSS-Minify. `pr-check.yml` blockiert PRs bei Fehlern.
 OpenRouter: Scout → Architekt → Implementierer → Reviewer. Ein Lauf darf
 höchstens zwei fest freigegebene, kleine Frontend-Dateien und 260 Diff-Zeilen
 berühren; Backend, Auth, Zahlungen, Workflows, Netzwerk- und Storage-Pfade sind
-hart ausgeschlossen. Kostenlimit: 0,35 USD pro Lauf, Mindestrest 1 USD.
+hart ausgeschlossen. Kostenlimit: 0,35 USD pro Lauf; hat der verwendete Key
+ein eigenes Limit, startet er unter 1 USD Rest nicht mehr. `null` bedeutet bei
+OpenRouter „kein Key-Limit", nicht „kein Guthaben".
 
 Der Autopilot führt Syntax-Gates, Reproduzierbarkeits-Gate und die komplette
 Playwright-Suite aus und erstellt erst dann einen PR. `openrouter-auto-merge.yml`

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -224,6 +224,9 @@ function jsonAusAntwort(inhalt) {
 }
 
 function zahl(v) {
+  // OpenRouter verwendet null fuer „kein eigenes Schluessel-Limit". Number(null)
+  // waere 0 und wuerde einen unbegrenzten Key faelschlich als leer sperren.
+  if (v === null || v === undefined || v === '') return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
 }
@@ -283,6 +286,9 @@ async function main(argv = []) {
     ?? ((zahl(kd.limit) !== null && zahl(kd.usage) !== null) ? zahl(kd.limit) - zahl(kd.usage) : null);
   if (remaining !== null && remaining < minRemaining) {
     throw new Error(`OpenRouter-Kostenbremse: nur noch $${remaining.toFixed(2)} Schluessel-Limit uebrig.`);
+  }
+  if (remaining === null) {
+    console.log(`OpenRouter-Schluessel ohne eigenes Limit; Laufbudget bleibt bei $${runBudget.toFixed(2)}.`);
   }
 
   const modellPreise = new Map((modelInfo.data || []).map((m) => [m.id, m.pricing || {}]));
@@ -503,6 +509,9 @@ function prBody(r) {
 }
 
 function selfTest() {
+  if (zahl(null) !== null || zahl(undefined) !== null || zahl('') !== null || zahl('0') !== 0) {
+    throw new Error('Zahlparser unterscheidet kein Limit nicht korrekt von dem Wert 0.');
+  }
   pruefeDateiliste(['js/modules/ui/43-showcase.js']);
   const gut = [
     'diff --git a/js/modules/ui/43-showcase.js b/js/modules/ui/43-showcase.js',

--- a/vault/30-Betrieb/Verbindungen.md
+++ b/vault/30-Betrieb/Verbindungen.md
@@ -192,8 +192,9 @@ Lauf nutzt vier voneinander getrennte Rollen und strukturierte JSON-Ausgaben:
 
 OpenRouter übernimmt Provider- und Modell-Fallbacks. Der Request verlangt
 Provider ohne Datenweitergabe (`data_collection: deny`) und Unterstützung aller
-verwendeten Parameter. Jeder Wochenlauf ist auf 0,35 USD begrenzt und startet
-nicht unter 1 USD verbleibendem Schlüssel-Limit.
+verwendeten Parameter. Jeder Wochenlauf ist auf 0,35 USD begrenzt. Hat der Key
+ein eigenes Limit, startet er unter 1 USD Rest nicht; OpenRouters `null` bei
+einem Key ohne eigenes Limit darf dabei nicht als 0 USD interpretiert werden.
 
 **Doppelte technische Grenze:** Das Agentenskript lässt nur eine feste Liste
 kleiner Frontend-Dateien zu und blockiert unter anderem Auth, Payment, Backend,

--- a/vault/50-Evolution/AI-Gedaechtnis/Claude-Kontext.md
+++ b/vault/50-Evolution/AI-Gedaechtnis/Claude-Kontext.md
@@ -19,8 +19,9 @@ tags: [layer/L5, domain/evolution, share/internal]
   nicht-sensibler Frontend-Dateien; höchstens 2 Dateien und 260 Diff-Zeilen.
   Kein Backend, Auth, Payment, Workflow, bestehender Test, Netzwerk-, Cookie-
   oder Storage-Pfad. `git apply --check` läuft vor dem Anwenden.
-- **Kostenbremse:** höchstens 0,35 USD je Wochenlauf; unter 1 USD verbleibendem
-  Schlüssel-Limit startet kein Lauf. Modell, Token und Kosten stehen im PR.
+- **Kostenbremse:** höchstens 0,35 USD je Wochenlauf; bei einem Key mit eigenem
+  Limit startet unter 1 USD Rest kein Lauf. OpenRouters `null` bedeutet „kein
+  Key-Limit", nicht 0 USD. Modell, Token und Kosten stehen im PR.
 - **Vollautonome, aber rückholbare Auslieferung:** Agenten-Review → Gate →
   Syntax-Gates → komplette Playwright-Suite → eindeutig zugeordneter PR →
   erneute Scope-Prüfung → Squash-Merge → explizit gestarteter bestehender

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -296,7 +296,8 @@ YouTube-Transkripte (das Tor steht, es fehlt nur der Abholer).
   - Vier getrennte Rollen: Scout → Architektur → Implementierung → unabhängiges Review.
   - Feste Whitelist kleiner Frontend-Dateien; max. 2 Dateien/260 Diff-Zeilen;
     Backend, Auth, Payment, Workflows, Netzwerk und Storage hart ausgeschlossen.
-  - Kostenlimit 0,35 USD/Lauf, Mindestrest 1 USD; Modell/Token/Kosten im PR.
+  - Kostenlimit 0,35 USD/Lauf; bei gesetztem Key-Limit Mindestrest 1 USD;
+    Modell/Token/Kosten im PR.
   - Autonome Auslieferung nur nach Syntax-Gates, Reproduzierbarkeits-Gate,
     kompletter Playwright-Suite und erneuter Scope-Prüfung; danach explizit
     gestarteter, normaler Rollback-fähiger Deploy.


### PR DESCRIPTION
## Root Cause

OpenRouter liefert für einen API-Key ohne eigenes Key-Limit `limit_remaining: null`. Der Parser verwendete `Number(null)` und interpretierte das als `0`; dadurch stoppte der erste Autopilot-Lauf vor dem Scout-Aufruf, obwohl der Schlüssel gültig ist.

## Fix

- `null`, `undefined` und leere Werte bleiben „nicht vorhanden“ statt 0
- ein echter numerischer Wert `0` bleibt 0 und löst weiterhin die Mindestrest-Sperre aus
- ohne eigenes Key-Limit gilt weiterhin das harte Laufbudget von 0,35 USD
- Selbsttest deckt alle vier Fälle ab; Betriebsdokumentation präzisiert die Semantik

## Validierung

- `npm run gate` — grün
- Autopilot-Integration 3/3 — grün
- Node-Syntax und `git diff --check` — grün
- Fehlerlauf [#1](https://github.com/Sabindro53/eventboerse/actions/runs/30881327454) bestätigt: Key vorhanden, Guardrails grün, Stop exakt vor dem ersten Modellaufruf
