### PR TITLE
Auch der Grund eines folgenlosen Laufs steht im Log

### DIFF
--- a/.github/workflows/openrouter-autopilot.yml
+++ b/.github/workflows/openrouter-autopilot.yml
@@ -200,14 +200,14 @@ jobs:
             # stiller Dauerausfall aus wie ein ruhiger Tag.
             grund="$(jq -r '.abbruch // empty' .ai-run/result.json)"
             if [ -n "$grund" ]; then
-              echo "### ⚠️ Lauf ohne Aenderung — technisch, nicht inhaltlich" >> "$GITHUB_STEP_SUMMARY"
-              echo "$grund" >> "$GITHUB_STEP_SUMMARY"
+              echo "### ⚠️ Lauf ohne Aenderung — technisch, nicht inhaltlich" | tee -a "$GITHUB_STEP_SUMMARY"
+              echo "$grund" | tee -a "$GITHUB_STEP_SUMMARY"
             elif [ "$(jq -r '.architekt.decision // empty' .ai-run/result.json)" = "skip" ]; then
-              echo "Architektin hat den Vorschlag bewusst verworfen: $(jq -r '.architekt.skip_reason // "ohne Begruendung"' .ai-run/result.json)" >> "$GITHUB_STEP_SUMMARY"
+              echo "Architektin hat den Vorschlag bewusst verworfen: $(jq -r '.architekt.skip_reason // "ohne Begruendung"' .ai-run/result.json)" | tee -a "$GITHUB_STEP_SUMMARY"
             elif [ "$(jq -r '(.scout.target_files // []) | length' .ai-run/result.json)" = "0" ]; then
-              echo "Scout hat keinen belastbaren, risikoarmen Hebel gefunden — Lauf sauber beendet." >> "$GITHUB_STEP_SUMMARY"
+              echo "Scout hat keinen belastbaren, risikoarmen Hebel gefunden — Lauf sauber beendet." | tee -a "$GITHUB_STEP_SUMMARY"
             else
-              echo "Die Agenten haben den Lauf sicher ohne Aenderung beendet." >> "$GITHUB_STEP_SUMMARY"
+              echo "Die Agenten haben den Lauf sicher ohne Aenderung beendet." | tee -a "$GITHUB_STEP_SUMMARY"
             fi
           fi
           # Die Budgets kommen aus der Umgebung, nicht aus einem festen Text:
@@ -215,7 +215,7 @@ jobs:
           # gestiegen war.
           jq -r --arg lauf "$EB_OPENROUTER_RUN_BUDGET_USD" --arg tag "$EB_OPENROUTER_DAILY_BUDGET_USD" \
             '"OpenRouter-Kosten dieses Laufs: $" + (.kosten|tostring) + " · Laufbudget $" + $lauf + " · Tagesbudget $" + $tag' \
-            .ai-run/result.json >> "$GITHUB_STEP_SUMMARY"
+            .ai-run/result.json | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Abhaengigkeiten installieren
         if: steps.cadence.outputs.run == 'true' && steps.result.outputs.changed == 'true'

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-13T10:28:47.277Z",
+  "erzeugt": "2026-08-13T10:40:13.025Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/tests/e2e/auftragsstrom.spec.js
+++ b/tests/e2e/auftragsstrom.spec.js
@@ -207,6 +207,17 @@ test.describe('Auftragsstrom: aus Befunden wird Arbeit', () => {
     expect(workflow, 'der Abbruchgrund wird nicht ausgelesen').toMatch(/\.abbruch \/\/ empty/);
     expect(workflow, 'ein technischer Abbruch ist nicht als solcher markiert')
       .toMatch(/technisch, nicht inhaltlich/);
+    // Der Grund muss auch im LOG stehen, nicht nur in der Step-Summary. Die
+    // Summary sieht nur, wer sie im Browser aufmacht; das Log steht in jeder
+    // API und jedem Werkzeug, das den Lauf spaeter untersucht. Genau daran
+    // bin ich am 13.08. gescheitert: der Lauf 31691382880 endete ohne
+    // Aenderung, und ich konnte den Grund nicht lesen.
+    for (const zeile of workflow.split('\n')) {
+      if (!/GITHUB_STEP_SUMMARY/.test(zeile)) continue;
+      if (!/(Aenderung|Abbruch|verworfen|Hebel|Kosten dieses Laufs)/.test(zeile)) continue;
+      expect(zeile, `nur in die Summary, nicht ins Log: ${zeile.trim().slice(0, 70)}`)
+        .toMatch(/tee -a/);
+    }
     expect(workflow, 'die skip-Entscheidung der Architektin wird verschwiegen')
       .toMatch(/architekt\.decision \/\/ empty/);
     expect(workflow, 'ein Scout ohne Fund wird nicht benannt')


### PR DESCRIPTION
## Der neue Takt wirkt — belegt

Erster **planmäßiger** Lauf unter der neuen Regel: `31691382880`, 10:30 auf `9cd2043`.

| Schritt | vorher (Zählwerk) | jetzt |
|---|---|---|
| Kostenfenster prüfen | ✅ | ✅ |
| Node, Schlüssel, Guardrails | `skipped` | ✅ |
| **Scout, Architektur, Umsetzung, Review** | `skipped` | ✅ **30 s, alle vier Rollen** |
| Ergebnis auswerten | `skipped` | ✅ |

Zum Vergleich: die Läufe um 08:57 und 09:31 haben alle Agentenschritte übersprungen. Der Takt hängt jetzt nicht mehr an einer Laufnummer.

## Aber ich konnte nicht lesen, warum kein Patch herauskam

Der Lauf endete ohne Änderung — und der Grund, den ich in #140 eingebaut hatte, ging **nur in die Step-Summary**. Die sieht nur, wer sie im Browser aufmacht; das Log steht in jeder API und in jedem Werkzeug, das den Lauf später untersucht.

Das ist **dieselbe Lücke, die ich eine Zeile weiter für den Auftragsstrom gerade geschlossen hatte** (#141). Ich hätte sie gleich mitnehmen müssen.

Alle vier Lagen und die Kostenzeile gehen jetzt zusätzlich nach stdout.

## Neuer Wachposten

Jede Zeile, die einen Grund oder die Kosten in die Step-Summary schreibt, muss `tee -a` benutzen.

| Mutation | Meldung |
|---|---|
| eine Zeile wieder nur in die Summary | `nur in die Summary, nicht ins Log: echo "Die Agenten haben den Lauf sicher…` |

278 Tests in 14 Suiten, alle Gates grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_