### PR TITLE
Der geöffnete Bereich wird ein Netz, die Mitte gibt einen Lagebericht

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-267 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+268 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-266 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+267 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-263 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+266 Tests in 13 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), TOTP (RFC-6238-Vektoren,

--- a/hq.html
+++ b/hq.html
@@ -1652,6 +1652,9 @@ async function loadSelfAudit() {
     return;
   }
   const c = data.counts || {};
+  // Auch fuer den Lagebericht der Mitte behalten: bisher wurde der Selbstcheck
+  // gerendert und weggeworfen, der Kreis konnte ihn deshalb nicht benennen.
+  state.audit = data;
   ebImpuls('betrieb', (c.error || 0) ? 'schlecht' : 'gut');
   $('audit-chip-err').textContent  = `❌ ${c.error || 0}`;
   $('audit-chip-warn').textContent = `⚠️ ${c.warn  || 0}`;
@@ -3270,14 +3273,103 @@ window.addEventListener('DOMContentLoaded', init);
   }
 
   /* HQ-Livezustand: der Circle kennt den Betrieb, nicht nur das Handbuch. */
+  /**
+   * Der Lagebericht — was der Betrieb JETZT tut, aus geladenen Quellen.
+   *
+   * Die tragende Regel: **eine nicht geladene Quelle wird als „nicht geladen"
+   * gemeldet, nie als Null.** „0 Schichten gearbeitet" heisst „der Betrieb
+   * lief und tat nichts". „Journal nicht geladen" heisst „ich weiss es
+   * nicht". Das sind zwei verschiedene Lagen, und man handelt unterschiedlich
+   * danach — sie zusammenfallen zu lassen ist genau die Art Fehler, die den
+   * Selbstcheck zwei Wochen lang über einen alten Code-Stand berichten liess.
+   */
+  function hqLagebericht() {
+    var z = [];
+    var rel = function (iso) {
+      if (!iso) return 'ohne Zeit';
+      var min = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+      if (!isFinite(min)) return 'ohne Zeit';
+      if (min < 2) return 'gerade eben';
+      if (min < 60) return 'vor ' + min + ' Min.';
+      if (min < 1440) return 'vor ' + Math.round(min / 60) + ' Std.';
+      return 'vor ' + Math.round(min / 1440) + ' Tagen';
+    };
+    var laeufe = state.runs || [];
+    var vonPfad = function (re) { return laeufe.filter(function (r) { return re.test(r.path || ''); }); };
+
+    if (!laeufe.length) {
+      z.push('Workflow-Läufe: nicht geladen — ohne sie kann ich zu Deploy und Puls nichts sagen.');
+    } else {
+      var dep = vonPfad(/ionos-deploy\.yml$/)[0];
+      z.push(dep
+        ? 'Letzter Deploy: ' + (dep.conclusion || 'läuft noch') + ' · ' + String(dep.head_sha || '').slice(0, 7) + ' · ' + rel(dep.created_at)
+        : 'Deploy: in den geladenen Läufen keiner.');
+      var puls = vonPfad(/hq-operations\.yml$/)[0];
+      z.push(puls
+        ? 'Letzter Ensemble-Puls: ' + (puls.conclusion || 'läuft noch') + ' · ' + rel(puls.created_at) + ' (Takt: alle 30 Min.)'
+        : 'Ensemble-Puls: in den geladenen Läufen keiner.');
+      var kaputt = laeufe.filter(function (r) { return r.conclusion === 'failure'; });
+      z.push(kaputt.length
+        ? 'Fehlgeschlagene Läufe unter den geladenen: ' + kaputt.length + ' — zuletzt ' + (kaputt[0].name || kaputt[0].path) + ' ' + rel(kaputt[0].created_at)
+        : 'Kein fehlgeschlagener Lauf unter den geladenen.');
+    }
+
+    if (!nnJournal) {
+      z.push('Arbeitsjournal: nicht geladen — ich kann nicht sagen, wer gearbeitet hat.');
+    } else {
+      var e = nnJournal.eintraege || [];
+      if (!e.length) {
+        z.push('Arbeitsjournal: geladen, aber leer — es hat noch keine Schicht gearbeitet.');
+      } else {
+        var nach = {};
+        e.forEach(function (x) { nach[x.ergebnis] = (nach[x.ergebnis] || 0) + 1; });
+        z.push('Arbeitsjournal: ' + e.length + ' Einträge (' + Object.keys(nach).map(function (k) { return nach[k] + '× ' + k; }).join(', ') + ').');
+        var letzte = e.filter(function (x) { return x.ergebnis === 'fertig'; })[0];
+        if (letzte) {
+          z.push('Zuletzt echt geliefert: ' + (letzte.person || letzte.rolle) + ' (' + (letzte.rollenname || '–') + ') ' + rel(letzte.zeit)
+            + ' — ' + String(letzte.text || '').replace(/\s+/g, ' ').slice(0, 200));
+        } else {
+          z.push('Keine einzige fertige Schicht im Journal — alle Einträge sind Ausfälle oder Kostenstopps.');
+        }
+        var kosten = e.reduce(function (a, x) { return a + (typeof x.kostenUsd === 'number' ? x.kostenUsd : 0); }, 0);
+        var tok = e.reduce(function (a, x) { return a + (x.tokens || 0); }, 0);
+        if (tok) z.push('Verbrauch im Journal: ' + tok + ' Token, $' + kosten.toFixed(5) + '.');
+      }
+    }
+
+    if (!state.audit) {
+      z.push('Selbstcheck: nicht geladen.');
+    } else {
+      var c = state.audit.counts || {};
+      z.push('Selbstcheck vom ' + (String(state.audit.erzeugt || state.audit.generated || '').slice(0, 10) || 'ohne Datum')
+        + ': ' + ((state.audit.findings || []).length) + ' Befunde (' + (c.error || 0) + ' Fehler, ' + (c.warn || 0) + ' Warnungen).');
+    }
+
+    if (state.pulls && state.pulls.length) {
+      z.push('Offene Pull Requests: ' + state.pulls.length + ' — ältester „' + String(state.pulls[state.pulls.length - 1].title || '').slice(0, 70) + '".');
+    } else if (laeufe.length) {
+      z.push('Keine offenen Pull Requests in den geladenen Daten.');
+    }
+
+    z.push(nnWissen
+      ? 'Wissensbasis: ' + nnWissen + ' freigegebene Abschnitte.'
+      : 'Wissensbasis: nicht geladen.');
+    if (state.siteUp !== null && state.siteUp !== undefined) {
+      z.push('Seite erreichbar: ' + (state.siteUp ? 'ja' : 'NEIN'));
+    }
+    return z.join('\n');
+  }
+
   function hqStatus(q) {
     var t = String(q || '').toLowerCase();
-    if (!/(status|deploy|live|version|sha|build|läuft|laeuft|seite|hq|system)/.test(t)) return null;
-    var sha = (document.getElementById('header-sha') || {}).textContent || 'unbekannt';
-    var bits = ['Aktueller HQ-Stand: ' + sha.trim()];
-    var lvl = document.getElementById('lvl-chip');
-    if (lvl && lvl.textContent.trim()) bits.push('Commander-Level: ' + lvl.textContent.trim());
-    return bits.join('. ') + '.';
+    // „wie laeuft" allein reicht nicht: „Wie laeuft eine Buchung ab?" ist eine
+    // Produktfrage. Eine Lage-Frage nennt ihren Gegenstand — den Betrieb.
+    if (!/lagebericht|betriebszustand|(ü|ue)berblick|\bstatus\b|\bdeploys?\b|wie steht (es|der betrieb|alles|die lage)|l(ä|ae)uft (alles|es)\b|aktueller stand|welcher stand|letzter (deploy|puls|lauf)/.test(t)) return null;
+    // Vorher standen hier zwei Zeilen: HQ-SHA und Commander-Level. Auf „wie
+    // steht es?" war das keine Antwort, sondern eine Ausweichbewegung.
+    var sha = ((document.getElementById('header-sha') || {}).textContent || '').trim();
+    var kopf = 'Lagebericht' + (sha ? ' (HQ-Stand ' + sha + ')' : '') + ':';
+    return kopf + '\n' + hqLagebericht();
   }
 
   function hqDialogContext() {
@@ -3374,7 +3466,10 @@ window.addEventListener('DOMContentLoaded', init);
     var treffer = topTreffer(q, 4);
     var hit = treffer[0] || search(q);
     var localAnswer = g || status || null;
-    if (hit) {
+    // Eine Status-Frage gewinnt gegen einen Wissenstreffer: auf „wie steht es?"
+    // ist ein Abschnitt ueber Buchungsablaeufe keine Antwort. Umgekehrt bleibt
+    // eine Produktfrage beim Wissen, weil hqStatus dann gar nicht anspringt.
+    if (hit && !status && !g) {
       var txt = hit.text.length > 700 ? hit.text.slice(0, 690).replace(/\s+\S*$/, '') + ' …' : hit.text;
       localAnswer = (hit.heading ? hit.heading + '. ' : '') + txt;
     }
@@ -3487,7 +3582,11 @@ window.addEventListener('DOMContentLoaded', init);
     },
     sprechen: toggleMic,
     istOffen: function () { return panel.classList.contains('open'); },
-    kannHoeren: function () { return !!(window.SpeechRecognition || window.webkitSpeechRecognition); }
+    kannHoeren: function () { return !!(window.SpeechRecognition || window.webkitSpeechRecognition); },
+    /* Der Lagebericht auch ausserhalb des Gespraechs — er ist eine Aussage
+       ueber den Betrieb, nicht bloss eine Chat-Antwort. */
+    lage: function () { return hqLagebericht(); },
+    statusAntwort: function (frage) { return hqStatus(frage); }
   };
   document.getElementById('ebc-close').addEventListener('click', close);
   micBtn.addEventListener('click', toggleMic);

