### PR TITLE
Autopilot: Reviewer-Befunde eindeutig blockierend definieren

### DIFF
--- a/docs/hq-live-codeflow.md
+++ b/docs/hq-live-codeflow.md
@@ -36,6 +36,7 @@ Nach jeder Modellphase schreibt `scripts/openrouter-agents.mjs` den aktuellen Zu
 - Der Scout bekommt fokusabhängige, nummerierte Zeilen aus der Whitelist und wählt nur kurze Beleg-IDs. Datei, Zeile und wortgetreuer Auszug werden danach ausschließlich vom System aus dem geprüften Katalog gesetzt.
 - Für die beleggebundene Scout-Aufgabe gilt eine 24B/30B-Qualitätsuntergrenze; 8B–12B-Modelle bleiben für kurze Operationssignale nutzbar, aber nicht für diese strukturierte Codeentscheidung.
 - Der Scout darf pro Lauf exakt eine Zieldatei und zwei Akzeptanzkriterien weiterreichen. Auch bei einem sicheren Fehlstopp zeigt die Telemetrie die bereits angefallenen Modellkosten.
+- Reviewer-`findings` sind ausschließlich offene, blockierende Mängel. Positive Prüfbestätigungen stehen in der Zusammenfassung; eine Freigabe hat eine leere Befundliste.
 - Der Autopilot darf höchstens zwei explizit freigegebene Frontend-Quelldateien ändern; generierte `app.js` ist nur als Buildfolge erlaubt.
 - Neue Dateien, Löschungen, Umbenennungen, Netzwerk-, Storage-, Auth- und Payment-Pfade sind blockiert.
 - Jede Änderung braucht strukturiertes Vier-Augen-Review, vollständige Gates und eine zweite Scope-Prüfung im Auto-Merge-Workflow.

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -638,7 +638,8 @@ async function main(argv = []) {
   const review = await agent('reviewer', REVIEW_SCHEMA,
     `Du bist der unabhaengige Code-Reviewer. ${fremdtextRegel} `
       + 'Lehne bei jeder Scope-Ausweitung, Seiteneffekt-Gefahr, unklaren Annahme oder unvollstaendigen Akzeptanzabdeckung ab. '
-      + 'Eine Freigabe braucht confidence >= 0.86 und alle safety-Felder true.',
+      + 'Eine Freigabe braucht confidence >= 0.86 und alle safety-Felder true. '
+      + 'findings enthaelt AUSSCHLIESSLICH offene, blockierende Maengel; bei approved=true muss findings exakt [] sein. Positive Bestaetigungen gehoeren nur in summary.',
     `ANFORDERUNG UND PLAN:\n${JSON.stringify({ scout, architekt }, null, 2)}\n\nPATCH:\n${patch}\n\nAUSGANGSCODE:\n${quellen}`);
 
   const sicher = Object.values(review.safety || {}).every(Boolean);

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -167,6 +167,7 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/Scout-Beleg-ID ist nicht im aktuellen Repo-Katalog/);
     expect(runner).toMatch(/target_files EXAKT EINE Datei/);
     expect(runner).toMatch(/codeflow\.budget\.kosten_usd = Number\(codeflowKosten/);
+    expect(runner).toMatch(/bei approved=true muss findings exakt \[\] sein/);
     expect(workflow).toMatch(/Live-Codeflow vorbereiten/);
     expect(workflow).toMatch(/\.ai-run\/codeflow\.json/);
     expect(workflow).toMatch(/assets\/eb-codeflow\.json/);


### PR DESCRIPTION
## Live-Befund

Run #33 erzeugte einen belegten Patch in `js/modules/ui/25-reviews.js`. Kito gab ihn mit `approved=true` und 0,92 Konfidenz frei, schrieb positive Prüfbestätigungen aber in `findings`; der deterministische Wächter stoppte korrekt, weil jede Finding-Zeile als offener Mangel gilt.

## Änderung

- `findings` darf nur offene, blockierende Mängel enthalten
- bei `approved=true` muss `findings` exakt leer sein
- positive Bestätigungen gehören in `summary`
- Freigabeschwelle, Safety-Felder und alle Patch-Grenzen bleiben unverändert

## Prüfung

- Guardrail-Selbsttest grün
- neue statische Vertragsprüfung
- `git diff --check` grün