### PR TITLE
Autopilot: Qualitätsuntergrenze für beleggebundenen Scout

### DIFF
--- a/docs/hq-live-codeflow.md
+++ b/docs/hq-live-codeflow.md
@@ -34,6 +34,7 @@ Nach jeder Modellphase schreibt `scripts/openrouter-agents.mjs` den aktuellen Zu
 
 - Die Telemetrie enthält Ziel, Dateinamen, Diff-Statistik, Review und Kosten, aber niemals Patchinhalt, Prompts oder Geheimnisse.
 - Der Scout bekommt fokusabhängige, nummerierte Zeilen aus der Whitelist und wählt nur kurze Beleg-IDs. Datei, Zeile und wortgetreuer Auszug werden danach ausschließlich vom System aus dem geprüften Katalog gesetzt.
+- Für die beleggebundene Scout-Aufgabe gilt eine 24B/30B-Qualitätsuntergrenze; 8B–12B-Modelle bleiben für kurze Operationssignale nutzbar, aber nicht für diese strukturierte Codeentscheidung.
 - Der Autopilot darf höchstens zwei explizit freigegebene Frontend-Quelldateien ändern; generierte `app.js` ist nur als Buildfolge erlaubt.
 - Neue Dateien, Löschungen, Umbenennungen, Netzwerk-, Storage-, Auth- und Payment-Pfade sind blockiert.
 - Jede Änderung braucht strukturiertes Vier-Augen-Review, vollständige Gates und eine zweite Scope-Prüfung im Auto-Merge-Workflow.

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -48,9 +48,9 @@ const SICHERE_DATEIEN = Object.freeze({
 const AGENTEN = Object.freeze({
   scout: {
     name: 'Ela Voss · Scout',
-    model: 'google/gemma-3-12b-it',
-    fallbacks: ['mistralai/mistral-nemo', 'meta-llama/llama-3.1-8b-instruct'],
-    maxTokens: 650,
+    model: 'qwen/qwen3-30b-a3b-instruct-2507',
+    fallbacks: ['mistralai/mistral-small-3.2-24b-instruct', 'meta-llama/llama-3.3-70b-instruct'],
+    maxTokens: 950,
     temperature: 0.15,
   },
   architect: {
@@ -375,7 +375,7 @@ function kostenSchaetzen(antwort, modellPreise) {
 /**
  * Waehlt innerhalb der fuer eine Rolle vorab geprueften Modelle den
  * guenstigsten Kandidaten fuer genau diesen Aufruf. Die Rollenqualitaet bleibt
- * damit eine Code-Entscheidung; der Preis entscheidet nur zwischen passenden
+ * mit einer pro Rolle gepflegten Modell-Whitelist eine Code-Entscheidung; der Preis entscheidet nur zwischen passenden
  * Modellen. OpenRouter sortiert danach auch die Provider dieses Modells nach
  * Preis. Bei fehlenden Preisen bleibt die deklarierte Reihenfolge erhalten.
  */

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -114,6 +114,9 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/runBudget.*0\.12/);
     expect(runner).toMatch(/dailyBudget.*0\.60/);
     expect(runner).toMatch(/modellKandidaten/);
+    const scoutModelle = runner.slice(runner.indexOf('scout: {'), runner.indexOf('architect: {'));
+    expect(scoutModelle).toContain('qwen/qwen3-30b-a3b-instruct-2507');
+    expect(scoutModelle).not.toMatch(/gemma-3-12b|llama-3\.1-8b|mistral-nemo/);
     expect(runner).toMatch(/sort:\s*'price'/);
     expect(runner).toMatch(/max_price/);
     expect(runner).toMatch(/for \(const modell of kandidaten\)/);


### PR DESCRIPTION
## Live-Befund

Run #30 zeigte, dass die billigsten 8B–12B-Modelle das beleggebundene Scout-Schema nicht zuverlässig einhalten: jeweils Dateiumfang, Zieltext oder Akzeptanzkriterien waren strukturell unbrauchbar.

## Routing-Änderung

- Scout: Qwen3 30B MoE
- Fallbacks: Mistral Small 24B, Llama 3.3 70B
- Preisrouting bleibt innerhalb dieser geeigneten Qualitätsklasse aktiv
- kleine Modelle bleiben für kurze Operationssignale verfügbar, aber nicht mehr für strukturierte Codeentscheidungen
- Antwortbudget 950 Tokens, Lauf-/Tageskostenbremsen unverändert

## Prüfung

- Guardrail-Selbsttest grün
- statischer Test blockiert künftig 8B–12B-Scoutmodelle
- `git diff --check` grün