### PR TITLE
Der Arbeitskontext hängt nicht mehr an der Länge einer Notiz

### DIFF
--- a/.github/workflows/hq-operations.yml
+++ b/.github/workflows/hq-operations.yml
@@ -110,9 +110,19 @@ jobs:
             git log -6 --pretty=format:'%h %s'
             echo
             echo "IST-STAND"
-            # Nur bis zum ersten abgeschlossenen Sprint — alles danach ist Historie.
-            sed -n '/^## Stand heute/,/^## Zuletzt abgeschlossen/p' \
-              vault/50-Evolution/Roadmap/Current-Sprint.md | head -n 24
+            # Nur bis zur naechsten Abschnittsueberschrift — alles danach ist
+            # Historie, und ein Modell, das sie als Ist-Stand liest, meldet
+            # Zahlen von vorgestern.
+            #
+            # Bewusst awk statt `sed | head`: GitHub faehrt bash mit
+            # `-o pipefail`. Wird der Abschnitt laenger als das Limit, schliesst
+            # head die Pipe, sed stirbt an SIGPIPE (141), und der Schritt reisst
+            # den Lauf mit. Genau so hat eine gewachsene Sprint-Notiz den Puls
+            # lahmgelegt — der Workflow hing still an der Laenge eines Textes.
+            awk '/^## Stand heute/ { drin = 1 }
+                 drin && /^## Zuletzt/ { exit }
+                 drin { print; if (++n >= 24) exit }' \
+              vault/50-Evolution/Roadmap/Current-Sprint.md
             echo
             echo "SELBSTCHECK (Kurzfassung)"
             jq -r '{erzeugt, befunde: (.befunde // [] | length),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-250 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+252 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -976,3 +976,76 @@ test.describe('Der Ausfall muss sichtbar sein', () => {
     }
   });
 });
+
+// ── Der Kontext-Schritt darf nicht an einer Textlänge hängen ──────────────
+//
+// Nach der ersten Reparatur lief der Puls weiter rot — an einer ganz anderen
+// Stelle. Der Schritt „Belegten Arbeitskontext bauen" schnitt den Ist-Stand
+// mit `sed … | head -n 24` zu. GitHub fährt bash mit `-o pipefail`: sobald der
+// Abschnitt länger wird als das Limit, schließt `head` die Pipe, `sed` stirbt
+// an SIGPIPE (Exit 141), und der Schritt reißt den ganzen Lauf mit.
+//
+// Ausgelöst hat es meine eigene Sprint-Notiz — der Abschnitt wuchs von 22 auf
+// 84 Zeilen. Ein Workflow, den man durch Schreiben umwerfen kann, ist eine
+// Falle mit Zeitzünder.
+test.describe('Der Arbeitskontext überlebt lange Notizen', () => {
+  const { execFileSync } = require('node:child_process');
+  const os = require('node:os');
+  const HQ_OPS = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'hq-operations.yml'), 'utf8');
+
+  /** Den `run:`-Block eines Schritts aus dem Workflow holen, ohne YAML-Parser. */
+  function schrittBlock(name) {
+    const von = HQ_OPS.indexOf(`- name: ${name}`);
+    expect(von, `Schritt nicht gefunden: ${name}`).toBeGreaterThan(0);
+    const rest = HQ_OPS.slice(von);
+    const naechster = rest.indexOf('\n      - name:', 1);
+    const block = naechster > 0 ? rest.slice(0, naechster) : rest;
+    const r = block.indexOf('run: |');
+    expect(r, `kein run-Block in: ${name}`).toBeGreaterThan(0);
+    // Einrückung der Schritt-Ebene (10 Leerzeichen) entfernen.
+    return block.slice(r + 'run: |'.length)
+      .split('\n').map((z) => z.replace(/^ {10}/, '')).join('\n');
+  }
+
+  test('der Schritt läuft auch bei sehr langem Ist-Stand durch', () => {
+    // Ausgeführt wird der echte Block aus dem Workflow, mit genau den
+    // Shell-Optionen, die GitHub setzt — nicht ein Nachbau davon.
+    let skript = schrittBlock('Belegten Arbeitskontext bauen');
+    const ziel = path.join(os.tmpdir(), `ctx-${Date.now()}-${Math.random()}.txt`);
+    skript = skript
+      .replace(/\.ai-run\/ensemble-context\.txt/g, ziel)
+      .replace(/mkdir -p \.ai-run/, 'true')
+      .replace(/>> "\$GITHUB_STEP_SUMMARY"/g, '>/dev/null');
+
+    // Die Sprint-Notiz künstlich aufblähen: genau der Fall, der es gerissen hat.
+    const sprint = path.join(ROOT, 'vault', '50-Evolution', 'Roadmap', 'Current-Sprint.md');
+    const original = fs.readFileSync(sprint, 'utf8');
+    // Bewusst über 64 KB: SIGPIPE tritt nur auf, wenn der Schreiber nach dem
+    // Ende des Lesers noch schreibt. Bei 300 Zeilen passt alles in den Puffer
+    // der Pipe, `sed` ist fertig bevor `head` schließt — der Test lief dann
+    // grün, obwohl der Fehler wieder drin war. Erst oberhalb der Puffergröße
+    // ist der Fall sicher reproduzierbar.
+    const fuellung = Array.from({ length: 5000 },
+      (_, i) => `- Zeile ${i} des Ist-Stands, absichtlich lang genug, um den Pipe-Puffer zu fuellen`).join('\n');
+    const aufgeblaeht = original.replace(/^## Stand heute.*$/m, (kopf) => `${kopf}\n${fuellung}`);
+    try {
+      fs.writeFileSync(sprint, aufgeblaeht, 'utf8');
+      execFileSync('bash', ['--noprofile', '--norc', '-eo', 'pipefail', '-c', skript],
+        { cwd: ROOT, encoding: 'utf8' });
+      // Und der Ausschnitt bleibt trotzdem klein — der Kontext ist der Verbrauch.
+      const zeilen = fs.readFileSync(ziel, 'utf8').split('\n');
+      expect(zeilen.length, 'der Kontext läuft ungebremst voll').toBeLessThan(60);
+    } finally {
+      fs.writeFileSync(sprint, original, 'utf8');
+      try { fs.unlinkSync(ziel); } catch { /* nie geschrieben */ }
+    }
+  });
+
+  test('kein Schritt schneidet mit einer Pipe nach head zu', () => {
+    // Dieselbe Falle steckt in jedem `… | head`, sobald pipefail gilt.
+    // `|| head` ist ein Rückfall und keine Pipe — nur ein einzelnes `|` zählt.
+    const treffer = HQ_OPS.split('\n')
+      .filter((z) => /(^|[^|])\|\s*head\b/.test(z) && !/^\s*#/.test(z));
+    expect(treffer, `SIGPIPE-Falle: ${treffer.join(' / ')}`).toHaveLength(0);
+  });
+});

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 250 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 252 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 250 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 252 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 250 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 252 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
Nachtrag zu #124. Nach dem Merge habe ich den Puls von Hand ausgelöst, statt bis 14:17 UTC zu warten — er lief weiter rot, aber an einer **anderen** Stelle.

