### PR TITLE
Autopilot: Scout-Belege um echtes Quellfenster erweitern

### DIFF
--- a/docs/hq-live-codeflow.md
+++ b/docs/hq-live-codeflow.md
@@ -34,6 +34,7 @@ Nach jeder Modellphase schreibt `scripts/openrouter-agents.mjs` den aktuellen Zu
 
 - Die Telemetrie enthält Ziel, Dateinamen, Diff-Statistik, Review und Kosten, aber niemals Patchinhalt, Prompts oder Geheimnisse.
 - Der Scout bekommt fokusabhängige, nummerierte Zeilen aus der Whitelist und wählt nur kurze Beleg-IDs. Datei, Zeile und wortgetreuer Auszug werden danach ausschließlich vom System aus dem geprüften Katalog gesetzt.
+- Jeder Beleg enthält ab seiner Trefferzeile ein kompaktes dreizeiliges Quellfenster, damit der Scout keine fehlenden Implementierungsdetails aus einer isolierten Zeile erfinden muss.
 - Für die beleggebundene Scout-Aufgabe gilt eine 24B/30B-Qualitätsuntergrenze; 8B–12B-Modelle bleiben für kurze Operationssignale nutzbar, aber nicht für diese strukturierte Codeentscheidung.
 - Der Scout darf pro Lauf exakt eine Zieldatei und zwei Akzeptanzkriterien weiterreichen. Auch bei einem sicheren Fehlstopp zeigt die Telemetrie die bereits angefallenen Modellkosten.
 - Reviewer-`findings` sind ausschließlich offene, blockierende Mängel. Positive Prüfbestätigungen stehen in der Zusammenfassung; eine Freigabe hat eine leere Befundliste.

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -321,11 +321,12 @@ function repoBelege(fokus) {
     for (let index = 0; index < zeilen.length && proDatei < 5 && belege.length < 60; index += 1) {
       const auszug = zeilen[index].trim();
       if (!auszug || !muster.test(auszug)) continue;
+      const quellfenster = zeilen.slice(index, index + 3).map((zeile) => zeile.trim()).filter(Boolean).join(' ⏎ ');
       belege.push({
         id: `B${String(belege.length + 1).padStart(3, '0')}`,
         file: datei,
         line: index + 1,
-        excerpt: auszug.slice(0, 240),
+        excerpt: quellfenster.slice(0, 240),
       });
       proDatei += 1;
     }
@@ -569,7 +570,7 @@ async function main(argv = []) {
     `Du bist der konservative Scout fuer EventBoerse. ${fremdtextRegel} `
       + 'Waehle genau EINE kleine, sichtbare, risikoarme Verbesserung. Keine erfundene Dringlichkeit, kein Backend, kein Auth, kein Payment. '
       + 'Bei einem Vorschlag muss target_files EXAKT EINE Datei enthalten, acceptance EXAKT ZWEI Kriterien und goal einen vollstaendigen Satz mit mindestens 30 Zeichen. '
-      + 'Jede Zieldatei braucht mindestens eine Beleg-ID aus REPOSITORY-BELEGE. Gib in evidence nur IDs wie B001 zurueck; Datei, Zeile und Auszug setzt das System. '
+      + 'Jede Zieldatei braucht mindestens eine Beleg-ID aus REPOSITORY-BELEGE. Jeder Beleg zeigt ein dreizeiliges Quellfenster. Gib in evidence nur IDs wie B001 zurueck; Datei, Zeile und Auszug setzt das System. '
       + 'Behaupte keine Selektoren, Tokens oder Funktionen, die nicht in den gewaehlten Belegen vorkommen. Wenn kein belastbarer Hebel sichtbar ist, gib leere target_files und evidence zurueck.',
     basisKontext(fokus, belegKatalog), { belege: belegKatalog });
   scout.evidence = scout.evidence.map((id) => belegKatalog.find((beleg) => beleg.id === id));

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -166,6 +166,7 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/REPOSITORY-BELEGE/);
     expect(runner).toMatch(/Scout-Beleg-ID ist nicht im aktuellen Repo-Katalog/);
     expect(runner).toMatch(/target_files EXAKT EINE Datei/);
+    expect(runner).toMatch(/zeilen\.slice\(index, index \+ 3\)/);
     expect(runner).toMatch(/codeflow\.budget\.kosten_usd = Number\(codeflowKosten/);
     expect(runner).toMatch(/bei approved=true muss findings exakt \[\] sein/);
     expect(workflow).toMatch(/Live-Codeflow vorbereiten/);


### PR DESCRIPTION
## Live-Befund

Run #34 erhielt für `js/modules/ui/25-reviews.js:98` nur die isolierte Zeile `.catch(function(err) {`. Der Scout erfand daraus eine `console.warn`-Annahme; Ada widerlegte sie im vollständigen Quellcode und stoppte korrekt.

## Änderung

- jeder fokusabhängige Beleg enthält ab der Trefferzeile drei echte Quellzeilen
- Datei und Startzeile bleiben exakt nachvollziehbar
- Fenster bleibt auf 240 Zeichen begrenzt und wird serverseitig erzeugt
- Beleg-ID, Ein-Datei-Scope, Reviewer und Budgets unverändert

## Prüfung

- Guardrail-Selbsttest grün
- statischer Regressionstest für das dreizeilige Fenster
- `git diff --check` grün