### PR TITLE
Sicheren Scout-Null-Lauf erlauben

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,9 @@ deterministisch validiert und lösen bei Verstoß ebenfalls den Rollen-Fallback 
 Eine Architekturentscheidung `skip` braucht einen substanziellen Grund, aber
 keine erfundenen Implementierungsschritte; nur `implement` verlangt Plan,
 Invarianten und Verifikation in voller Mindestmenge.
+Findet bereits der Scout keinen klaren, risikoarmen Vorschlag, darf er eine
+leere Dateiliste liefern. Das beendet den Lauf erfolgreich ohne Patch/PR;
+sobald er Dateien nennt, gelten weiter exakt 1–2 Einträge der festen Whitelist.
 
 Der Autopilot führt Syntax-Gates, Reproduzierbarkeits-Gate und die komplette
 Playwright-Suite aus und erstellt erst dann einen PR. `openrouter-auto-merge.yml`

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -391,6 +391,9 @@ async function main(argv = []) {
     `Du bist der konservative Scout fuer EventBoerse. ${fremdtextRegel} `
       + 'Waehle genau EINE kleine, sichtbare, risikoarme Verbesserung. Keine erfundene Dringlichkeit, kein Backend, kein Auth, kein Payment.',
     basisKontext(fokus));
+  if (!scout.target_files.length) {
+    return ergebnisSchreiben({ changed: false, fokus, scout, laeufe, kosten: ausgegeben });
+  }
   pruefeDateiliste(scout.target_files);
 
   const quellen = dateiKontext(scout.target_files);
@@ -475,7 +478,7 @@ function validiereAgentenJson(rolle, json) {
     textLaenge(json, 'title', 8, 100);
     textLaenge(json, 'goal', 30, 700);
     textLaenge(json, 'why_now', 20, 500);
-    pruefeDateiliste(json.target_files);
+    pruefeDateiliste(json.target_files, true);
     arrayLaenge(json, 'acceptance', 2, 5).forEach((x) => {
       if (typeof x !== 'string' || x.length < 8 || x.length > 240) throw new Error('Akzeptanzkriterium ungueltig.');
     });
@@ -506,10 +509,14 @@ function validiereAgentenJson(rolle, json) {
   }
 }
 
-function pruefeDateiliste(dateien) {
-  if (!Array.isArray(dateien) || dateien.length < 1 || dateien.length > 2) {
-    throw new Error('Agent muss ein bis zwei Dateien auswaehlen.');
+function pruefeDateiliste(dateien, leerErlaubt = false) {
+  const minimum = leerErlaubt ? 0 : 1;
+  if (!Array.isArray(dateien) || dateien.length < minimum || dateien.length > 2) {
+    throw new Error(leerErlaubt
+      ? 'Scout darf null bis zwei Dateien auswaehlen.'
+      : 'Agent muss ein bis zwei Dateien auswaehlen.');
   }
+  if (new Set(dateien).size !== dateien.length) throw new Error('Dateiliste enthaelt Duplikate.');
   for (const datei of dateien) {
     if (!Object.hasOwn(SICHERE_DATEIEN, datei)) throw new Error(`Datei nicht freigegeben: ${datei}`);
     const norm = relative(ROOT, resolve(ROOT, datei));
@@ -617,6 +624,13 @@ function selfTest() {
     target_files: ['js/modules/ui/43-showcase.js'],
     steps: [], invariants: [], verification: [],
   });
+  const keinVorschlag = {
+    title: 'Kein sicherer Vorschlag',
+    goal: 'Der Scout beendet diesen Lauf bewusst ohne Aenderung am Produkt.',
+    why_now: 'Im aktuellen Kontext ist kein klarer risikoarmer Nutzen belegbar.',
+    target_files: [], acceptance: ['Keine Datei wird veraendert.', 'Der Lauf endet erfolgreich ohne PR.'], risk: 'low',
+  };
+  validiereAgentenJson('scout', keinVorschlag);
   pruefeDateiliste(['js/modules/ui/43-showcase.js']);
   const gut = [
     'diff --git a/js/modules/ui/43-showcase.js b/js/modules/ui/43-showcase.js',

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -102,6 +102,7 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/validiereAgentenJson\(rolle, json\)/);
     expect(runner).toMatch(/nicht portable Validierungs-Schluesselwoerter/);
     expect(runner).toMatch(/json\.decision === 'skip'/);
+    expect(runner).toMatch(/if \(!scout\.target_files\.length\)/);
   });
 
   test('autonomer Scope schließt sensible Dateien und Seiteneffekte aus', () => {


### PR DESCRIPTION
## Root Cause

Im fünften echten Agentenlauf lieferten zwei Scout-Modelle gültiges JSON, aber eine leere `target_files`-Liste; ein weiteres war rate-limitiert. „Kein klarer, risikoarmer Vorschlag“ ist eine sichere fachliche Stop-Entscheidung und darf den Wochenlauf nicht rot markieren.

## Fix

- ausschließlich der Scout darf 0–2 Whitelist-Dateien liefern
- 0 Dateien beendet den Lauf erfolgreich mit `changed: false`, Kostenbericht und ohne Patch/PR
- ab 1 Datei gelten unverändert: maximal 2, keine Duplikate, feste Whitelist und alle Architektur-/Patch-/Review-/CI-Gates
- Selbsttest deckt den sicheren Null-Lauf ab

## Validierung

- `npm run gate` — grün
- Autopilot-Integration 3/3 — grün
- Node-Syntax und `git diff --check` — grün
- echter Lauf [#5](https://github.com/Sabindro53/eventboerse/actions/runs/30897060287): zwei gültige Null-Vorschläge, insgesamt 0,0024 USD, Stop exakt an der früheren Mindestlänge
