### PR TITLE
GitHub App statt Token — für Routine und Autopilot

### DIFF
--- a/.github/workflows/openrouter-autopilot.yml
+++ b/.github/workflows/openrouter-autopilot.yml
@@ -51,8 +51,22 @@ jobs:
       SFTP_PASS: ${{ secrets.IONOS_FTP_PASSWORD }}
       SFTP_USER: ${{ secrets.IONOS_FTP_USERNAME }}
       SFTP_HOST: ${{ secrets.IONOS_FTP_SERVER }}
+      HAT_APP: ${{ secrets.EB_ROUTINE_APP_ID != '' }}
 
     steps:
+      # Dieselbe Falle wie in der Tagesroutine: ein PR, den GITHUB_TOKEN
+      # anlegt, loest keine Workflow-Laeufe aus. Die im Ruleset geforderte
+      # PR-Validierung lief daher nie an — PR #123 steht seit dem 11.08. offen
+      # und kann grundsaetzlich nicht mergen. Der Autopilot hat also gearbeitet
+      # und geliefert, und das Ergebnis blieb trotzdem liegen.
+      - name: Routine-Token beschaffen
+        id: apptoken
+        if: env.HAT_APP == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.EB_ROUTINE_APP_ID }}
+          private-key: ${{ secrets.EB_ROUTINE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -214,7 +228,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.apptoken.outputs.token || secrets.GITHUB_TOKEN }}
           base: main
           branch: openrouter/auto-${{ env.FOCUS }}
           delete-branch: true

--- a/.github/workflows/tagesroutine.yml
+++ b/.github/workflows/tagesroutine.yml
@@ -27,7 +27,7 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: write   # die Routine liefert ueber einen PR, nicht direkt auf main   # Fehlschlag sichtbar machen (siehe „Ausfall melden" unten)
+  pull-requests: write   # die Routine liefert ueber einen PR, nicht direkt auf main
 
 concurrency:
   group: tagesroutine
@@ -37,16 +37,37 @@ jobs:
   feed:
     name: Demo-Feed und Selbstcheck erneuern
     runs-on: ubuntu-latest
+    env:
+      # Der `secrets`-Kontext ist in `steps.*.if` nicht verfuegbar, in
+      # `jobs.<id>.env` aber schon — deshalb der Umweg ueber einen Merker.
+      HAT_APP: ${{ secrets.EB_ROUTINE_APP_ID != '' }}
     steps:
