### PR TITLE
Ein gescheiterter Push ist kein grüner Lauf

### DIFF
--- a/.github/workflows/tagesroutine.yml
+++ b/.github/workflows/tagesroutine.yml
@@ -101,11 +101,28 @@ jobs:
           git config user.email "noreply@users.noreply.github.com"
           git add assets/eb-demo-feed.json audit/latest.json assets/eb-arbeit.json
           git commit -m "chore(routine): Demo-Feed und Selbstcheck fuer $(date -u +%Y-%m-%d)"
+          # Der Push MUSS gelingen, sonst war der ganze Lauf umsonst.
+          #
+          # Vorher endete die Schleife nach vier Fehlversuchen einfach, und der
+          # Schritt lief gruen weiter. Ergebnis: die Routine meldete Erfolg und
+          # hat in ihrer gesamten Laufzeit kein einziges Mal committet — es gibt
+          # keinen einzigen chore(routine)-Commit. Demo-Feed und Selbstcheck
+          # sahen dadurch aktuell aus und waren sieben bis zehn Tage alt.
+          gepusht=0
           for i in 1 2 3 4; do
-            git push origin HEAD:main && break
+            if git push origin HEAD:main; then gepusht=1; break; fi
+            echo "Push-Versuch $i fehlgeschlagen." >> "$GITHUB_STEP_SUMMARY"
             sleep $((2 ** i))
             git pull --rebase origin main || true
           done
+          if [ "$gepusht" -ne 1 ]; then
+            {
+              echo "### ⛔ Push nach main fehlgeschlagen"
+              echo "Feed und Selbstcheck wurden erzeugt, sind aber NICHT gespeichert."
+              echo "Der genaue Grund steht im Log des letzten Versuchs oben."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
           {
             echo "### Tagesroutine gelaufen"
             node -e "const f=require('./assets/eb-demo-feed.json');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-252 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+254 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -1049,3 +1049,41 @@ test.describe('Der Arbeitskontext überlebt lange Notizen', () => {
     expect(treffer, `SIGPIPE-Falle: ${treffer.join(' / ')}`).toHaveLength(0);
   });
 });
+
+// ── Ein gescheiterter Push ist kein gruener Lauf ──────────────────────────
+//
+// Die Tagesroutine hat in ihrer gesamten Laufzeit kein einziges Mal
+// committet — es gibt keinen einzigen `chore(routine)`-Commit. Sie meldete
+// trotzdem jedes Mal Erfolg: die Push-Schleife brach nach vier Versuchen
+// einfach ab, und der Schritt lief gruen weiter. Demo-Feed und Selbstcheck
+// sahen dadurch aktuell aus und waren sieben bis zehn Tage alt.
+test.describe('Die Routine darf Erfolg nicht vortäuschen', () => {
+  const TAGES = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'tagesroutine.yml'), 'utf8');
+
+  test('scheitert der Push, scheitert der Lauf', () => {
+    const block = TAGES.slice(
+      TAGES.indexOf('- name: Committen, falls geaendert'),
+      TAGES.indexOf('- name: Ausfall melden'));
+    expect(block, 'Commit-Schritt nicht gefunden').toContain('git push');
+    // Der Erfolg muss festgehalten und danach geprüft werden — eine Schleife,
+    // die nur `&& break` kennt, endet bei Totalausfall genauso wie bei Erfolg.
+    expect(block, 'der Push-Erfolg wird nicht festgehalten').toMatch(/gepusht=1/);
+    expect(block, 'ein gescheiterter Push beendet den Lauf nicht')
+      .toMatch(/if \[ "\$gepusht" -ne 1 \][\s\S]{0,400}exit 1/);
+  });
+
+  test('kein Liefer-Schritt endet still nach der letzten Wiederholung', () => {
+    // Dasselbe Muster wie oben, aber allgemein: jede `for … done`-Schleife um
+    // einen Push herum braucht danach eine Auswertung. Sonst ist „vier Mal
+    // vergeblich versucht" von „beim ersten Mal geklappt" nicht zu
+    // unterscheiden — und genau das ist hier monatelang passiert.
+    for (const [name, quelle] of [['tagesroutine', TAGES]]) {
+      const schleifen = quelle.split('\n').filter((z) => /git push/.test(z));
+      expect(schleifen.length, `${name}: kein Push gefunden`).toBeGreaterThan(0);
+      for (const z of schleifen) {
+        expect(z, `${name}: Push ohne Erfolgsmerker — ${z.trim().slice(0, 50)}`)
+          .toMatch(/if git push|gepusht/);
+      }
+    }
+  });
+});

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 252 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 254 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 252 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 254 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 252 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 254 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
Nachtrag zu #124 und #126. Der Ensemble-Puls läuft wieder (**11/11 Rollen**), die Tagesroutine ist grün — und liefert trotzdem nichts ab.

## Der Befund

**Die Tagesroutine hat in ihrer gesamten Laufzeit kein einziges Mal committet.** Es existiert kein einziger `chore(routine)`-Commit im Repo. Sie meldet trotzdem jedes Mal Erfolg.

Das erklärt eine Lücke, die ich in #124 falsch zugeordnet hatte: ich hatte die alten Dateien (`eb-demo-feed.json` vom 01.08., `audit/latest.json` vom 04.08.) auf die Abbruchkette geschoben. Die war ein Teil der Ursache — aber selbst wenn sie nie existiert hätte, wäre nichts angekommen.

## Der Beleg

Der Beweis-Lauf von heute (`31589012944`, grün):

| Schritt | Dauer |
|---|---|
| Committen, falls geaendert | **35 s** |

35 Sekunden ist exakt die Summe der Retry-Pausen `2+4+8+16`. Der Schritt hat also Änderungen gefunden, committet, **alle vier Push-Versuche verloren** — und Erfolg gemeldet. Auf `main` kam nichts an.

Die Schleife sah so aus:

```bash
for i in 1 2 3 4; do
  git push origin HEAD:main && break
  sleep $((2 ** i))
  git pull --rebase origin main || true
done
# … und hier geht es gruen weiter, egal wie es ausging
```

Vier vergebliche Versuche waren von „beim ersten Mal geklappt" nicht zu unterscheiden.

## Was ich *nicht* getan habe

**Ich rate den Grund des Push-Fehlers nicht.** Direkt-Pushes auf `main` sind grundsätzlich möglich — es gibt zwei Commits ohne PR-Nummer (`64276d0`, `bf9fa20`), es ist also nicht pauschal Branch-Protection. Ob es an einer Repo-Einstellung für `GITHUB_TOKEN`, an einer Regel für Bot-Actors oder an etwas anderem liegt, sagt mir das Log nicht, und ich habe von hier aus keinen Weg, es sauber festzustellen.

Statt eine plausible Ursache zu behaupten, macht der nächste Lauf sie selbst sichtbar: der Push-Erfolg wird festgehalten, jeder Fehlversuch landet in der Zusammenfassung, und ein Totalausfall macht den Schritt rot — mit dem echten git-Fehler im Log darüber.

## Das Muster

Das ist heute das **dritte** Mal dieselbe Form:

| Stelle | Der Code tut das Richtige … | … aber der Beweis geht verloren |
|---|---|---|
| Migration 2.5 | prüft die Spalten | Version stieg trotzdem |
| Arbeitsjournal | schreibt den Abbruch | Upload lief nach Fehlschlag nicht |
| Tagesroutine | committet die Dateien | Push scheitert, Lauf bleibt grün |

Es lohnt sich, das als eigene Regel zu führen: **jede Automatik muss ihren eigenen Ausfall sichtbar machen können.**

## Geprüft

**254 Tests grün** (2 neue), alle Tore grün, beide Rückbauten als Mutation gegengeprüft.

Der zweite neue Test ist allgemein gehalten: *jeder* `git push` in der Routine braucht eine Erfolgsauswertung — dieselbe Falle in einem anderen Schritt wäre derselbe stille Ausfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_