### PR TITLE
fix(hq): publish runtime stream outside protected main

### DIFF
--- a/.github/workflows/hq-operations.yml
+++ b/.github/workflows/hq-operations.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: hq-operations-ensemble
@@ -27,6 +27,9 @@ jobs:
       EB_OPENROUTER_API_KEY: ${{ secrets.EB_OPENROUTER_API_KEY }}
       EB_OPENROUTER_DAILY_BUDGET_USD: '0.60'
       EB_OPENROUTER_MIN_REMAINING_USD: '1.00'
+      SFTP_PASS: ${{ secrets.IONOS_FTP_PASSWORD }}
+      SFTP_USER: ${{ secrets.IONOS_FTP_USERNAME }}
+      SFTP_HOST: ${{ secrets.IONOS_FTP_SERVER }}
 
     steps:
       - name: Kostenloses Pulsfenster bestimmen
@@ -96,6 +99,10 @@ jobs:
         if: steps.cadence.outputs.work == 'true'
         run: node scripts/agent.mjs --check
 
+      - name: SFTP-Werkzeug einrichten
+        if: steps.cadence.outputs.work == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+
       - name: Echte Laufzeitspur veroeffentlichen
         if: steps.cadence.outputs.work == 'true'
         shell: bash
@@ -104,10 +111,19 @@ jobs:
             echo "Journal unveraendert." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          git config user.name "eventboerse-hq-bot"
-          git config user.email "hq-bot@eventboerse.de"
-          git add assets/eb-arbeit.json
-          git commit -m "chore(hq): echten Operationspuls protokollieren"
-          git pull --rebase origin main
-          git push origin HEAD:main
-
+          if [ -z "$SFTP_HOST" ] || [ -z "$SFTP_USER" ] || [ -z "$SFTP_PASS" ]; then
+            echo "SFTP-Zugang fuer die Laufzeitspur fehlt." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          # Laufzeitdaten gehoeren nicht in die geschuetzte Code-Historie.
+          # Diese eine Datei wird atomar in den bereits deployten Theme-Ordner
+          # geladen; Code-Deploys lassen sie deshalb bewusst unangetastet.
+          lftp -u "$SFTP_USER","$SFTP_PASS" "sftp://$SFTP_HOST" -e "
+            set sftp:auto-confirm yes;
+            set net:timeout 60;
+            set net:max-retries 3;
+            put assets/eb-arbeit.json -o /public/wp-content/themes/eventboerse/assets/eb-arbeit.json.neu;
+            mv /public/wp-content/themes/eventboerse/assets/eb-arbeit.json.neu /public/wp-content/themes/eventboerse/assets/eb-arbeit.json;
+            bye
+          "
+          echo "✅ Echte Laufzeitspur direkt im HQ veroeffentlicht." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ionos-deploy.yml
+++ b/.github/workflows/ionos-deploy.yml
@@ -74,6 +74,7 @@ jobs:
               -x '^\.obsidian/' -x '^\.claude/' -x '^\.claude\.json$' \
               -x '^vault/' -x '^docs/' -x '^tests/' -x '^node_modules/' \
               -x '^js/modules/' -x '^build-app-js\.sh$' \
+              -x '^assets/eb-arbeit\.json$' \
               -x '^package\.json$' -x '^package-lock\.json$' -x '^playwright\.config\.js$' \
               -x '^LICENSE$' -x '^README\.md$' -x '^CNAME$' -x '^AGENTS\.md$' \
               -x '^SECURITY\.md$' \

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -76,6 +76,10 @@ const AUFTRAG = {
 };
 
 const zahl = (v) => {
+  // OpenRouter verwendet `null` fuer ein nicht gesetztes (also nicht fuer ein
+  // aufgebrauchtes) Schluessellimit. Number(null) waere 0 und wuerde einen
+  // Unlimited-Key faelschlich komplett sperren.
+  if (v === null || v === undefined || v === '') return null;
   const n = Number(v);
   return Number.isFinite(n) ? n : null;
 };


### PR DESCRIPTION
## Ursache

OpenRouter liefert bei Unlimited-Keys limit_remaining: null. Die Zahl-Konvertierung behandelte null als 0 und stoppte alle Rollen. Danach blockierte der geschuetzte Main-Branch die Laufzeitspur.

## Korrektur

- Nullable Kontingentwerte korrekt behandeln
- Arbeitsjournal atomar direkt in den Live-Theme-Ordner schreiben
- Laufzeitjournal bei normalen Code-Deploys erhalten
- Protected Main bleibt unveraendert geschuetzt

## Pruefung

- npm run gate gruen
- git diff --check gruen
- erster Fehlversuch hat keine Tokens verbraucht