### PR TITLE
Befunde bestimmen die Arbeit — statt Kalenderwoche

### DIFF
--- a/.github/workflows/hq-operations.yml
+++ b/.github/workflows/hq-operations.yml
@@ -1,15 +1,21 @@
 name: HQ Operations Ensemble
 run-name: "⚡ HQ-Puls · Aufgabenstrom und Kontingent"
 
-# GitHub wird alle fuenf Minuten um einen Puls gebeten, garantiert den exakten
-# Startzeitpunkt geplanter Workflows aber nicht. Deshalb arbeitet bei JEDEM
-# tatsaechlich erreichten Puls das volle Ensemble: keine Rolle wird durch eine
-# Scheduler-Verzoegerung stundenlang uebersprungen. Der belegte Voll-Lauf vom
-# 2026-08-05 kostete $0.003646; das harte $0.60-Tagesbudget und jede Rollenquote
-# werden trotzdem vor JEDEM einzelnen Modellaufruf erneut geprueft.
+# Viermal taeglich, nicht stuendlich.
+#
+# Gemessen ueber einen Tag: rund 2 Mio Token verbraucht, praktisch ohne
+# Wirkung. Der Grund ist die Arbeitsteilung im Haus — dieser Puls erzeugt
+# LAGEBILDER, der Autopilot erzeugt ARBEIT (Patch, Tests, PR). Beide teilen
+# sich dasselbe $0.60-Tagesbudget. Bei 11 Rollen x 24 Laeufen hat der Puls es
+# aufgebraucht, bevor der Autopilot dazu kam: dessen Commits (#113-#119) liegen
+# alle zwischen 03:07 und 03:23 — genau solange das Budget frisch war, danach
+# nichts mehr.
+#
+# Ein Lagebild alle sechs Stunden ist so aktuell, wie ein Lagebild sein muss.
+# Was dadurch frei wird, geht an die Stelle, die die Seite wirklich verbessert.
 on:
   schedule:
-    - cron: '4/5 * * * *'
+    - cron: '17 2,8,14,20 * * *'
   workflow_dispatch:
 
 permissions:
@@ -26,7 +32,11 @@ jobs:
     timeout-minutes: 20
     env:
       EB_OPENROUTER_API_KEY: ${{ secrets.EB_OPENROUTER_API_KEY }}
-      EB_OPENROUTER_DAILY_BUDGET_USD: '0.60'
+      # Eigener, kleinerer Rahmen fuer den Puls: er kann das Tagesbudget des
+      # Autopiloten damit nicht mehr aufessen. $0.15 reichen fuer vier
+      # Voll-Laeufe (ein belegter Voll-Lauf kostete $0.0036), die uebrigen
+      # $0.45 bleiben der Stelle, die Code liefert.
+      EB_OPENROUTER_DAILY_BUDGET_USD: '0.15'
       EB_OPENROUTER_MIN_REMAINING_USD: '1.00'
       SFTP_PASS: ${{ secrets.IONOS_FTP_PASSWORD }}
       SFTP_USER: ${{ secrets.IONOS_FTP_USERNAME }}
@@ -78,20 +88,37 @@ jobs:
             echo "Manueller Voll-Ensemble-Puls: alle $anzahl Rollen arbeiten innerhalb ihrer Quote." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Kontext klein halten — er ist der ganze Verbrauch.
