### PR TITLE
Konservatives Architektur-Skip korrekt zulassen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,9 @@ fehlgeschlagenen Versuch gegen dasselbe Laufbudget.
 Das an Provider gesendete JSON-Schema nutzt nur den gemeinsamen Structured-
 Output-Kern; feinere Längen-, Mengen- und Risikogrenzen werden danach lokal
 deterministisch validiert und lösen bei Verstoß ebenfalls den Rollen-Fallback aus.
+Eine Architekturentscheidung `skip` braucht einen substanziellen Grund, aber
+keine erfundenen Implementierungsschritte; nur `implement` verlangt Plan,
+Invarianten und Verifikation in voller Mindestmenge.
 
 Der Autopilot führt Syntax-Gates, Reproduzierbarkeits-Gate und die komplette
 Playwright-Suite aus und erstellt erst dann einen PR. `openrouter-auto-merge.yml`

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -482,10 +482,17 @@ function validiereAgentenJson(rolle, json) {
     if (json.risk !== 'low') throw new Error('Scout-Risiko ist nicht low.');
   } else if (rolle === 'architect') {
     pruefeDateiliste(json.target_files);
-    textLaenge(json, 'skip_reason', 0, 500);
-    arrayLaenge(json, 'steps', 2, 6);
-    arrayLaenge(json, 'invariants', 3, 8);
-    arrayLaenge(json, 'verification', 2, 6);
+    if (json.decision === 'skip') {
+      textLaenge(json, 'skip_reason', 20, 1000);
+      arrayLaenge(json, 'steps', 0, 6);
+      arrayLaenge(json, 'invariants', 0, 8);
+      arrayLaenge(json, 'verification', 0, 6);
+    } else {
+      textLaenge(json, 'skip_reason', 0, 1000);
+      arrayLaenge(json, 'steps', 2, 6);
+      arrayLaenge(json, 'invariants', 3, 8);
+      arrayLaenge(json, 'verification', 2, 6);
+    }
   } else if (rolle === 'implementer') {
     textLaenge(json, 'patch', 0, 48000);
     textLaenge(json, 'summary', 20, 700);
@@ -604,6 +611,12 @@ function selfTest() {
   if (/"(?:minLength|maxLength|minItems|maxItems|uniqueItems|minimum|maximum)"/.test(schemas)) {
     throw new Error('API-Schema enthaelt nicht portable Validierungs-Schluesselwoerter.');
   }
+  validiereAgentenJson('architect', {
+    decision: 'skip',
+    skip_reason: 'Der Nutzen ist mit dem vorhandenen Kontext nicht sicher belegbar.',
+    target_files: ['js/modules/ui/43-showcase.js'],
+    steps: [], invariants: [], verification: [],
+  });
   pruefeDateiliste(['js/modules/ui/43-showcase.js']);
   const gut = [
     'diff --git a/js/modules/ui/43-showcase.js b/js/modules/ui/43-showcase.js',

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -101,6 +101,7 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/ergebnis: 'unbrauchbar'/);
     expect(runner).toMatch(/validiereAgentenJson\(rolle, json\)/);
     expect(runner).toMatch(/nicht portable Validierungs-Schluesselwoerter/);
+    expect(runner).toMatch(/json\.decision === 'skip'/);
   });
 
   test('autonomer Scope schließt sensible Dateien und Seiteneffekte aus', () => {


### PR DESCRIPTION
## Root Cause

Im vierten echten Agentenlauf lieferte der Scout gültiges strukturiertes JSON. Die drei Architekturmodelle entschieden konservativ `skip`, wurden aber trotzdem gegen die Mindestmengen eines Implementierungsplans geprüft. Leere `steps` bei einer bewussten Stop-Entscheidung wurden fälschlich als Fehler behandelt.

## Fix

- `decision: skip`: substanzieller Grund mit 20–1000 Zeichen erforderlich; Plan-/Invarianten-/Verifikationslisten dürfen leer sein
- `decision: implement`: unverändert mindestens 2 Schritte, 3 Invarianten und 2 Verifikationen
- Selbsttest deckt die gültige konservative Stop-Entscheidung ab

## Validierung

- `npm run gate` — grün
- Autopilot-Integration 3/3 — grün
- Node-Syntax und `git diff --check` — grün
- echter Lauf [#4](https://github.com/Sabindro53/eventboerse/actions/runs/30896226048): Scout erfolgreich; Architektur-Fallbacks insgesamt 0,0015 USD; Stop exakt im lokalen Validator
