### PR TITLE
HQ: Live-Arbeitsjournal über Rollenläufe erhalten

### DIFF
--- a/.github/workflows/hq-operations.yml
+++ b/.github/workflows/hq-operations.yml
@@ -46,6 +46,20 @@ jobs:
       - name: Ensemble-Katalog pruefen
         run: node scripts/models.mjs --check
 
+      - name: Bestehende Laufzeitspur vorladen
+        shell: bash
+        run: |
+          tmp="$(mktemp)"
+          curl --fail --silent --show-error --location --retry 3 --max-time 30 \
+            "https://xn--eventbrse-57a.de/wp-content/themes/eventboerse/assets/eb-arbeit.json?run=${GITHUB_RUN_ID}" \
+            --output "$tmp"
+          if ! jq -e '.version == 1 and (.eintraege | type == "array")' "$tmp" >/dev/null; then
+            echo "Live-Journal ist nicht valide; bestehende Laufzeitspur wird nicht ueberschrieben." >&2
+            exit 1
+          fi
+          mv "$tmp" assets/eb-arbeit.json
+          echo "Bestehende Laufzeitspur mit $(jq '.eintraege | length' assets/eb-arbeit.json) Eintraegen geladen." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Naechste Rolle im Rundlauf bestimmen
         id: cadence
         shell: bash

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -154,6 +154,9 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(operations).toMatch(/EB_OPENROUTER_DAILY_BUDGET_USD:\s*'0\.60'/);
     expect(operations).toMatch(/rolle=\$rolle/);
     expect(operations).toMatch(/5-Minuten-HQ-Rundlauf/);
+    expect(operations).toMatch(/Bestehende Laufzeitspur vorladen/);
+    expect(operations).toMatch(/eb-arbeit\.json\?run=\$\{GITHUB_RUN_ID\}/);
+    expect(operations.indexOf('Bestehende Laufzeitspur vorladen')).toBeLessThan(operations.indexOf('Rolle taskweise arbeiten lassen'));
     expect(operations).toMatch(/select\(\.weg == "openrouter"\)/);
     expect(operations).toMatch(/scripts\/agent\.mjs/);
     expect(operations).toMatch(/assets\/eb-arbeit\.json/);


### PR DESCRIPTION
## Fix

Jeder 5-Minuten-Rollenlauf lädt und validiert zuerst die bestehende Laufzeitspur vom Live-HQ. Erst danach wird genau ein neuer Beleg ergänzt und die Datei wieder veröffentlicht. Bei einem fehlenden oder ungültigen Live-Journal stoppt der Lauf sicher, statt die Historie zu überschreiben.

## Verifikation

- Live-Journal mit 11 vorhandenen Einträgen erfolgreich validiert
- `npm run gate`
- 32/32 HQ-Kern- und Workflow-Tests grün