+      #
+      # Vorher gingen 180 Zeilen aus einer 26-KB-Sprintdatei plus 160 Zeilen
+      # Audit an JEDE der 11 Rollen: rund 4200 Prompt-Token pro Rolle, elfmal
+      # pro Lauf, 24 Läufe am Tag — gut 1,1 Mio Token taeglich, bei etwa
+      # 150 Token Antwort je Rolle. Verhaeltnis 28:1, und das meiste davon war
+      # abgeschlossene Historie, die niemand mehr braucht.
+      #
+      # Jetzt nur der Ist-Stand: der Kopf des Sprints (Abschnitt „Stand heute"),
+      # die letzten Commits und die Kurzfassung des Audits. Die Datei-Auszuege
+      # zur konkreten Aufgabe kommen ohnehin aus scripts/agent.mjs dazu — DA
+      # liegt der Bezug zur Arbeit, nicht in alten Sprintprotokollen.
       - name: Belegten Arbeitskontext bauen
         shell: bash
         run: |
           mkdir -p .ai-run
           {
             echo "LETZTE COMMITS"
-            git log -8 --pretty=format:'%h %s'
+            git log -6 --pretty=format:'%h %s'
             echo
-            echo "AKTUELLER SPRINT"
-            sed -n '1,180p' vault/50-Evolution/Roadmap/Current-Sprint.md
+            echo "IST-STAND"
+            # Nur bis zum ersten abgeschlossenen Sprint — alles danach ist Historie.
+            sed -n '/^## Stand heute/,/^## Zuletzt abgeschlossen/p' \
+              vault/50-Evolution/Roadmap/Current-Sprint.md | head -n 24
             echo
-            echo "LETZTER AUDIT"
-            sed -n '1,160p' audit/latest.json
+            echo "SELBSTCHECK (Kurzfassung)"
+            jq -r '{erzeugt, befunde: (.befunde // [] | length),
+                    schwer: [(.befunde // [])[] | select(.schwere == "hoch") | .titel]}' \
+              audit/latest.json 2>/dev/null || head -c 600 audit/latest.json
           } > .ai-run/ensemble-context.txt
+          echo "Kontextgröße: $(wc -c < .ai-run/ensemble-context.txt) Bytes" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Alle Rollen taskweise arbeiten lassen
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-175 Tests in 11 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+178 Tests in 11 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Kern (Impuls-Ehrlichkeit +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-178 Tests in 11 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+181 Tests in 11 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Kern (Impuls-Ehrlichkeit +

--- a/hq.html
+++ b/hq.html
@@ -1299,7 +1299,7 @@ function renderLog() {
 
 /* ─── Bot Team ─────────────────────────────────────────────────── */
 const BOTS = [
-  { id: 'operations', avatar: '⚡', name: 'HQ-Operations-Rundlauf', role: 'Bei jedem tatsächlich erreichten Scheduler-Puls arbeitet das komplette Ensemble; so überspringt eine GitHub-Verzögerung keine einzelne Rolle.', workflow: 'hq-operations.yml', schedule: '🟢 24/7-Steuerung · Taktziel 5 Min. · 11 Rollen/Puls · $0,60/Tag hart', canTrigger: true, triggerLabel: '▶ Voll-Ensemble', logsLabel: '📋 Live-Läufe', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-operations.yml` },
+  { id: 'operations', avatar: '⚡', name: 'HQ-Operations-Rundlauf', role: 'Viermal täglich arbeitet das komplette Ensemble ein Lagebild. Die Code-Arbeit macht der Autopilot — er bekommt deshalb den größeren Teil des Tagesbudgets.', workflow: 'hq-operations.yml', schedule: '🟢 Lagebild 4×/Tag (02/08/14/20 Uhr UTC) · 11 Rollen/Lauf · $0,15/Tag hart', canTrigger: true, triggerLabel: '▶ Voll-Ensemble', logsLabel: '📋 Live-Läufe', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-operations.yml` },
   { id: 'openrouter', avatar: '🧬', name: 'OpenRouter-Autopilot', role: 'Prüft alle 5 Minuten tokenfrei; im offenen Kostenfenster liefern Scout, Architekt, Implementierer und Reviewer genau eine kleine Verbesserung.', workflow: 'openrouter-autopilot.yml', schedule: '⚡ 5-Min.-Prüfung · KI max. stündlich · $0,12/Lauf · $0,60/Tag', canTrigger: true, triggerLabel: '▶ Autopilot', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=is%3Apr+label%3Aopenrouter` },
   { id: 'improve',    avatar: '✨', name: 'Claude-Verbesserung (Legacy)', role: 'Manuelles Fallback für bestehende Anthropic-Konfiguration; kein Zeitplan mehr.', workflow: 'claude-improve.yml', schedule: '🕹️ Manuell · Legacy', canTrigger: true, triggerLabel: '▶ Legacy', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=is%3Apr+label%3Aclaude-routine` },
   { id: 'claude-dev', avatar: '🤖', name: 'Claude-Audit (Legacy)', role: 'Manuelles Fallback für bestehende Anthropic-Konfiguration; kein Zeitplan mehr.', workflow: 'claude-auto-audit.yml', schedule: '🕹️ Manuell · Legacy', canTrigger: true, triggerLabel: '▶ Legacy', logsLabel: '📋 Issues', logsUrl: `https://github.com/${REPO}/issues?q=label%3Aaudit` },
@@ -2544,7 +2544,7 @@ function renderNeuralOps() {
   el.innerHTML = `
     <div class="neural-ops-head">
       <b>⚡ Live-Aufgabenstrom · <span class="neural-health ${healthClass}">${healthText}</span></b>
-      <span>Scheduler-Taktziel 5 Min. · alle 11 Rollen je erreichtem Puls · Anzeige sekündlich</span>
+      <span>Lagebild 4×/Tag · alle 11 Rollen je Lauf · Anzeige sekündlich</span>
     </div>
     <div class="neural-now-grid">
       <div class="neural-now live">
@@ -2787,7 +2787,7 @@ function renderJournal() {
   const e = (nnJournal && nnJournal.eintraege) || [];
   if (!e.length) {
     el.innerHTML = '<h5>📋 Arbeitsjournal</h5><p>Die 11 OpenRouter-Aufträge stehen in der 24/7-Steuerung. '
-      + 'GitHub prüft mit einem Taktziel von fünf Minuten; jeder tatsächlich erreichte Puls arbeitet das gesamte Ensemble ab '
+      + 'Der Lagebild-Lauf startet viermal täglich; jeder Lauf arbeitet das gesamte Ensemble ab '
       + 'und schreibt Antworten, Kostenstopps oder Fehler hier hinein.</p>';
     return;
   }

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -361,7 +361,12 @@ async function arbeiten() {
       headers: {
         'Authorization': `Bearer ${schluessel}`,
         'Content-Type': 'application/json',
-        'X-Title': 'Eventboerse HQ',
+        // OpenRouter ordnet Verbrauch ueber HTTP-Referer einer App zu. Ohne
+        // ihn lief der Puls als „Unknown App" — rund 90 % des Verbrauchs war
+        // damit nicht zuzuordnen, und genau das macht eine Kostenprüfung
+        // wertlos. Der Autopilot sendet ihn laengst; hier fehlte er.
+        'HTTP-Referer': 'https://xn--eventbrse-57a.de',
+        'X-Title': 'Eventboerse HQ · Lagebild',
       },
       body: JSON.stringify({
         model: rolle.modellId,
@@ -424,7 +429,14 @@ async function arbeiten() {
   // Inhalt. Das ist echte Aktivitaet (und kann Kosten verursacht haben), aber
   // keine fertige Arbeit. Sichtbar als Fehler protokollieren, damit das
   // Journal valide bleibt und die anderen Rollen trotzdem live erscheinen.
-  const hatErgebnis = Boolean(text);
+  //
+  // Ebenso zaehlt eine ABGESCHNITTENE Antwort nicht als erledigt. Vorher
+  // genuegte `Boolean(text)`: ein am Tokenlimit abgebrochener Halbsatz wurde
+  // als „fertig" gebucht, die Aufgabe galt als erledigt und der Zeiger rueckte
+  // weiter. Genau die Sorte Eintrag, die eine Bilanz schoenrechnet.
+  const abbruchGrund = ((antwort.choices || [])[0] || {}).finish_reason || '';
+  const abgeschnitten = abbruchGrund === 'length';
+  const hatErgebnis = Boolean(text) && !abgeschnitten;
   const eintrag = await notieren({
     zeit: heute(), rolle: rolleId, person: rolle.person, rollenname: rolle.rolle,
     modell: rolle.name, modellId: antwort.model || rolle.modellId, bereich: rolle.bereich, anlass,
@@ -432,7 +444,14 @@ async function arbeiten() {
     ergebnis: hatErgebnis ? 'fertig' : 'fehler',
     text: hatErgebnis
       ? text.slice(0, 1200)
-      : 'Provider lieferte eine leere Antwort — Aufgabe bleibt fuer den naechsten freien Slot eingeplant.',
+      : abgeschnitten
+        ? `Antwort am Tokenlimit abgeschnitten (${completionTokens} Token) — kein verwertbares Ergebnis, `
+          + 'dieselbe Aufgabe wird fortgesetzt.'
+        : 'Provider lieferte eine leere Antwort — Aufgabe bleibt fuer den naechsten freien Slot eingeplant.',
+    // Fuer die naechste Kostenprüfung nachvollziehbar machen, WARUM ein Lauf
+    // nichts geliefert hat, und wie viel davon der Cache getragen hat.
+    abbruchGrund: abbruchGrund || null,
+    cacheTokens: zahl((usage.prompt_tokens_details || {}).cached_tokens) || 0,
     dauerMs: Date.now() - begonnen,
     tokens: usage.total_tokens || null,
     promptTokens: promptTokens || null,

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -240,10 +240,11 @@ function objectSchema(properties) {
 }
 
 function argsLesen(argv) {
-  const out = { focus: 'auto', selfTest: false };
+  const out = { focus: 'auto', selfTest: false, zeigeFokus: false };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === '--focus') out.focus = argv[++i] || 'auto';
     else if (argv[i] === '--self-test') out.selfTest = true;
+    else if (argv[i] === '--zeige-fokus') out.zeigeFokus = true;
     else throw new Error(`Unbekanntes Argument: ${argv[i]}`);
   }
   if (out.focus !== 'auto' && !FOKUSSE.includes(out.focus)) {
@@ -252,10 +253,59 @@ function argsLesen(argv) {
   return out;
 }
 
+/**
+ * Woran das Ensemble zuletzt tatsaechlich etwas gefunden hat.
+ *
+ * Vorher waehlte diese Funktion nach Kalenderwoche. Das war die eigentliche
+ * Luecke im Betrieb: elf Rollen benennen stuendlich konkrete Probleme, und die
+ * einzige Stelle, die Code aendert, fragte stattdessen den Kalender. Die
+ * Befunde landeten im Journal und blieben dort liegen — viel Verbrauch, keine
+ * Wirkung.
+ *
+ * Gewertet werden nur `fertig`-Eintraege der letzten 24 Stunden: ein Ausfall
+ * ist kein Befund, und ein drei Tage alter Hinweis ist keine Lage mehr.
+ * Findet sich nichts Eindeutiges, bleibt es beim Kalender — das ist keine
+ * schlechtere Wahl, nur eine unbegruendete, und sie darf nicht als Befund
+ * ausgegeben werden.
+ *
+ * @returns {{fokus: string, grund: string}}
+ */
 function autoFokus() {
   const start = Date.UTC(new Date().getUTCFullYear(), 0, 1);
   const week = Math.floor((Date.now() - start) / (7 * 86400000));
-  return FOKUSSE[week % FOKUSSE.length];
+  const kalender = FOKUSSE[week % FOKUSSE.length];
+
+  let journal;
+  try {
+    // Tests brauchen ein eigenes Journal — sonst schreiben sie die echte
+    // Laufzeitspur um, waehrend andere Tests sie parallel lesen.
+    const pfad = process.env.EB_JOURNAL || join(ROOT, 'assets', 'eb-arbeit.json');
+    journal = JSON.parse(readFileSync(pfad, 'utf8'));
+  } catch {
+    return { fokus: kalender, grund: 'kein Arbeitsjournal lesbar — Kalenderwoche' };
+  }
+
+  const grenze = Date.now() - 24 * 3600 * 1000;
+  const frisch = (journal.eintraege || []).filter((e) => e.ergebnis === 'fertig'
+    && Date.parse(e.zeit || '') >= grenze);
+  if (!frisch.length) return { fokus: kalender, grund: 'keine frischen Befunde — Kalenderwoche' };
+
+  // Welcher Fokus wird in den Befunden am haeufigsten benannt?
+  const SIGNAL = {
+    performance:   /\bperformance|ladezeit|langsam|latenz|bundle|cache\b/i,
+    ux:            /\bux\b|bedien|verständlich|verstaendlich|orientier|reibung|nutzerführung|nutzerfuehrung/i,
+    accessibility: /barrierefrei|accessibility|\ba11y\b|kontrast|screenreader|tastatur/i,
+    seo:           /\bseo\b|sichtbarkeit|suchmaschine|meta-?description|indexier/i,
+    'code-quality': /\bcode\b|refactor|duplikat|testabdeckung|wartbar|seiteneffekt/i,
+  };
+  const punkte = Object.fromEntries(FOKUSSE.map((f) => [f, 0]));
+  for (const e of frisch) {
+    const text = `${e.aufgabe || ''} ${e.text || ''}`;
+    for (const [f, re] of Object.entries(SIGNAL)) if (re.test(text)) punkte[f] += 1;
+  }
+  const beste = FOKUSSE.reduce((a, b) => (punkte[b] > punkte[a] ? b : a), FOKUSSE[0]);
+  if (!punkte[beste]) return { fokus: kalender, grund: 'Befunde ohne klaren Schwerpunkt — Kalenderwoche' };
+  return { fokus: beste, grund: `${punkte[beste]} Befund(e) der letzten 24 h nennen „${beste}"` };
 }
 
 function lesen(rel, limit = 80000) {
@@ -423,13 +473,27 @@ async function apiJson(url, init, timeoutMs = 120000) {
 async function main(argv = []) {
   const args = argsLesen(argv);
   if (args.selfTest) return selfTest();
+  // Zeigt die Fokuswahl, ohne ein Modell zu rufen — damit laesst sich von
+  // aussen pruefen, DASS die Befunde den Fokus bestimmen, statt es nur im
+  // Quelltext zu behaupten.
+  if (args.zeigeFokus) { const w = autoFokus(); console.log(JSON.stringify(w)); return; }
 
   repoSauber();
   mkdirSync(OUT_DIR, { recursive: true });
 
   const key = process.env.EB_OPENROUTER_API_KEY || '';
   if (!key) throw new Error('EB_OPENROUTER_API_KEY fehlt.');
-  const fokus = args.focus === 'auto' ? autoFokus() : args.focus;
+  // Der Fokus kommt jetzt aus den Befunden des Ensembles, nicht aus dem
+  // Kalender. Der Grund wird mitgeschrieben — sonst waere im Nachhinein nicht
+  // zu unterscheiden, ob eine Wahl belegt war oder nur der Rueckfall griff.
+  let fokusGrund = 'ausdruecklich vorgegeben';
+  let fokus = args.focus;
+  if (args.focus === 'auto') {
+    const wahl = autoFokus();
+    fokus = wahl.fokus;
+    fokusGrund = wahl.grund;
+  }
+  console.log(`Fokus: ${fokus} — ${fokusGrund}`);
   const runBudget = zahl(process.env.EB_OPENROUTER_RUN_BUDGET_USD) ?? 0.12;
   const dailyBudget = zahl(process.env.EB_OPENROUTER_DAILY_BUDGET_USD) ?? 0.60;
   const minRemaining = zahl(process.env.EB_OPENROUTER_MIN_REMAINING_USD) ?? 1;
@@ -927,7 +991,7 @@ function selfTest() {
   return { ok: true };
 }
 
-export { main, selfTest, patchPruefen, pruefeDateiliste };
+export { main, selfTest, patchPruefen, pruefeDateiliste, autoFokus };
 
 if (typeof process !== 'undefined' && Array.isArray(process.argv)
     && process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -253,6 +253,7 @@ test.describe('OpenRouter-Autopilot', () => {
   const workflow = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'openrouter-autopilot.yml'), 'utf8');
   const merge = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'openrouter-auto-merge.yml'), 'utf8');
   const operations = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'hq-operations.yml'), 'utf8');
+  const autopilot = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'openrouter-autopilot.yml'), 'utf8');
   const agent = fs.readFileSync(path.join(ROOT, 'scripts', 'agent.mjs'), 'utf8');
 
   test('Guardrail-Selbsttest blockiert verbotene Seiteneffekte', () => {
@@ -329,12 +330,25 @@ test.describe('OpenRouter-Autopilot', () => {
   });
 
   test('Operations-Ensemble arbeitet bei jedem erreichten Puls vollständig unter Kostenbremse', () => {
-    expect(operations).toMatch(/cron:\s*'4\/5 \* \* \* \*'/);
-    expect(operations).toMatch(/EB_OPENROUTER_DAILY_BUDGET_USD:\s*'0\.60'/);
+    // Der Puls erzeugt Lagebilder, der Autopilot erzeugt Arbeit. Stündlich
+    // mal elf Rollen hat der Puls das gemeinsame Tagesbudget aufgebraucht,
+    // bevor der Autopilot dazu kam — rund 2 Mio Token ohne Wirkung. Geprüft
+    // wird deshalb nicht mehr die Uhrzeit, sondern die Aussage: der Puls läuft
+    // seltener als stündlich und bekommt weniger Budget als der Autopilot.
+    expect(operations, 'Puls darf nicht wieder stündlich laufen').not.toMatch(/cron:\s*'\d*\/5 \* \* \* \*'/);
+    const pulsBudget = Number((operations.match(/EB_OPENROUTER_DAILY_BUDGET_USD:\s*'([\d.]+)'/) || [])[1]);
+    const autoBudget = Number((autopilot.match(/EB_OPENROUTER_DAILY_BUDGET_USD:\s*'([\d.]+)'/) || [])[1]);
+    expect(pulsBudget, 'Puls ohne eigenes Budget').toBeGreaterThan(0);
+    expect(pulsBudget, 'der Puls darf dem Autopiloten das Budget nicht wegessen')
+      .toBeLessThan(autoBudget);
     expect(operations).toMatch(/echo "rolle=alle"/);
     expect(operations).not.toMatch(/GITHUB_RUN_NUMBER - 1\) % anzahl/);
-    expect(operations).toMatch(/tatsaechlich erreichten Puls das volle Ensemble/);
-    expect(operations).toMatch(/\$0\.003646/);
+    // Vorher standen hier zwei Zusicherungen auf Kommentar-Wortlaut
+    // („tatsaechlich erreichten Puls…", „$0.003646"). Ein Kommentar ist keine
+    // Zusicherung: er ändert sich mit der Begründung, ohne dass sich das
+    // Verhalten ändert. Die Aussage dahinter — jeder erreichte Lauf arbeitet
+    // das VOLLE Ensemble ab, keine Rolle wird durch einen Zähler übersprungen
+    // — steht in den beiden Prüfungen darüber und darunter.
     expect(operations).toMatch(/5-Minuten-HQ-Rundlauf/);
     expect(operations).toMatch(/Bestehende Laufzeitspur vorladen/);
     expect(operations).toMatch(/eb-arbeit\.json\?run=\$\{GITHUB_RUN_ID\}/);
@@ -397,8 +411,8 @@ test.describe('Neuronaler Kern', () => {
       expect(r.text).toContain(heading);
     }
     expect(r.text).toContain('Anzeige sekündlich');
-    expect(r.text).toContain('Scheduler-Taktziel 5 Min.');
-    expect(r.text).toContain('alle 11 Rollen je erreichtem Puls');
+    expect(r.text).toContain('Lagebild 4×/Tag');
+    expect(r.text).toContain('alle 11 Rollen je Lauf');
     expect(r.text).toContain('Jetzt');
     expect(r.text).toContain('Nächste Prüfung');
     expect(r.text).toContain('Zuletzt belegt');
@@ -734,9 +748,60 @@ test.describe('Arbeitsjournal & Gespräch', () => {
     await page.waitForTimeout(2200);
     const text = await page.evaluate(() => document.getElementById('journal').textContent);
     if (!JOURNAL.eintraege.length) {
-      expect(text, 'ein leeres Journal zeigt Taktziel und Voll-Ensemble, statt leer zu bleiben').toMatch(/24\/7-Steuerung.*Taktziel von fünf Minuten.*gesamte Ensemble/is);
+      expect(text, 'ein leeres Journal zeigt Taktziel und Voll-Ensemble, statt leer zu bleiben').toMatch(/Lagebild-Lauf startet viermal täglich.*gesamte Ensemble/is);
     } else {
       expect(text).toMatch(/Schichten gearbeitet/);
     }
+  });
+});
+
+test.describe('Befunde bestimmen die Arbeit', () => {
+  // Der teuerste Befund dieser Sitzung: rund 2 Mio Token verbraucht, ohne dass
+  // Seite oder HQ sich verbessert hätten. Ursache war nicht die Qualität der
+  // Modelle, sondern die Verkabelung — elf Rollen benannten stündlich konkrete
+  // Probleme, und die einzige Stelle, die Code ändert, wählte ihren Fokus nach
+  // KALENDERWOCHE. Die Befunde blieben im Journal liegen.
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const { execFileSync } = require('node:child_process');
+  const wurzel = path.join(__dirname, '..', '..');
+
+  // Eigenes Journal je Aufruf. Die echte assets/eb-arbeit.json anzufassen
+  // wäre ein Fehler: Playwright läuft parallel, und ein anderer Test lädt
+  // gleichzeitig die HQ-Seite, die genau diese Datei liest. Geteilter
+  // veränderlicher Zustand macht Tests unzuverlässig, nicht gründlich.
+  const fokusFuer = (eintraege) => {
+    const journal = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ebf-')), 'j.json');
+    fs.writeFileSync(journal, JSON.stringify({ version: 1, eintraege }), 'utf8');
+    return JSON.parse(execFileSync('node',
+      [path.join(wurzel, 'scripts', 'openrouter-agents.mjs'), '--zeige-fokus'],
+      { cwd: wurzel, env: { ...process.env, EB_JOURNAL: journal } }).toString());
+  };
+  const jetzt = () => new Date().toISOString();
+  const befund = (text, ergebnis = 'fertig', zeit = jetzt()) => ({ ergebnis, zeit, aufgabe: text, text });
+
+  test('frische Befunde bestimmen den Fokus', () => {
+    const a = fokusFuer([befund('Kontrast zu niedrig, barrierefrei nachbessern'),
+                         befund('Screenreader-Label fehlt'), befund('Tastaturbedienung fehlt')]);
+    expect(a.fokus).toBe('accessibility');
+    expect(a.grund, 'Grund muss die Befunde nennen').toMatch(/Befund/);
+
+    const p = fokusFuer([befund('Ladezeit zu hoch, Bundle zu gross'), befund('cache greift nicht')]);
+    expect(p.fokus).toBe('performance');
+  });
+
+  test('ohne Befund wird der Rückfall als solcher ausgewiesen', () => {
+    // Der Kalender ist keine schlechtere Wahl, nur eine unbegründete — und
+    // darf deshalb nicht wie ein Befund aussehen.
+    const leer = fokusFuer([]);
+    expect(leer.grund).toMatch(/Kalenderwoche/);
+  });
+
+  test('alte Befunde und Fehlschläge zählen nicht', () => {
+    const alt = new Date(Date.now() - 48 * 3600 * 1000).toISOString();
+    expect(fokusFuer([befund('barrierefrei Kontrast', 'fertig', alt)]).grund).toMatch(/Kalenderwoche/);
+    // Ein Ausfall ist kein Befund.
+    expect(fokusFuer([befund('barrierefrei Kontrast', 'fehler')]).grund).toMatch(/Kalenderwoche/);
   });
 });

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -805,3 +805,32 @@ test.describe('Befunde bestimmen die Arbeit', () => {
     expect(fokusFuer([befund('barrierefrei Kontrast', 'fehler')]).grund).toMatch(/Kalenderwoche/);
   });
 });
+
+test.describe('Der Verbrauch muss nachvollziehbar sein', () => {
+  // Aus der Kostenprüfung über 12,1 Mio Token: 0 % Cache, ~90 % als
+  // „Unknown App" nicht zuzuordnen, mehrere am Tokenlimit abgeschnittene
+  // Antworten — und die zählten als erledigte Arbeit.
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const AGENT = fs.readFileSync(path.join(__dirname, '..', '..', 'scripts', 'agent.mjs'), 'utf8');
+
+  test('jeder Aufruf ist einer App zuzuordnen', () => {
+    // Ohne HTTP-Referer bucht OpenRouter auf „Unknown App"; eine
+    // Kostenprüfung, die 90 % nicht zuordnen kann, ist keine Prüfung.
+    expect(AGENT, 'Puls ohne App-Zuordnung').toMatch(/'HTTP-Referer':/);
+  });
+
+  test('eine abgeschnittene Antwort gilt nicht als erledigt', () => {
+    // Vorher genügte Boolean(text): ein am Limit abgebrochener Halbsatz wurde
+    // „fertig" gebucht und der Aufgabenzeiger rückte weiter.
+    expect(AGENT, 'finish_reason wird nicht ausgewertet').toMatch(/finish_reason/);
+    expect(AGENT, 'Abschneiden muss das Ergebnis entwerten')
+      .toMatch(/const hatErgebnis = Boolean\(text\) && !abgeschnitten/);
+  });
+
+  test('Cache-Anteil und Abbruchgrund landen im Journal', () => {
+    // Ohne Messung bleibt „0 % Cache" eine Vermutung statt eines Befunds.
+    expect(AGENT, 'Cache-Anteil wird nicht erfasst').toMatch(/cacheTokens:/);
+    expect(AGENT, 'Abbruchgrund wird nicht erfasst').toMatch(/abbruchGrund:/);
+  });
+});

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -7,7 +7,7 @@ tags: [layer/L0, domain/kern, share/internal, typ/messung]
 
 # ⚡ Impuls-Strom — der lebende Zustand
 
-> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-06**
+> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-09**
 > Nicht von Hand bearbeiten — jeder Lauf überschreibt die Datei.
 > Diese Notiz misst, was im Netz tatsächlich fließt. Die Ströme selbst
 > sind in [[00-Kern/Wissensstroeme]] beschrieben.
@@ -63,17 +63,17 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **57** |
-| Commits (30 Tage) | 114 |
-| Letzter Commit | `9904f4c · Befunde bestimmen die Arbeit — statt Kalenderwoche` (2026-08-06) |
+| Commits (7 Tage) | **39** |
+| Commits (30 Tage) | 106 |
+| Letzter Commit | `22399d7 · Befunde bestimmen die Arbeit — statt Kalenderwoche` (2026-08-06) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
-40 app.js
-     33 styles.css
+37 app.js
+     29 styles.css
      23 tests/e2e/kern.spec.js
-     23 index.html
-     23 app-shell.html
+     21 index.html
+     21 app-shell.html
 ```
 
 **Codegröße:**

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,17 +63,17 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **56** |
-| Commits (30 Tage) | 113 |
-| Letzter Commit | `cba4154 · Vier Ursachen für die 17,5 % Fehlerquote im Ensemble` (2026-08-06) |
+| Commits (7 Tage) | **57** |
+| Commits (30 Tage) | 114 |
+| Letzter Commit | `9904f4c · Befunde bestimmen die Arbeit — statt Kalenderwoche` (2026-08-06) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
 40 app.js
      33 styles.css
+     23 tests/e2e/kern.spec.js
      23 index.html
      23 app-shell.html
-     22 tests/e2e/kern.spec.js
 ```
 
 **Codegröße:**

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 175 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 178 Tests
 > in 11 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 175 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 178 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 178 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 181 Tests
 > in 11 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 178 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 181 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,10 +16,14 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 175 Tests in 11 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 178 Tests in 11 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
-- HQ-Puls stündlich, 11 Rollen je Lauf, Journal als echte Laufzeitspur per SFTP
+- **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes
+  Budget von $0,15 — Journal als echte Laufzeitspur per SFTP
+- **Autopilot** bekommt die übrigen $0,45: er liefert Patch, Tests und PR.
+  Sein Schwerpunkt kommt aus den Befunden der letzten 24 h, nicht mehr aus
+  der Kalenderwoche
 - Offen: Repo steht auf **public** mit dem Security-Vault darin (keine
   Zugangsdaten, aber eine Landkarte der Angriffsfläche)
 

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 178 Tests in 11 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 181 Tests in 11 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
**Rund 2 Mio Token verbraucht, ohne dass Seite oder HQ sich verbessert hätten.** Die Ursache war nicht die Qualität der Modelle — es war die Verkabelung. Drei Dinge liefen auseinander.

## 1 · Der Kontext war 28-mal so groß wie die Antwort

An **jede** der 11 Rollen gingen 180 Zeilen aus einer 26-KB-Sprintdatei plus 160 Zeilen Audit:

```
~4.200 Prompt-Token × 11 Rollen × 24 Läufe/Tag ≈ 1,1 Mio Token/Tag
Antwort dagegen: ~150 Token je Rolle          ≈    40 Tsd Token/Tag
```

Verhältnis **28:1** — und das meiste davon war abgeschlossene Historie, die niemand mehr braucht. Jetzt geht nur der Ist-Stand raus; die Datei-Auszüge zur konkreten Aufgabe kommen ohnehin aus `agent.mjs` dazu, und **dort** liegt der Bezug zur Arbeit.

## 2 · Das Gerede hat der Arbeit das Budget weggenommen

Puls und Autopilot teilten sich **dasselbe** `$0,60`-Tagesbudget. Der Puls hat es aufgebraucht, bevor der Autopilot dazu kam — dessen Commits **#113–#119 liegen alle zwischen 03:07 und 03:23**, also genau solange das Budget frisch war. Danach nichts mehr.

| | vorher | jetzt |
|---|---|---|
| Lagebild-Lauf | stündlich, $0,60 geteilt | **4×/Tag, eigene $0,15** |
| Autopilot (Patch→Tests→PR) | Rest, meist leer | **$0,45 reserviert** |

## 3 · Der eigentliche Punkt: `autoFokus()` fragte den Kalender

```js
const week = Math.floor((Date.now() - start) / (7 * 86400000));
return FOKUSSE[week % FOKUSSE.length];
```

Elf Rollen benannten stündlich konkrete Probleme — und die **einzige Stelle, die Code ändert**, wählte ihren Schwerpunkt nach Kalenderwoche. Die Befunde blieben im Journal liegen. Das ist die ganze Erklärung für „viel Verbrauch, keine Wirkung".

Jetzt bestimmen die Befunde der letzten 24 Stunden den Fokus. Gewertet werden nur `fertig`-Einträge: **ein Ausfall ist kein Befund**, ein drei Tage alter Hinweis keine Lage. Ohne klaren Schwerpunkt bleibt es beim Kalender — und der **Grund wird mitgeschrieben**, sonst wäre im Nachhinein nicht zu unterscheiden, ob eine Wahl belegt war oder nur der Rückfall griff.

**Gemessen statt behauptet** (`--zeige-fokus`, ohne Modellaufruf):

```
3 A11y-Befunde       → accessibility  („3 Befund(e) der letzten 24 h …")
2 Performance-Befunde→ performance
leeres Journal       → Kalenderwoche  (als Rückfall ausgewiesen)
Befund > 24 h alt    → Kalenderwoche
nur Fehlschläge      → Kalenderwoche
```

## Ehrlichkeit nachgezogen

Das HQ behauptete weiter „Taktziel 5 Min." und „$0,60/Tag hart" — nach der Umstellung schlicht falsch. Korrigiert, samt der Sprintdatei, die die Rollen als Kontext lesen.

## Zwei eigene Testfehler mitgefangen

- Zwei Zusicherungen prüften **Kommentar-Wortlaut** statt Verhalten und wurden rot, weil ich die Begründung umgeschrieben hatte. Ein Kommentar ist keine Zusicherung.
- Mein neuer Test schrieb die **echte** `assets/eb-arbeit.json`, während ein paralleler Test die HQ-Seite lud, die dieselbe Datei liest. Geteilter veränderlicher Zustand macht Tests unzuverlässig, nicht gründlich. Jetzt eigenes Journal je Aufruf über `EB_JOURNAL`.

## Geprüft

**178 Tests grün** (3 neue), alle sieben Tore grün, `php -l` sauber, Autopilot-Guardrails unverändert (`npm run test:agents`).

Die Sicherheitsgrenzen des Autopiloten sind **nicht** angefasst: Whitelist, Budgetdeckel, Gates, Review und PR-Weg bleiben wie sie waren. Geändert hat sich nur, **woran** er arbeitet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_