## Was der Lauf gezeigt hat

Die Schritt-für-Schritt-Bilanz von Lauf `31587390434`:

| # | Schritt | Ergebnis |
|---|---|---|
| 7 | Belegten Arbeitskontext bauen | **failure** |
| 8 | Alle Rollen taskweise arbeiten lassen | skipped |
| 9 | Journal validieren | **success** ← `if: always()` |
| 10 | SFTP-Werkzeug einrichten | **success** ← `if: always()` |
| 11 | Echte Laufzeitspur veröffentlichen | **success** ← `if: always()` |
| 12 | Ausfall melden | **success** — Issue angelegt |

Drei der vier Reparaturen aus #124 sind damit **im Betrieb belegt**, nicht nur im Test: das Journal überlebt den Fehlschlag, und der Ausfall meldet sich selbst. Genau dieser Lauf wäre vorher spurlos verschwunden.

## Der verbliebene Fehler — und wer ihn verursacht hat

Der Schritt schnitt den Ist-Stand so zu:

```bash
sed -n '/^## Stand heute/,/^## Zuletzt abgeschlossen/p' … | head -n 24
```

GitHub fährt `bash` mit `-o pipefail`. Wird der Abschnitt länger als das Limit, schließt `head` die Pipe, `sed` stirbt an SIGPIPE (Exit 141), und `pipefail` reißt den Schritt mit.

**Ausgelöst habe ich es selbst:** meine Dokumentation des Ausfalls in #124 hat den Ist-Stand-Bereich von 22 auf **84 Zeilen** wachsen lassen. Ein Workflow, den man durch *Schreiben* umwerfen kann, ist eine Falle mit Zeitzünder — sie hätte irgendwann zugeschnappt, nur eben ohne erkennbaren Zusammenhang zur Ursache.

Jetzt `awk` statt `sed | head`: ein Prozess, keine Pipe, und der Abschnitt endet an der **nächsten Überschrift** statt an einer bestimmten — damit stimmt auch die Absicht wieder („Ist-Stand", nicht Historie).

## Zu den Tests — der erste Entwurf war wertlos

Der Verhaltenstest blähte die Notiz um 300 Zeilen auf und führte den echten Workflow-Block mit GitHubs Shell-Optionen aus. Beim Rückbau auf `sed | head` blieb er **grün**.

Der Grund: SIGPIPE entsteht nur, wenn der Schreiber *nach* dem Ende des Lesers noch schreibt. 300 Zeilen (~8 KB) passen vollständig in den 64-KB-Puffer der Pipe — `sed` ist fertig, bevor `head` schließt. Der Test prüfte einen Fall, den er gar nicht herstellte.

Mit 5000 Zeilen liegt die Ausgabe sicher über der Puffergröße, und **beide** Tests fallen beim Rückbau auf. Dazu ein zweiter, der jede `… | head`-Pipe im Workflow verbietet — dieselbe Falle in einem anderen Schritt wäre derselbe Ausfall.

## Geprüft

**252 Tests grün** (2 neue), alle Tore grün. Beide Rückbauten als Mutation gegengeprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_