### PR TITLE
Autopilot: Eine belegte Datei pro Lauf und ehrliche Fehlerkosten

### DIFF
--- a/docs/hq-live-codeflow.md
+++ b/docs/hq-live-codeflow.md
@@ -35,6 +35,7 @@ Nach jeder Modellphase schreibt `scripts/openrouter-agents.mjs` den aktuellen Zu
 - Die Telemetrie enthält Ziel, Dateinamen, Diff-Statistik, Review und Kosten, aber niemals Patchinhalt, Prompts oder Geheimnisse.
 - Der Scout bekommt fokusabhängige, nummerierte Zeilen aus der Whitelist und wählt nur kurze Beleg-IDs. Datei, Zeile und wortgetreuer Auszug werden danach ausschließlich vom System aus dem geprüften Katalog gesetzt.
 - Für die beleggebundene Scout-Aufgabe gilt eine 24B/30B-Qualitätsuntergrenze; 8B–12B-Modelle bleiben für kurze Operationssignale nutzbar, aber nicht für diese strukturierte Codeentscheidung.
+- Der Scout darf pro Lauf exakt eine Zieldatei und zwei Akzeptanzkriterien weiterreichen. Auch bei einem sicheren Fehlstopp zeigt die Telemetrie die bereits angefallenen Modellkosten.
 - Der Autopilot darf höchstens zwei explizit freigegebene Frontend-Quelldateien ändern; generierte `app.js` ist nur als Buildfolge erlaubt.
 - Neue Dateien, Löschungen, Umbenennungen, Netzwerk-, Storage-, Auth- und Payment-Pfade sind blockiert.
 - Jede Änderung braucht strukturiertes Vier-Augen-Review, vollständige Gates und eine zweite Scope-Prüfung im Auto-Merge-Workflow.

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -84,6 +84,7 @@ const CODEFLOW_ROLLEN = Object.freeze([
 ]);
 const CODEFLOW_REIHENFOLGE = ['scout', 'architect', 'implementer', 'reviewer', 'gates', 'pull_request', 'merge', 'deploy'];
 let codeflow = null;
+let codeflowKosten = 0;
 
 function codeflowSchreiben(phase, daten = {}) {
   if (!codeflow) return;
@@ -120,6 +121,7 @@ function codeflowSchreiben(phase, daten = {}) {
 }
 
 function codeflowStart(fokus, runBudget, dailyBudget) {
+  codeflowKosten = 0;
   const runId = process.env.GITHUB_RUN_ID || null;
   const repo = process.env.GITHUB_REPOSITORY || 'Sabindro53/eventboerse';
   const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
@@ -155,6 +157,7 @@ function codeflowStart(fokus, runBudget, dailyBudget) {
 
 function codeflowFehler(error) {
   if (!codeflow) return;
+  codeflow.budget.kosten_usd = Number(codeflowKosten.toFixed(6));
   codeflowSchreiben(codeflow.phase || 'scout', {
     status: 'fehler',
     fehler: String(error && error.message || error).slice(0, 700),
@@ -529,6 +532,7 @@ async function main(argv = []) {
 
       const kosten = kostenSchaetzen(antwort, modellPreise);
       ausgegeben += kosten;
+      codeflowKosten = ausgegeben;
       if (ausgegeben > runBudget) {
         throw new Error(`OpenRouter-Laufbudget ueberschritten ($${ausgegeben.toFixed(4)} > $${runBudget.toFixed(2)}).`);
       }
@@ -564,6 +568,7 @@ async function main(argv = []) {
   const scout = await agent('scout', scoutLaufSchema,
     `Du bist der konservative Scout fuer EventBoerse. ${fremdtextRegel} `
       + 'Waehle genau EINE kleine, sichtbare, risikoarme Verbesserung. Keine erfundene Dringlichkeit, kein Backend, kein Auth, kein Payment. '
+      + 'Bei einem Vorschlag muss target_files EXAKT EINE Datei enthalten, acceptance EXAKT ZWEI Kriterien und goal einen vollstaendigen Satz mit mindestens 30 Zeichen. '
       + 'Jede Zieldatei braucht mindestens eine Beleg-ID aus REPOSITORY-BELEGE. Gib in evidence nur IDs wie B001 zurueck; Datei, Zeile und Auszug setzt das System. '
       + 'Behaupte keine Selektoren, Tokens oder Funktionen, die nicht in den gewaehlten Belegen vorkommen. Wenn kein belastbarer Hebel sichtbar ist, gib leere target_files und evidence zurueck.',
     basisKontext(fokus, belegKatalog), { belege: belegKatalog });

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -165,6 +165,8 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/codeflowSchreiben\('reviewer'/);
     expect(runner).toMatch(/REPOSITORY-BELEGE/);
     expect(runner).toMatch(/Scout-Beleg-ID ist nicht im aktuellen Repo-Katalog/);
+    expect(runner).toMatch(/target_files EXAKT EINE Datei/);
+    expect(runner).toMatch(/codeflow\.budget\.kosten_usd = Number\(codeflowKosten/);
     expect(workflow).toMatch(/Live-Codeflow vorbereiten/);
     expect(workflow).toMatch(/\.ai-run\/codeflow\.json/);
     expect(workflow).toMatch(/assets\/eb-codeflow\.json/);


### PR DESCRIPTION
## Live-Befund

Run #32 wählte mehrere Code-Quality-Dateien, obwohl der Autopilot einen einzelnen reversiblen Hebel liefern soll. Die Fallbackantworten verfehlten Ziel- bzw. Akzeptanzlängen.

## Änderung

- Scout-Anweisung: exakt eine Zieldatei, exakt zwei Akzeptanzkriterien
- Zieltext muss ein vollständiger Satz mit mindestens 30 Zeichen sein
- Dateibeleg-ID bleibt Pflicht
- bereits verbrauchte Modellkosten werden auch beim Fehlstopp live ausgewiesen
- Patch-Whitelist, Vier-Augen-Prüfung und Budgets unverändert

## Prüfung

- Guardrail-Selbsttest grün
- neue statische Regressionstests für Kardinalität und Fehlerkosten
- `git diff --check` grün