### PR TITLE
fix(hq): overwrite runtime journal on IONOS

### DIFF
--- a/.github/workflows/hq-operations.yml
+++ b/.github/workflows/hq-operations.yml
@@ -116,14 +116,15 @@ jobs:
             exit 1
           fi
           # Laufzeitdaten gehoeren nicht in die geschuetzte Code-Historie.
-          # Diese eine Datei wird atomar in den bereits deployten Theme-Ordner
+          # Diese eine Datei wird in den bereits deployten Theme-Ordner
           # geladen; Code-Deploys lassen sie deshalb bewusst unangetastet.
+          # IONOS erlaubt fuer diesen SFTP-Benutzer kein serverseitiges Rename,
+          # deshalb wird wie im bewaehrten Theme-Deploy direkt ueberschrieben.
           lftp -u "$SFTP_USER","$SFTP_PASS" "sftp://$SFTP_HOST" -e "
             set sftp:auto-confirm yes;
             set net:timeout 60;
             set net:max-retries 3;
-            put assets/eb-arbeit.json -o /public/wp-content/themes/eventboerse/assets/eb-arbeit.json.neu;
-            mv /public/wp-content/themes/eventboerse/assets/eb-arbeit.json.neu /public/wp-content/themes/eventboerse/assets/eb-arbeit.json;
+            put assets/eb-arbeit.json -o /public/wp-content/themes/eventboerse/assets/eb-arbeit.json;
             bye
           "
           echo "✅ Echte Laufzeitspur direkt im HQ veroeffentlicht." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Der echte Ensemble-Lauf und die Journalprüfung waren erfolgreich. IONOS akzeptiert den Upload, verbietet für diesen SFTP-Benutzer aber das serverseitige Rename. Diese Korrektur verwendet denselben direkten put/overwrite-Pfad wie der bewährte Produktionsdeploy.

Prüfung: npm run gate und git diff --check grün.