--- a/hq.html
+++ b/hq.html
@@ -238,6 +238,16 @@
      als Dateiname lesbar ist und nicht als Fließtext. */
   .nn-datei { font-size: 7.5px; fill: var(--cyan); text-anchor: middle;
               font-family: ui-monospace, SFMono-Regular, Menlo, monospace; opacity: .9; }
+  /* Aufgabenknoten im geöffneten Bereich. Das Ziel wird umgebrochen, nicht
+     abgeschnitten — ein Satz, der mitten im Wort endet, liest sich wie ein
+     Fehler und nicht wie eine Kürzung. */
+  .nn-ziel { font-size: 8px; fill: var(--muted); text-anchor: middle; opacity: .8; }
+  .nn-ziel-jetzt { font-size: 8.5px; fill: var(--text); text-anchor: middle; font-weight: 600; }
+  .nn-aufgabe circle { transition: r .25s ease, opacity .25s; }
+  .nn-aufgabe:hover circle { opacity: 1; }
+  .nn-aufgabe:hover .nn-ziel { fill: var(--text); opacity: 1; }
+  .nn-dateiknoten rect { transition: opacity .25s; }
+  .nn-dateiknoten:hover rect { opacity: 1; }
   .nn-bahn { fill: none; stroke: rgba(255,255,255,.16); stroke-width: 1; stroke-dasharray: 3 5; }
   /* Der Impuls: einmalig, dann weg. Kein Loop. */
   .nn-impuls { fill: none; stroke-width: 2.2; stroke-linecap: round; opacity: .95; }