+      # Token der GitHub App holen.
+      #
+      # Warum nicht GITHUB_TOKEN: ein damit angelegter PR loest keine
+      # Workflow-Laeufe aus. Die im Ruleset geforderte PR-Validierung liefe
+      # nie an, und der PR bliebe fuer immer offen stehen. Ein
+      # Installations-Token einer App loest die Pruefungen dagegen normal aus.
+      #
+      # Warum eine App statt eines PAT: kein Ablaufdatum, eigene Identitaet
+      # (die PRs haengen nicht an einem persoenlichen Konto), und die Rechte
+      # sind an die Installation gebunden statt an einen Menschen.
+      - name: Routine-Token beschaffen
+        id: apptoken
+        if: env.HAT_APP == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.EB_ROUTINE_APP_ID }}
+          private-key: ${{ secrets.EB_ROUTINE_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Der Push laeuft unter diesem Token. Mit GITHUB_TOKEN loest ein
-          # angelegter PR keine Workflow-Laeufe aus — die im Ruleset geforderte
-          # PR-Validierung liefe dann nie an, und der PR bliebe fuer immer
-          # offen stehen. Ein eng geschnittenes PAT (contents: write,
-          # pull requests: write) loest die Pruefungen normal aus.
-          token: ${{ secrets.EB_ROUTINE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Der Push laeuft unter diesem Token. Ohne eingerichtete App faellt
+          # es auf GITHUB_TOKEN zurueck — dann wird der PR zwar angelegt, kann
+          # aber nicht mergen. Das steht dann ausdruecklich in der
+          # Zusammenfassung, statt still zu passieren.
+          token: ${{ steps.apptoken.outputs.token || secrets.GITHUB_TOKEN }}
           persist-credentials: true
 
       - name: Node einrichten
@@ -102,8 +123,8 @@ jobs:
 
       - name: Committen, falls geaendert
         env:
-          GH_TOKEN: ${{ secrets.EB_ROUTINE_TOKEN || secrets.GITHUB_TOKEN }}
-          HAT_ROUTINE_TOKEN: ${{ secrets.EB_ROUTINE_TOKEN != '' }}
+          GH_TOKEN: ${{ steps.apptoken.outputs.token || secrets.GITHUB_TOKEN }}
+          HAT_ROUTINE_TOKEN: ${{ steps.apptoken.outputs.token != '' }}
         run: |
           if git diff --quiet -- assets/eb-demo-feed.json audit/latest.json assets/eb-arbeit.json; then
             echo "Keine Aenderung — Feed, Selbstcheck und Journal sind aktuell." >> "$GITHUB_STEP_SUMMARY"
@@ -163,10 +184,11 @@ jobs:
             {
               echo "PR fuer \`$zweig\` angelegt."
               echo ""
-              echo "⚠️ **EB_ROUTINE_TOKEN fehlt.** Der PR wurde mit GITHUB_TOKEN angelegt;"
-              echo "damit laufen keine Pruefungen an und er kann nicht mergen."
-              echo "Abhilfe: fine-grained PAT (contents: write, pull requests: write)"
-              echo "als Secret \`EB_ROUTINE_TOKEN\` hinterlegen."
+              echo "⚠️ **Routine-App nicht eingerichtet.** Der PR wurde mit GITHUB_TOKEN"
+              echo "angelegt; damit laufen keine Pruefungen an und er kann nicht mergen."
+              echo "Abhilfe: GitHub App anlegen (Contents + Pull requests: Read and write),"
+              echo "im Repo installieren und \`EB_ROUTINE_APP_ID\` sowie"
+              echo "\`EB_ROUTINE_APP_KEY\` als Secrets hinterlegen."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-257 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+258 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-256 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+257 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -543,9 +543,22 @@ test.describe('Neuronaler Kern', () => {
     expect(HQ_CSS).toMatch(/\.neural\.denkt .nn-orb-ring\s*\{\s*animation/);
     expect(HQ_CSS).toMatch(/\.neural\.spricht #nn-orb/);
 
-    // Der Test hat API und Journal absichtlich ohne frischen Beleg geladen.
-    // Dann existieren die Transportpfade, laufen aber nicht und kein Knoten
-    // behauptet, dass gerade ein Modell arbeitet.
+    // Das Journal wird hier bewusst LEER untergeschoben, statt sich auf die
+    // committete Datei zu verlassen.
+    //
+    // Vorher tat der Test genau das — und war grün, solange die Belegschaft
+    // stillstand. Mit dem ersten echten Lauf (12.08.) wurde das Journal frisch
+    // und der Test rot, ohne dass sich an der geprüften Regel etwas geändert
+    // hätte. Ein Test, der von der Datenlage im Repo abhängt, misst den
+    // Zufall mit.
+    await page.route('**/eb-arbeit.json*', (r) => r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ version: 1, hinweis: 'Testvorgabe', eintraege: [] }),
+    }));
+    await page.reload();
+    await expect(page.locator('[data-bereich]')).toHaveCount(10, { timeout: 12000 });
+
     const stand = await page.evaluate(() => ({
       arbeitend: document.querySelectorAll('.nn-node.arbeitet').length,
       pfade: document.querySelectorAll('.nn-transport').length,
@@ -555,6 +568,40 @@ test.describe('Neuronaler Kern', () => {
     expect(stand.gesund).toBe(false);
     const arbeitend = stand.arbeitend;
     expect(arbeitend, 'ohne echten Lauf darf nichts „arbeitet gerade" zeigen').toBe(0);
+  });
+
+  test('mit frischem Betriebsbeleg läuft der Strom wirklich', async ({ page }) => {
+    // Die Gegenprobe zum Test darüber, und erst seit dem 12.08. überhaupt
+    // sinnvoll: vorher gab es nie einen frischen Beleg, mit dem sich die
+    // andere Hälfte der Regel prüfen ließe. Ein Impuls entspricht einem
+    // echten Ereignis — also muss ein echtes Ereignis auch ankommen, sonst
+    // wäre die Anzeige nur vorsichtig statt ehrlich.
+    await page.route('**/eb-arbeit.json*', (r) => r.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        version: 1,
+        hinweis: 'Testvorgabe',
+        eintraege: [{
+          zeit: new Date().toISOString(),
+          rolle: 'mistral-ops', person: 'Nils Falk', rollenname: 'Reliability-Wächter',
+          modell: 'Mistral Small 3.2 24B', bereich: 'betrieb', anlass: 'Test',
+          aufgabe: 'Lagebild verdichten.', dateien: ['audit/latest.json'],
+          ergebnis: 'fertig', text: 'Betriebszustand unauffällig.',
+          tokens: 2073, kostenUsd: 0.00017,
+        }],
+        aktualisiert: new Date().toISOString(),
+      }),
+    }));
+    await page.reload();
+    await expect(page.locator('[data-bereich]')).toHaveCount(10, { timeout: 12000 });
+
+    const stand = await page.evaluate(() => ({
+      gesund: document.getElementById('neural').classList.contains('strom-gesund'),
+      pfade: document.querySelectorAll('.nn-transport').length,
+    }));
+    expect(stand.pfade, 'die Transportpfade fehlen').toBeGreaterThan(0);
+    expect(stand.gesund, 'ein frischer Lauf muss den Strom als gesund zeigen').toBe(true);
   });
 
   test('Arbeitsstand kommt aus echten Workflow-Läufen', async ({ page }) => {

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -1075,17 +1075,37 @@ test.describe('Die Routine darf Erfolg nicht vortäuschen', () => {
       .toMatch(/pull-requests: write/);
   });
 
+  test('beide Liefer-Workflows nutzen die App, nicht GITHUB_TOKEN', () => {
+    // Ein PR, den GITHUB_TOKEN anlegt, loest keine Workflow-Laeufe aus. Die im
+    // Ruleset geforderte PR-Validierung laeuft dann nie an, und der PR kann
+    // grundsaetzlich nicht mergen — bei der Tagesroutine wie beim Autopiloten
+    // (PR #123 stand deshalb seit dem 11.08. offen).
+    const AUTOPILOT = fs.readFileSync(
+      path.join(ROOT, '.github', 'workflows', 'openrouter-autopilot.yml'), 'utf8');
+    for (const [name, quelle] of [['tagesroutine', TAGES], ['autopilot', AUTOPILOT]]) {
+      expect(quelle, `${name}: holt kein App-Token`)
+        .toMatch(/uses: actions\/create-github-app-token@v\d/);
+      expect(quelle, `${name}: der Merker fehlt (secrets ist in steps.*.if nicht verfügbar)`)
+        .toMatch(/HAT_APP: \$\{\{ secrets\.EB_ROUTINE_APP_ID != '' \}\}/);
+      // Kein Liefer-Token darf mehr fest auf GITHUB_TOKEN stehen — nur als
+      // ausdruecklicher Rueckfall hinter dem App-Token.
+      const feste = quelle.split('\n').filter((z) =>
+        /^\s*token: \$\{\{ secrets\.GITHUB_TOKEN \}\}\s*$/.test(z));
+      expect(feste, `${name}: Token fest auf GITHUB_TOKEN — ${feste.join(' / ')}`).toHaveLength(0);
+    }
+  });
+
   test('das Routine-Token ist optional, sein Fehlen aber nicht still', () => {
     // Mit GITHUB_TOKEN loest ein angelegter PR keine Workflow-Laeufe aus, also
     // laeuft die im Ruleset geforderte Pruefung nie an und der PR bliebe ewig
     // offen. Ohne das PAT muss die Routine das SAGEN — sonst waere es wieder
     // ein Ausfall, der wie Erfolg aussieht.
     expect(TAGES, 'kein Rückfall auf GITHUB_TOKEN')
-      .toMatch(/secrets\.EB_ROUTINE_TOKEN \|\| secrets\.GITHUB_TOKEN/);
-    expect(TAGES, 'der Push läuft nicht unter dem Routine-Token')
-      .toMatch(/token: \$\{\{ secrets\.EB_ROUTINE_TOKEN/);
-    expect(TAGES, 'das fehlende Token wird nicht benannt')
-      .toMatch(/EB_ROUTINE_TOKEN fehlt/);
+      .toMatch(/steps\.apptoken\.outputs\.token \|\| secrets\.GITHUB_TOKEN/);
+    expect(TAGES, 'der Push läuft nicht unter dem App-Token')
+      .toMatch(/token: \$\{\{ steps\.apptoken\.outputs\.token/);
+    expect(TAGES, 'die fehlende App wird nicht benannt')
+      .toMatch(/Routine-App nicht eingerichtet/);
     // Und mit Token soll er von selbst zufallen, sobald die Prüfungen grün sind.
     expect(TAGES, 'kein Auto-Merge').toMatch(/gh pr merge --squash --auto/);
   });

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,9 +63,9 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **25** |
-| Commits (30 Tage) | 106 |
-| Letzter Commit | `6a39166 · Routine-Token verdrahtet, sein Fehlen bleibt sichtbar` (2026-08-12) |
+| Commits (7 Tage) | **26** |
+| Commits (30 Tage) | 107 |
+| Letzter Commit | `79cee61 · GitHub App statt Token — fuer Routine UND Autopilot` (2026-08-12) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,17 +63,17 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **20** |
-| Commits (30 Tage) | 101 |
-| Letzter Commit | `cea1c5f · HQ-Zugang für Mitarbeiter (TOTP) und Event-Radar mit echten Koordinaten (#122)` (2026-08-10) |
+| Commits (7 Tage) | **25** |
+| Commits (30 Tage) | 106 |
+| Letzter Commit | `6a39166 · Routine-Token verdrahtet, sein Fehlen bleibt sichtbar` (2026-08-12) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
 34 app.js
+     29 tests/e2e/kern.spec.js
+     27 CLAUDE.md
      26 styles.css
-     24 tests/e2e/kern.spec.js
-     22 CLAUDE.md
-     20 hq.html
+     21 vault/30-Betrieb/Testing.md
 ```
 
 **Codegröße:**

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 256 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 257 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 256 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 257 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 257 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 258 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 257 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 258 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Verbindungen.md
+++ b/vault/30-Betrieb/Verbindungen.md
@@ -232,6 +232,62 @@ Landkarte, die man Angreifern nicht mitgibt. Nicht-öffentliche Dateien gehen
 mit `Cache-Control: private, no-store` raus, damit kein geteilter
 Zwischenspeicher sie für einen anderen Abrufer aufhebt.
 
+## Die Routine-App — warum kein GITHUB_TOKEN reicht
+
+Ein Repository-Ruleset auf `main` verlangt: *„Changes must be made through a
+pull request"* plus den erforderlichen Check `PR Check / PR-Validierung`. Ein
+direkter Push wird abgelehnt (`GH013`), auch aus einem Workflow heraus.
+
+Der naheliegende Ausweg — der Workflow legt einen PR an — trägt aber nicht,
+solange er `GITHUB_TOKEN` benutzt:
+
+> Ein Pull Request, den `GITHUB_TOKEN` anlegt, löst **keine** Workflow-Läufe
+> aus. Der erforderliche Check läuft damit nie an, und der PR kann
+> grundsätzlich nicht mergen.
+
+Das hat zwei Lieferwege lahmgelegt, ohne dass es auffiel: die **Tagesroutine**
+hat in ihrer gesamten Laufzeit kein einziges Mal committet (kein einziger
+`chore(routine)`-Commit existiert), und der **Autopilot** hat mit PR #123 am
+11.08. geliefert — der PR stand danach offen und war nicht mergefähig.
+
+Beide nutzen deshalb ein **Installations-Token einer GitHub App**. Ein Token
+daraus löst Workflows normal aus.
+
+### Warum App statt PAT
+
+| | GitHub App | Fine-grained PAT |
+|---|---|---|
+| Ablauf | keiner | max. 1 Jahr, muss erneuert werden |
+| Identität | eigene (`…[bot]`) | hängt an einem persönlichen Konto |
+| Rechte | an die Installation gebunden | an den Menschen gebunden |
+
+Beide lösen Workflows aus. Die App gewinnt bei Lebensdauer und daran, dass die
+täglichen PRs nicht so aussehen, als hätte sie ein Mensch geöffnet.
+
+### Einrichtung
+
+1. **App anlegen** → <https://github.com/settings/apps/new>
+   - Name z. B. `Eventbörse Routine`, Homepage-URL beliebig
+   - **Webhook: aktiv → abwählen** (die App empfängt nichts)
+   - Repository permissions: **Contents: Read and write**, **Pull requests:
+     Read and write** — sonst nichts. Kein `Workflows`, kein `Administration`.
+2. **Private Key erzeugen** (Abschnitt *Private keys* → *Generate a private
+   key*). Die `.pem`-Datei wird genau einmal heruntergeladen.
+3. **Installieren** → *Install App* → nur `Sabindro53/eventboerse`.
+4. **Zwei Secrets hinterlegen**
+   (<https://github.com/Sabindro53/eventboerse/settings/secrets/actions>):
+   - `EB_ROUTINE_APP_ID` — die App-ID von der Einstellungsseite
+   - `EB_ROUTINE_APP_KEY` — der **komplette** Inhalt der `.pem`, inklusive der
+     `-----BEGIN`- und `-----END`-Zeilen
+
+### Fail-Safe
+
+Fehlt die App, laufen beide Workflows weiter und fallen auf `GITHUB_TOKEN`
+zurück — aber **nicht stillschweigend**: die Tagesroutine schreibt in ihre
+Zusammenfassung, dass der PR so nicht mergen kann und was zu tun ist. Ein
+stiller Rückfall wäre derselbe Fehler wie die verschluckte Push-Ablehnung,
+nur eine Ebene höher.
+
 ## Wo Geheimnisse liegen
 
 | Ablage | Was | Erreichbar für |

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 256 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 257 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 257 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 258 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
Du hast dich für die GitHub App entschieden. Beim Umbau kam heraus, dass **derselbe Fehler noch einen zweiten Lieferweg lahmlegt**.

## Der zweite Betroffene

`openrouter-autopilot.yml` legt seine PRs ebenfalls mit `GITHUB_TOKEN` an. Ergebnis für **PR #123** (vom 11.08., *„Konsistente Focus-Visualisierung bei Modals"*):

```
check_runs: 0
```

Null Prüfungen, seit einem Tag offen, **grundsätzlich nicht mergefähig**. Der Autopilot hat gearbeitet, vier Rollen bezahlt ($0,0029), einen reviewten Patch produziert — und das Ergebnis blieb liegen. Genau dasselbe Muster wie bei der Tagesroutine, nur an anderer Stelle.

Beide nutzen jetzt ein Installations-Token einer GitHub App.

## Warum App und nicht PAT

| | GitHub App | Fine-grained PAT |
|---|---|---|
| Ablauf | keiner | max. 1 Jahr, muss erneuert werden |
| Identität | eigene (`…[bot]`) | hängt an deinem persönlichen Konto |
| Rechte | an die Installation gebunden | an den Menschen gebunden |

Beide lösen Workflows aus — das ist der Punkt, an dem `GITHUB_TOKEN` scheitert. Die App gewinnt bei Lebensdauer und daran, dass die täglichen PRs nicht so aussehen, als hättest du sie geöffnet.

## Eine Stolperstelle, die Erwähnung verdient

Der `secrets`-Kontext ist in `steps.*.if` **nicht** verfügbar, in `jobs.<id>.env` aber schon. Ein naheliegendes `if: secrets.EB_ROUTINE_APP_ID != ''` wäre still zu `false` ausgewertet worden — die App wäre nie benutzt worden, und beide Workflows hätten wortlos weiter auf `GITHUB_TOKEN` zurückgegriffen. Also der Umweg über einen Merker auf Job-Ebene.

## Was du einrichten musst

**1. App anlegen** → https://github.com/settings/apps/new

- Name z. B. `Eventbörse Routine`
- **Webhook: den Haken bei „Active" entfernen** — die App empfängt nichts
- Repository permissions: **Contents: Read and write** + **Pull requests: Read and write**. Sonst nichts — kein `Workflows`, kein `Administration`

**2. Private Key erzeugen** (Abschnitt *Private keys* → *Generate a private key*). Die `.pem` wird genau einmal heruntergeladen.

**3. Installieren** → *Install App* → nur `Sabindro53/eventboerse`

**4. Zwei Secrets** unter https://github.com/Sabindro53/eventboerse/settings/secrets/actions

| Secret | Wert |
|---|---|
| `EB_ROUTINE_APP_ID` | die App-ID von der Einstellungsseite |
| `EB_ROUTINE_APP_KEY` | der **komplette** `.pem`-Inhalt, inkl. `-----BEGIN`/`-----END` |

Die Anleitung steht ab jetzt auch im Vault unter `30-Betrieb/Verbindungen.md` — nicht nur hier im PR, wo sie in einem halben Jahr niemand mehr sucht.

## Fail-Safe

Ohne App laufen beide Workflows weiter und fallen auf `GITHUB_TOKEN` zurück — aber **nicht stillschweigend**. Die Routine schreibt in ihre Zusammenfassung, dass der PR so nicht mergen kann und was zu tun ist.

## Geprüft

**257 Tests grün** (1 neu), alle Tore grün. Rückbau des Autopilot-Tokens als Mutation gegengeprüft.

Der neue Test verbietet in beiden Workflows jedes fest verdrahtete `token: ${{ secrets.GITHUB_TOKEN }}` — derselbe Fehler in einem dritten Lieferweg fiele damit sofort auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_