@@ -1375,7 +1385,7 @@ function renderLog() {
 
 /* ─── Bot Team ─────────────────────────────────────────────────── */
 const BOTS = [
-  { id: 'operations', avatar: '⚡', name: 'HQ-Operations-Rundlauf', role: 'Viermal täglich arbeitet das komplette Ensemble ein Lagebild. Die Code-Arbeit macht der Autopilot — er bekommt deshalb den größeren Teil des Tagesbudgets.', workflow: 'hq-operations.yml', schedule: '🟢 Lagebild 4×/Tag (02/08/14/20 Uhr UTC) · 11 Rollen/Lauf · $0,15/Tag hart', canTrigger: true, triggerLabel: '▶ Voll-Ensemble', logsLabel: '📋 Live-Läufe', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-operations.yml` },
+  { id: 'operations', avatar: '⚡', name: 'HQ-Operations-Rundlauf', role: 'Alle 30 Minuten arbeitet das komplette Ensemble ein Lagebild. Die Code-Arbeit macht der Autopilot — er bekommt deshalb den größeren Teil des Tagesbudgets.', workflow: 'hq-operations.yml', schedule: '🟢 Lagebild alle 30 Min. · 11 Rollen/Lauf · $0,50/Tag hart', canTrigger: true, triggerLabel: '▶ Voll-Ensemble', logsLabel: '📋 Live-Läufe', logsUrl: `https://github.com/${REPO}/actions/workflows/hq-operations.yml` },
   { id: 'openrouter', avatar: '🧬', name: 'OpenRouter-Autopilot', role: 'Prüft alle 5 Minuten tokenfrei; im offenen Kostenfenster liefern Scout, Architekt, Implementierer und Reviewer genau eine kleine Verbesserung.', workflow: 'openrouter-autopilot.yml', schedule: '⚡ 5-Min.-Prüfung · KI max. stündlich · $0,12/Lauf · $0,60/Tag', canTrigger: true, triggerLabel: '▶ Autopilot', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=is%3Apr+label%3Aopenrouter` },
   { id: 'improve',    avatar: '✨', name: 'Claude-Verbesserung (Legacy)', role: 'Manuelles Fallback für bestehende Anthropic-Konfiguration; kein Zeitplan mehr.', workflow: 'claude-improve.yml', schedule: '🕹️ Manuell · Legacy', canTrigger: true, triggerLabel: '▶ Legacy', logsLabel: '📋 PRs', logsUrl: `https://github.com/${REPO}/pulls?q=is%3Apr+label%3Aclaude-routine` },
   { id: 'claude-dev', avatar: '🤖', name: 'Claude-Audit (Legacy)', role: 'Manuelles Fallback für bestehende Anthropic-Konfiguration; kein Zeitplan mehr.', workflow: 'claude-auto-audit.yml', schedule: '🕹️ Manuell · Legacy', canTrigger: true, triggerLabel: '▶ Legacy', logsLabel: '📋 Issues', logsUrl: `https://github.com/${REPO}/issues?q=label%3Aaudit` },
@@ -2393,49 +2403,154 @@ function nnBaum() {
   const rollen = nnKatalog.modelle.filter(m => m.bereich === b.id);
   const bild = nnBetriebsbild();
   const teile = [];
-  const unten = 396, mitteReihe = 250, oben = 108;
-  const bx = 450;
 
-  const spalten = rollen.length;
-  const px = i => 450 + (i - (spalten - 1) / 2) * Math.min(230, 780 / Math.max(spalten, 1));
+  // Vier Ebenen, von unten nach oben gelesen: Bereich, Mitarbeiter, seine
+  // Aufgaben, deren Dateien. Vorher waren es drei, und die mittlere trug
+  // genau EINE Aufgabe — bei einem Bereich mit einem Mitarbeiter stand damit
+  // ein einzelner Punkt auf einer leeren Fläche. Der Aufgabenstrom ist echt
+  // und steht im Katalog; ihn nicht zu zeigen war eine verschenkte Ebene.
+  const yBereich = 452, yRolle = 336, yAufgabe = 176, yDatei = 58;
+  const bx = 450, LINKS = 60, RECHTS = 840;
 
-  // Bereich unten
+  // Gleichmäßig über die Breite verteilen — auch bei einem einzigen Knoten,
+  // der dann mittig steht statt am Rand zu kleben.
+  const verteile = (n, i, links = LINKS, rechts = RECHTS) =>
+    n <= 1 ? (links + rechts) / 2 : links + (i * (rechts - links)) / (n - 1);
+
+  // Wortsicherer Umbruch. Vorher wurde hart nach 52 Zeichen geschnitten,
+  // mitten im Wort: „…als ein Produkt betrachten und die". Ein Satz, der
+  // mitten im Wort endet, liest sich wie ein Fehler, nicht wie eine Kürzung.
+  const zeilen = (text, proZeile, maxZeilen) => {
+    const worte = String(text || '').trim().split(/\s+/).filter(Boolean);
+    const out = [];
+    let z = '';
+    for (const w of worte) {
+      if (!z.length) { z = w; continue; }
+      if ((z + ' ' + w).length <= proZeile) { z += ' ' + w; continue; }
+      out.push(z); z = w;
+      if (out.length === maxZeilen) break;
+    }
+    if (out.length < maxZeilen && z) out.push(z);
+    // Gekürzt wird an einer Wortgrenze und sichtbar, nicht heimlich.
+    const rest = worte.join(' ').length > out.join(' ').length;
+    if (rest && out.length) out[out.length - 1] += ' …';
+    return out;
+  };
+  const text = (x, y, inhalt, klasse, proZeile, maxZeilen, extra = '') => {
+    const zs = zeilen(inhalt, proZeile, maxZeilen);
+    return zs.map((z, i) =>
+      `<text x="${x}" y="${(y + i * 11).toFixed(1)}" class="${klasse}" ${extra}>${escHtml(z)}</text>`).join('');
+  };
+
+  // ── Bereich unten: der Rückweg ──────────────────────────────────────
   teile.push(`
     <g id="nn-zurueck" class="nn-orb-hit" role="button" tabindex="0" aria-label="Zurück zur Übersicht">
-      <circle cx="${bx}" cy="${unten}" r="30" fill="${b.farbe}" opacity=".2"/>
-      <circle cx="${bx}" cy="${unten}" r="30" fill="none" stroke="${b.farbe}" stroke-width="1.5"/>
-      <text x="${bx}" y="${unten + 5}" style="font-size:17px;text-anchor:middle">${b.emoji}</text>
-      <text x="${bx}" y="${unten + 46}" class="nn-label">${escHtml(b.label)}</text>
-      <text x="${bx}" y="${unten + 58}" class="nn-sub">← zurück</text>
+      <circle cx="${bx}" cy="${yBereich}" r="30" fill="${b.farbe}" opacity=".2"/>
+      <circle cx="${bx}" cy="${yBereich}" r="30" fill="none" stroke="${b.farbe}" stroke-width="1.5"/>
+      <text x="${bx}" y="${yBereich + 6}" style="font-size:18px;text-anchor:middle">${b.emoji}</text>
+      <text x="${bx}" y="${yBereich + 48}" class="nn-label">${escHtml(b.label)}</text>
+      <text x="${bx}" y="${yBereich + 60}" class="nn-sub">← zurück</text>
     </g>`);
 
+  // ── Dateien der ganzen Ebene einsammeln, damit jede nur EINMAL als
+  //    Knoten steht. Zwei Aufgaben an derselben Datei sind zwei Bahnen zu
+  //    einem Knoten — genau das macht das Bild zu einem Netz statt zu
+  //    einem Baum. ────────────────────────────────────────────────────
+  const alleDateien = [...new Set(rollen.flatMap(m =>
+    (m.aufgabenstrom || []).flatMap(a => a.dateien || [])))].slice(0, 9);
+  const dateiX = {};
+  alleDateien.forEach((d, i) => { dateiX[d] = verteile(alleDateien.length, i, 90, 810); });
+
+  alleDateien.forEach(d => {
+    const x = dateiX[d];
+    teile.push(`
+      <g class="nn-node nn-dateiknoten" role="img" tabindex="0" aria-label="Datei ${escHtml(d)}">
+        <rect x="${x - 5}" y="${yDatei - 5}" width="10" height="10" rx="2"
+              fill="none" stroke="var(--cyan)" stroke-width="1.3" opacity=".75"/>
+        ${text(x, yDatei + 22, nnDateiKurz(d), 'nn-datei', 20, 2)}
+      </g>`);
+  });
+
+  // Die Staffelung laeuft ueber ALLE Aufgaben, nicht je Mitarbeiter. Sonst
+  // treffen sich die letzte Aufgabe des einen und die erste des naechsten
+  // genau auf derselben Hoehe — an der Nahtstelle zwischen zwei Faechern.
+  let aufgabeNr = 0;
+
   rollen.forEach((m, i) => {
-    const x = px(i);
+    const rx = verteile(rollen.length, i, rollen.length > 2 ? 130 : 300, rollen.length > 2 ? 770 : 600);
     const st = nnSchichtStand(m);
     const farbe = NN_STAND_FARBE[st.stand];
-    // Woran diese Rolle gerade arbeitet — aus dem Katalog, nicht geraten.
-    const dateien = nnAufgabenDateien(m);
+    const aktuell = nnAufgabeRoh(m);
 
-    // Bereich → Rolle (gestrichelt, wie die Aufgabenlinien in der Vorlage)
-    const d = `M ${bx} ${unten - 30} L ${x} ${mitteReihe + 20}`;
+    // Bereich → Mitarbeiter
+    const d0 = `M ${bx} ${yBereich - 30} L ${rx} ${yRolle + 22}`;
     const live = bild.voll || (bild.aktiv && bild.aktiv.id === m.id);
     const next = bild.naechste && bild.naechste.id === m.id;
-    teile.push(`<path class="nn-bahn" id="bahn-${m.id}" d="${d}"/>`);
-    teile.push(`<path class="nn-transport ${live ? 'nn-live' : next ? 'nn-next' : ''}" d="${d}" stroke="${b.farbe}" style="color:${b.farbe};animation-delay:-${(i * .17).toFixed(2)}s"/>`);
+    teile.push(`<path class="nn-bahn" id="bahn-${m.id}" d="${d0}"/>`);
+    teile.push(`<path class="nn-transport ${live ? 'nn-live' : next ? 'nn-next' : ''}" d="${d0}" stroke="${b.farbe}" style="color:${b.farbe};animation-delay:-${(i * .17).toFixed(2)}s"/>`);
 
-    // Rolle → Werkzeuge
-    (m.werkzeuge || []).forEach((w, j) => {
-      const wx = x + (j - ((m.werkzeuge.length - 1) / 2)) * 74;
+    // ── Aufgaben dieses Mitarbeiters ─────────────────────────────────
+    const strom = (m.aufgabenstrom || []).slice(0, 4);
+    // Das Faecher eines Mitarbeiters muss schmaler sein als der Abstand zum
+    // naechsten, sonst treffen sich die aeusseren Aufgaben genau in der Mitte
+    // und die Beschriftungen liegen uebereinander.
+    const breite = Math.min(250, (700 / Math.max(rollen.length, 1)) * 0.8);
+    // Die Zeilenbreite folgt dem PLATZ, nicht einer festen Zahl. Bei drei
+    // Mitarbeitern ist das Faecher schmal; 30 Zeichen sind dort rund 126 px
+    // breit und liegen bei 93 px Abstand zwangslaeufig uebereinander.
+    const abstand = strom.length > 1 ? breite / (strom.length - 1) : 260;
+    const proZeile = Math.max(13, Math.min(32, Math.round(abstand / 5.0)));
+    const maxZeilen = proZeile < 20 ? 7 : 5;
+
+    // Das ganze Faecher verschieben statt einzelne Knoten zu klemmen. Klemmen
+    // schiebt den aeussersten Knoten auf seinen Nachbarn und erzeugt genau die
+    // Ueberlappung, die es verhindern soll.
+    const halb = breite / 2;
+    let versatz = 0;
+    if (rx - halb < 78) versatz = 78 - (rx - halb);
+    else if (rx + halb > 822) versatz = 822 - (rx + halb);
+
+    strom.forEach((a, j) => {
+      const ax = (strom.length <= 1 ? rx
+        : rx + (j - (strom.length - 1) / 2) * (breite / Math.max(strom.length - 1, 1))) + versatz;
+      // Benachbarte Ziele auf zwei Hoehen staffeln — bei schmalen Faechern
+      // stehen sonst zwei mehrzeilige Texte Schulter an Schulter.
+      const ay = yAufgabe + (aufgabeNr++ % 2 ? 34 : 0);
+      const istAktuell = aktuell && aktuell.ziel === a.ziel;
+
+      teile.push(`<path class="nn-bahn" style="opacity:${istAktuell ? .5 : .22}" d="M ${rx} ${yRolle - 22} L ${ax} ${ay + 14}"/>`);
+      (a.dateien || []).forEach(d => {
+        if (dateiX[d] === undefined) return;
+        teile.push(`<path class="nn-bahn" style="opacity:${istAktuell ? .4 : .16}" d="M ${ax} ${ay - 12} L ${dateiX[d]} ${yDatei + 8}"/>`);
+      });
+
+      teile.push(`
+        <g class="nn-node nn-aufgabe ${istAktuell ? 'jetzt' : ''}" role="img" tabindex="0"
+           aria-label="Aufgabe von ${escHtml(m.person)}: ${escHtml(a.ziel)}">
+          <circle cx="${ax}" cy="${ay}" r="${istAktuell ? 8 : 5.5}"
+                  fill="${istAktuell ? b.farbe : 'none'}" stroke="${b.farbe}" stroke-width="1.3"
+                  opacity="${istAktuell ? .95 : .6}"/>
+          ${istAktuell ? `<circle cx="${ax}" cy="${ay}" r="14" fill="${b.farbe}" opacity=".12"/>` : ''}
+          ${text(ax, ay + 26, a.ziel, istAktuell ? 'nn-ziel-jetzt' : 'nn-ziel', proZeile, maxZeilen)}
+        </g>`);
+    });
+
+    // ── Werkzeuge seitlich am Mitarbeiter, nicht mehr oben ───────────
+    (m.werkzeuge || []).forEach((w, k) => {
+      // Seitlich auf Augenhoehe des Mitarbeiters. Darunter stiessen sie in
+      // den Bereichsnamen, und ein Werkzeug ist keine eigene Ebene.
+      const seite = k % 2 ? 1 : -1;
+      const wx = rx + seite * (52 + Math.floor(k / 2) * 26);
+      const wy = yRolle;
       const c = (connKatalog && connKatalog.connectors || []).find(y => y.id === w);
       const z = (connZustand[w] || {}).status || 'getrennt';
       const wf = z === 'verbunden' ? '#4ade80' : z === 'eingeschraenkt' ? '#fbbf24' : '#475569';
-      teile.push(`<path class="nn-bahn" style="opacity:.3" d="M ${x} ${mitteReihe - 20} L ${wx} ${oben + 14}"/>`);
+      teile.push(`<path class="nn-bahn" style="opacity:.25" d="M ${rx + seite * 22} ${yRolle} L ${wx - seite * 11} ${wy}"/>`);
       teile.push(`
         <g class="nn-node nn-wz" data-werkzeug="${escHtml(w)}" role="button" tabindex="0"
            aria-label="Werkzeug ${escHtml(c ? c.dienst : w)}">
-          <circle class="nn-ring" cx="${wx}" cy="${oben}" r="13" stroke="${wf}"/>
-          <text x="${wx}" y="${oben + 4}" style="font-size:11px;text-anchor:middle">${c ? c.logo : '🔌'}</text>
-          <text x="${wx}" y="${oben - 20}" class="nn-sub">${escHtml(c ? c.anbieter : w)}</text>
+          <circle class="nn-ring" cx="${wx}" cy="${wy}" r="11" stroke="${wf}"/>
+          <text x="${wx}" y="${wy + 4}" style="font-size:10px;text-anchor:middle">${c ? c.logo : '🔌'}</text>
         </g>`);
     });
 
@@ -2443,14 +2558,13 @@ function nnBaum() {
       <g class="nn-node nn-agent ${st.stand === 'laeuft' ? 'arbeitet' : ''}" id="node-${m.id}"
          data-modell="${m.id}" role="button" tabindex="0"
          aria-label="${escHtml(m.person)}, ${escHtml(m.rolle)}: ${escHtml(st.text)}">
-        <circle class="nn-ring" cx="${x}" cy="${mitteReihe}" r="20" stroke="${farbe}"/>
-        <circle class="nn-core" cx="${x}" cy="${mitteReihe}" r="13" fill="${farbe}" opacity=".16"/>
-        <text x="${x}" y="${mitteReihe + 5}" style="font-size:13px;text-anchor:middle">👤</text>
-        <text x="${x}" y="${mitteReihe + 36}" class="nn-label">${escHtml(m.person)}</text>
-        <text x="${x}" y="${mitteReihe + 48}" class="nn-sub">${escHtml(m.rolle)}</text>
-        <text x="${x}" y="${mitteReihe + 60}" class="nn-sub" fill="${farbe}">${escHtml(st.text)}</text>
-        <text x="${x}" y="${mitteReihe + 73}" class="nn-task">${escHtml(String(st.task || m.aufgabe || '').slice(0, 52))}</text>
-        ${dateien.length ? `<text x="${x}" y="${mitteReihe + 85}" class="nn-datei">${escHtml(dateien.map(nnDateiKurz).join(' · ').slice(0, 44))}</text>` : ''}
+        <circle class="nn-hof" cx="${rx}" cy="${yRolle}" r="34" fill="${farbe}"/>
+        <circle class="nn-ring" cx="${rx}" cy="${yRolle}" r="22" stroke="${farbe}"/>
+        <circle class="nn-core" cx="${rx}" cy="${yRolle}" r="14" fill="${farbe}" opacity=".18"/>
+        <text x="${rx}" y="${yRolle + 6}" style="font-size:15px;text-anchor:middle">👤</text>
+        <text x="${rx}" y="${yRolle - 50}" class="nn-label">${escHtml(m.person)}</text>
+        <text x="${rx}" y="${yRolle - 38}" class="nn-sub">${escHtml(m.rolle)}</text>
+        <text x="${rx}" y="${yRolle + 52}" class="nn-sub" fill="${farbe}">${escHtml(st.text)}</text>
       </g>`);
   });
   return teile.join('');
@@ -2705,7 +2819,7 @@ function renderNeuralOps() {
   el.innerHTML = `
     <div class="neural-ops-head">
       <b>⚡ Live-Aufgabenstrom · <span class="neural-health ${healthClass}">${healthText}</span></b>
-      <span>Lagebild 4×/Tag · alle 11 Rollen je Lauf · Anzeige sekündlich</span>
+      <span>Lagebild alle 30 Min. · alle 11 Rollen je Lauf · Anzeige sekündlich</span>
     </div>
     <div class="neural-now-grid">
       <div class="neural-now live">
@@ -2948,7 +3062,7 @@ function renderJournal() {
   const e = (nnJournal && nnJournal.eintraege) || [];
   if (!e.length) {
     el.innerHTML = '<h5>📋 Arbeitsjournal</h5><p>Die 11 OpenRouter-Aufträge stehen in der 24/7-Steuerung. '
-      + 'Der Lagebild-Lauf startet viermal täglich; jeder Lauf arbeitet das gesamte Ensemble ab '
+      + 'Der Lagebild-Lauf startet alle 30 Minuten; jeder Lauf arbeitet das gesamte Ensemble ab '
       + 'und schreibt Antworten, Kostenstopps oder Fehler hier hinein.</p>';
     return;
   }

--- a/styles.css
+++ b/styles.css
@@ -7533,7 +7533,7 @@ body.dark-mode .stripe-connect-diagnostics-perms code {
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid var(--border-light);
-  background: var(--light);
+  background: var(--bg-alt);
 }
 .stripe-onboarding-steps > div > .material-icons-round {
   color: #635BFF;
@@ -15419,7 +15419,7 @@ button:disabled {
   display: flex; align-items: center; justify-content: center;
   border-radius: 8px;
   border: 1px solid var(--border-light);
-  background: var(--bg-card);
+  background: var(--bg);
   cursor: pointer;
   color: var(--text);
   transition: background 0.15s ease, border-color 0.15s ease;

--- a/tests/e2e/design-system.spec.js
+++ b/tests/e2e/design-system.spec.js
@@ -13,6 +13,51 @@ const { openApp } = require('./helpers');
 const ROOT = path.join(__dirname, '..', '..');
 
 test.describe('Design-System', () => {
+  test('kein Stylesheet benutzt eine Variable, die keines definiert', () => {
+    // `ui-enhancements.css` benutzte 13 Variablen, die in KEINER CSS-Datei
+    // des Projekts standen — --brand-primary, --eb-radius-sm, --eb-spacing-*
+    // und weitere. Ein var() ohne Definition ist „invalid at computed-value
+    // time": die Deklaration faellt still auf `unset` zurueck. Es gibt keine
+    // Fehlermeldung, keinen roten Test, nichts — die Regel steht da und tut
+    // nichts.
+    //
+    // Genau das hat einen KI-Patch (#123) durchgewunken, der eine
+    // „konsistente Focus-Visualisierung" versprach und nachweislich nichts
+    // bewirkte: er benutzte dieselben nicht existierenden Namen.
+    const fs = require('node:fs');
+    const dateien = ['styles.css', 'ui-enhancements.css', 'eb-hq-evolution.css']
+      .filter((f) => fs.existsSync(path.join(ROOT, f)));
+    expect(dateien.length, 'keine Stylesheets gefunden').toBeGreaterThan(0);
+
+    const quelle = Object.fromEntries(dateien.map((f) => [f, fs.readFileSync(path.join(ROOT, f), 'utf8')]));
+
+    // Definitionen stehen nicht nur in .css: hq.html traegt sein eigenes
+    // :root im Inline-<style>, und einige Variablen setzt erst JS zur
+    // Laufzeit (style="--task-color:…"). Wer nur die CSS-Dateien scannt,
+    // meldet die als fehlend — und ein Waechter, der Falsches meldet, wird
+    // abgeschaltet statt befolgt.
+    const definiert = new Set();
+    const quellenFuerDefinition = [...Object.values(quelle)];
+    for (const f of ['hq.html', 'app-shell.html', 'index.php', 'app.js']) {
+      const abs = path.join(ROOT, f);
+      if (fs.existsSync(abs)) quellenFuerDefinition.push(fs.readFileSync(abs, 'utf8'));
+    }
+    for (const t of quellenFuerDefinition) {
+      for (const m of t.matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)) definiert.add(m[1]);
+      for (const m of t.matchAll(/setProperty\(\s*['"`](--[a-zA-Z0-9-]+)/g)) definiert.add(m[1]);
+    }
+
+    const fehlend = [];
+    for (const [f, t] of Object.entries(quelle)) {
+      for (const m of t.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)\s*(,|\))/g)) {
+        // Ein Rueckfallwert (`var(--x, 8px)`) ist eine bewusste Entscheidung
+        // und deshalb erlaubt — nur der nackte Zugriff muss definiert sein.
+        if (m[2] === ')' && !definiert.has(m[1])) fehlend.push(`${f}: ${m[1]}`);
+      }
+    }
+    expect([...new Set(fehlend)], 'Variablen ohne Definition und ohne Rückfallwert').toEqual([]);
+  });
+
   test('Hero-Suchvorschläge („Beliebt:") sind sichtbar — Klassenkollision bleibt behoben', async ({ page }) => {
     await openApp(page);
     const r = await page.evaluate(() => {

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -414,6 +414,22 @@ test.describe('OpenRouter-Autopilot', () => {
     const summe = budgetAus(operations) + budgetAus(autopilot);
     expect(summe, `Puls $${budgetAus(operations)} + Autopilot $${budgetAus(autopilot)} = $${summe.toFixed(2)} über der Freigabe`)
       .toBeLessThanOrEqual(2.0);
+
+    // Und die Oberflaeche selbst. Der Katalog-Test allein hat nicht gereicht:
+    // hq.html trug an DREI Stellen hartkodiert „Lagebild 4×/Tag" und
+    // „$0,15/Tag hart" weiter, nachdem der Cron längst auf 30 Minuten stand.
+    // Wer aufs HQ schaut, liest den Text — nicht die JSON.
+    const hq = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
+    const pulsMin = cronMinuten((operations.match(/cron:\s*'([^']+)'/) || [])[1]);
+    for (const m of hq.matchAll(/Lagebild\s+(?:alle\s+(\d+)\s*Min\.|(\d+)×\/Tag)/g)) {
+      const behauptet = m[1] ? Number(m[1]) : (24 * 60) / Number(m[2]);
+      expect(behauptet, `hq.html sagt „${m[0]}", der Cron läuft alle ${pulsMin} Min.`).toBe(pulsMin);
+    }
+    for (const m of hq.matchAll(/\$(\d+),(\d+)\/Tag hart/g)) {
+      expect(Number(`${m[1]}.${m[2]}`), `hq.html sagt „${m[0]}", der Workflow setzt $${budgetAus(operations)}`)
+        .toBe(budgetAus(operations));
+    }
+    expect(hq, 'hq.html behauptet weiter „viermal täglich"').not.toMatch(/viermal täglich/);
   });
 });
 
@@ -464,7 +480,11 @@ test.describe('Neuronaler Kern', () => {
       expect(r.text).toContain(heading);
     }
     expect(r.text).toContain('Anzeige sekündlich');
-    expect(r.text).toContain('Lagebild 4×/Tag');
+    // Kein Literal: „Lagebild 4×/Tag" war eine Wort-Zusicherung und hat die
+    // veraltete Behauptung mitkonserviert, als der Cron auf 30 Min. wechselte.
+    // Geprüft wird die Eigenschaft — der Strom nennt SEINEN Takt. Ob die Zahl
+    // stimmt, prüft „der Katalog nennt den Takt, der wirklich läuft".
+    expect(r.text, 'der Strom nennt keinen Takt').toMatch(/Lagebild (alle \d+ Min\.|\d+×\/Tag)/);
     expect(r.text).toContain('alle 11 Rollen je Lauf');
     expect(r.text).toContain('Jetzt');
     expect(r.text).toContain('Nächste Prüfung');
@@ -856,6 +876,44 @@ test.describe('Neuronaler Kern', () => {
         for (const d of aufgabe.dateien || []) {
           expect(gesehen.dateien, `${m.person}: Datei ${d} fehlt oder ist gekürzt`).toContain(d);
         }
+      }
+    }
+  });
+
+  test('der geöffnete Bereich zeigt alle Aufgaben — und kein Ziel endet mitten im Wort', async ({ page }) => {
+    // Vorher trug die mittlere Ebene EINE Aufgabe je Mitarbeiter, hart nach
+    // 52 Zeichen geschnitten: „…als ein Produkt betrachten und die". Ein Satz,
+    // der mitten im Wort endet, liest sich wie ein Fehler, nicht wie eine
+    // Kürzung — und ein Bereich mit einem Mitarbeiter war ein einzelner Punkt
+    // auf leerer Fläche, obwohl sein Aufgabenstrom im Katalog steht.
+    for (const bid of ['produkt', 'engineering', 'experience']) {
+      const gesehen = await page.evaluate((id) => {
+        nnOeffne(id);
+        return {
+          aufgaben: [...document.querySelectorAll('#nn .nn-aufgabe')].map((g) =>
+            [...g.querySelectorAll('text')].map((t) => t.textContent).join(' ').trim()),
+          dateien: document.querySelectorAll('#nn .nn-dateiknoten').length,
+        };
+      }, bid);
+
+      const ziele = KATALOG.modelle.filter((m) => m.bereich === bid)
+        .flatMap((m) => (m.aufgabenstrom || []).map((a) => a.ziel));
+      expect(gesehen.aufgaben.length, `${bid}: nicht jede Aufgabe hat einen Knoten`)
+        .toBe(Math.min(ziele.length, 4 * KATALOG.modelle.filter((m) => m.bereich === bid).length));
+
+      for (const beschriftung of gesehen.aufgaben) {
+        const sichtbar = beschriftung.replace(/\s*…\s*$/, '').trim();
+        const echtesZiel = ziele.find((t) => t.startsWith(sichtbar));
+        expect(echtesZiel, `${bid}: „${sichtbar}" ist kein Wort-Präfix eines echten Ziels`).toBeTruthy();
+        // Falls gekürzt wurde: an einer Wortgrenze, nie mitten im Wort.
+        if (sichtbar !== echtesZiel) {
+          expect(echtesZiel[sichtbar.length], `${bid}: „…${sichtbar.slice(-24)}" endet mitten im Wort`)
+            .toBe(' ');
+        }
+      }
+      if (ziele.length) {
+        expect(gesehen.dateien, `${bid}: keine Datei-Knoten trotz Aufgaben mit Dateien`)
+          .toBeGreaterThan(0);
       }
     }
   });

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -752,6 +752,77 @@ test.describe('Neuronaler Kern', () => {
     expect(zu.orb).toBe(true);
   });
 
+  test('der Lagebericht nennt Betriebsdaten und trennt „nicht geladen" von „null"', async ({ page }) => {
+    // Der Kreis antwortete auf „wie steht es?" mit HQ-SHA und Commander-Level.
+    // Das war keine Antwort, sondern eine Ausweichbewegung.
+    const bericht = await page.evaluate(() => window.ebCircleAPI.statusAntwort('wie steht es?'));
+    expect(bericht, 'auf eine Lage-Frage kommt kein Bericht').toBeTruthy();
+    // Er benennt die Quellen, die es gibt — nicht bloß eine Versionsnummer.
+    for (const feld of ['Deploy', 'Puls', 'Arbeitsjournal', 'Selbstcheck', 'Wissensbasis']) {
+      expect(bericht, `der Bericht sagt nichts über ${feld}`).toContain(feld);
+    }
+
+    // Die tragende Regel: eine NICHT geladene Quelle wird als „nicht geladen"
+    // gemeldet, nicht als Null. „0 Schichten gearbeitet" heißt „der Betrieb
+    // lief und tat nichts"; „nicht geladen" heißt „ich weiß es nicht". Wer
+    // beides zusammenfallen lässt, handelt nach einer Lage, die es nicht gibt.
+    const ohne = await page.evaluate(() => {
+      const journalVorher = nnJournal, auditVorher = state.audit, laeufeVorher = state.runs;
+      nnJournal = null; state.audit = null; state.runs = [];
+      const t = window.ebCircleAPI.statusAntwort('lagebericht');
+      nnJournal = journalVorher; state.audit = auditVorher; state.runs = laeufeVorher;
+      return t;
+    });
+    expect(ohne, 'ein fehlendes Journal wird nicht als solches gemeldet')
+      .toMatch(/Arbeitsjournal: nicht geladen/);
+    expect(ohne, 'ein fehlender Selbstcheck wird nicht als solcher gemeldet')
+      .toMatch(/Selbstcheck: nicht geladen/);
+    expect(ohne, 'fehlende Läufe werden nicht als solche gemeldet')
+      .toMatch(/Workflow-Läufe: nicht geladen/);
+    // Und genau NICHT als Zahl: keine Null-Aussage über etwas Unbekanntes.
+    expect(ohne, 'fehlende Daten erscheinen als Null-Aussage')
+      .not.toMatch(/0 Einträge|0 Befunde|Journal: 0|keine? (Schicht|Befund) /i);
+
+    // Umgekehrt: ein GELADENES, aber leeres Journal darf das sagen — leer ist
+    // eine Aussage über den Betrieb, fehlend ist keine.
+    const leer = await page.evaluate(() => {
+      const v = nnJournal;
+      nnJournal = { version: 1, eintraege: [] };
+      const t = window.ebCircleAPI.statusAntwort('lagebericht');
+      nnJournal = v;
+      return t;
+    });
+    expect(leer, 'ein leeres Journal wird mit einem fehlenden verwechselt')
+      .toMatch(/geladen, aber leer/);
+  });
+
+  test('eine Lage-Frage wird als Lagebericht beantwortet, nicht als Wissensabschnitt', async ({ page }) => {
+    // Nicht hqStatus() allein prüfen, sondern was der Kreis wirklich sagt:
+    // in ask() setzte ein Wissenstreffer die lokale Antwort bedingungslos neu,
+    // die Lage kam also nie beim Fragenden an. Ohne diesen Test wäre die
+    // Rückkehr zu `if (hit)` unbemerkt geblieben.
+    await page.evaluate(() => window.ebCircleAPI.oeffnen());
+    await page.fill('#ebc-input', 'wie steht es?');
+    await page.press('#ebc-input', 'Enter');
+    // Textmodus mit lokaler Antwort bleibt tokenfrei — kein Netz im Spiel.
+    await expect(page.locator('#ebc-log')).toContainText('Lagebericht', { timeout: 8000 });
+    await expect(page.locator('#ebc-log')).toContainText('Arbeitsjournal');
+  });
+
+  test('eine Produktfrage bekommt Wissen, keinen Lagebericht', async ({ page }) => {
+    // Das alte Muster fing „seite", „hq", „system", „live" — damit hätte
+    // jede Produktfrage einen Betriebsbericht ausgelöst.
+    for (const frage of ['Wie läuft eine Buchung ab?', 'Was kostet die Plattform?', 'Wie bezahle ich?']) {
+      const s = await page.evaluate((f) => window.ebCircleAPI.statusAntwort(f), frage);
+      expect(s, `„${frage}" löst einen Lagebericht aus`).toBeNull();
+    }
+    // Und die Lage-Fragen greifen weiterhin.
+    for (const frage of ['wie steht es?', 'Lagebericht', 'status', 'letzter Deploy?']) {
+      const s = await page.evaluate((f) => window.ebCircleAPI.statusAntwort(f), frage);
+      expect(s, `„${frage}" löst keinen Lagebericht aus`).toBeTruthy();
+    }
+  });
+
   test('der geöffnete Bereich nennt je Mitarbeiter Ziel und Datei — ungekürzt', async ({ page }) => {
     // Im SVG ist das Ziel auf 52 Zeichen und die Dateiliste auf 44 gekappt.
     // Ein halbes Ziel beantwortet „woran arbeitet der gerade" nicht, deshalb

--- a/ui-enhancements.css
+++ b/ui-enhancements.css
@@ -2,7 +2,41 @@
   ui-enhancements.css
   Loads AFTER styles.css. Use this file for all visual improvements, overrides, and new UI components.
   Always adhere to the Eventbörse Design System and use CSS variables where appropriate.
+
+  ── Warum hier Variablen stehen ──────────────────────────────────────────
+  Diese Datei benutzte 13 Variablen, die in KEINER CSS-Datei des Projekts
+  definiert waren. Ein var() ohne Definition macht die Deklaration „invalid
+  at computed-value time": die Eigenschaft faellt auf `unset` zurueck. Weil
+  diese Datei NACH styles.css laedt und bei gleicher Spezifitaet gewinnt,
+  hat sie damit live geloescht, was styles.css absichtlich setzt:
+
+    .listing-card / .review-card / .kanban-card
+      box-shadow: var(--eb-shadow-2)   -> unset -> gar kein Schatten,
+      obwohl styles.css den Karten mit --eb-depth-1 Tiefe gibt.
+
+    button/a/input:focus-visible
+      border-radius: var(--eb-radius-sm) -> unset -> 0,
+      also sprangen runde Elemente bei Tastatur-Fokus auf eckig.
+
+  Die Namen werden deshalb hier auf die echten Tokens aus styles.css
+  abgebildet, statt sie in styles.css zu erfinden — das Design-System hat
+  bereits Namen, diese Datei benutzte nur andere.
 */
+:root {
+  --brand-primary: var(--primary);
+  --brand-primary-rgb: 255, 56, 92;   /* = --primary #FF385C, fuer rgba() */
+  --surface: var(--bg);
+  --surface-2: var(--bg-alt);
+  --eb-shadow-2: var(--shadow-md);
+  --eb-transition-fast: .18s ease;
+  --eb-radius-sm: var(--radius-sm);
+  --eb-radius-md: var(--radius-md);
+  --eb-spacing-xs: .35rem;
+  --eb-spacing-sm: .6rem;
+  --eb-spacing-md: 1rem;
+  --eb-spacing-lg: 1.5rem;
+  --eb-spacing-xl: 2.25rem;
+}
 
 /* --- Global Enhancements --- */
 
@@ -46,16 +80,11 @@
   background: linear-gradient(to bottom, rgba(var(--brand-primary-rgb), 0.08), transparent); /* Slightly more prominent in dark mode */
 }
 
-/* Example: Better focus styles for accessibility */
-a:focus-visible,
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible {
-  outline: 2px solid var(--brand-primary);
-  outline-offset: 2px;
-  border-radius: var(--eb-radius-sm);
-}
+/* Fokus-Ringe stehen bewusst NICHT hier.
+   styles.css setzt sie als `outline: none` + `box-shadow: var(--eb-ring)` —
+   eine bewusste Entscheidung, kein Versehen. Ein zweiter Ring als Outline
+   waere ein konkurrierender Indikator; und der `border-radius` in diesem
+   Block war es, der fokussierte Elemente eckig machte. */
 
 /* ===== MODAL BACKDROP BLUR ===== */
 .modal-backdrop {

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 266 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 267 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 266 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 267 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 267 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 268 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 267 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 268 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 263 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 266 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 263 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 266 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 266 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 267 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 263 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 266 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 267 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 268 Tests in 13 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
Drei Stücke, alle aus dem, was im Live-HQ tatsächlich zu sehen war.

---

## 1 · Der geöffnete Bereich ist ein Netz, kein einzelner Punkt

Screenshot vom Live-HQ, „Produkt & Strategie": **ein** Mitarbeiter auf leerer Fläche, darunter ein Satz, der mitten im Wort endet:

```
Eventbörse und HQ als ein Produkt betrachten und die
```

Dieselbe Ursache für beides: die mittlere Ebene trug **eine** Aufgabe je Mitarbeiter, hart nach 52 Zeichen geschnitten. Der Aufgabenstrom steht vollständig im Katalog — ihn nicht zu zeigen war eine verschenkte Ebene.

Jetzt vier Ebenen von unten nach oben: **Bereich → Mitarbeiter → alle seine Aufgaben → deren Dateien.**

| Bereich | vorher | jetzt |
|---|---|---|
| Produkt & Strategie | 1 Knoten | 1 Mitarbeiter, 3 Aufgaben, 4 Dateien |
| Engineering | 2 Knoten | 2 Mitarbeiter, 6 Aufgaben, 7 Dateien |

Dateien stehen je **einmal**: zwei Aufgaben an derselben Datei sind zwei Bahnen zu einem Knoten — genau das macht aus dem Baum ein Netz. Text wird umgebrochen statt geschnitten; gekürzt wird an einer Wortgrenze und sichtbar.

### Layout-Fehler, die dabei nacheinander auftraten

Jeder einzeln gemessen und behoben:

- Beschriftungen lagen **auf** den Knoten → über den Hof gehoben
- Werkzeuge stießen unten in den Bereichsnamen → seitlich auf Augenhöhe
- Zwei Fächer berührten sich exakt → Fächerbreite auf 80 % des Mitarbeiterabstands
- Das äußerste Ziel lief aus dem Bild → **das ganze Fächer** wird verschoben. Einzelne Knoten zu klemmen schiebt den äußersten auf seinen Nachbarn und erzeugt genau die Überlappung, die es verhindern soll — das war mein erster, falscher Versuch
- Zeilenbreite folgt jetzt dem Platz, nicht einer festen Zahl
- Benachbarte Ziele stehen auf zwei Höhen, gestaffelt über **alle** Aufgaben — je Mitarbeiter gestaffelt trafen sich die letzte des einen und die erste des nächsten wieder

---

## 2 · Die Mitte gibt einen echten Lagebericht

Vorher auf „wie steht es?": `Aktueller HQ-Stand: 5875afc. Commander-Level: 3.` Und selbst das kam oft nicht durch, weil ein Wissenstreffer die Antwort bedingungslos überschrieb.

Jetzt: Deploy, Puls, Fehlschläge, Journal nach Ergebnis mit letzter echter Lieferung, Token, Kosten, Selbstcheck, offene PRs, Wissensbasis, Erreichbarkeit.

**Die tragende Regel:** eine nicht geladene Quelle wird als „nicht geladen" gemeldet, nie als Null. `0 Einträge` heißt *der Betrieb lief und tat nichts*; `nicht geladen` heißt *ich weiß es nicht*. Ein geladenes, aber leeres Journal darf „leer" sagen.

---

## 3 · Das HQ log über seinen eigenen Takt

`hq.html` behauptete an **drei** Stellen hartkodiert „Lagebild 4×/Tag" und „$0,15/Tag hart", obwohl der Cron seit `5875afc` auf 30 Minuten und $0,50 steht. Genau das stand im Screenshot.

Mein Katalog-Test hat es nicht gefangen — er prüft `eb-models.json`, und wer aufs HQ schaut, liest den **Text**. Der Takt-Test deckt jetzt auch `hq.html` ab.

Der Puls läuft inzwischen belegt: Läufe **14:47** und **15:19 UTC**, beide `schedule`, beide grün. Vorher lagen sechs Stunden dazwischen.

## 4 · Wächter gegen tote CSS-Variablen

`ui-enhancements.css` benutzte 13 Variablen, die in keiner CSS-Datei standen — dieselben Namen, mit denen der KI-Patch #123 eine Focus-Visualisierung versprach und nichts bewirkte.

**Korrektur:** ich hatte behauptet, die Datei lösche live Kartenschatten und mache Fokus eckig. Mit Grundlinie gemessen ändert sich **nichts** — die Datei war wirkungslos, nicht schädlich. Meine erste Messung hatte keine Grundlinie. Der Wächter hat dafür zwei echte tote Stellen in `styles.css` gefunden (`--light`, `--bg-card` → `background: transparent`).

---

## Tests

Zehn Mutationen geprüft, jede fällt — darunter: nach 52 Zeichen schneiden, nur die aktuelle Aufgabe zeigen, alte Taktangabe ins HQ zurück, falsches Budget ins HQ, fehlendes Journal als Null melden, Variablen-Definition entfernen.

**Zwei Wort-Zusicherungen ersetzt.** Der Strom-Test forderte wörtlich `'Lagebild 4×/Tag'` und der Autopilot-Test das Literal `'0.60'`. Beide haben veraltete Werte mitkonserviert. Geprüft wird jetzt die Eigenschaft — *dass* ein Takt und *dass* ein hartes Budget genannt wird; die Richtigkeit der Zahl prüft der Cron-Abgleich.

268 Tests in 13 Suiten, alle Gates grün.

## Noch offen

Die Befund→Arbeit-Schicht — heute erzeugen die Rollen Befunde, aber nichts verwandelt einen Befund in einen Pull Request. Das ist der Grund, warum sich auf eventbörse.de selbst wenig tut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd