### PR TITLE
Ein Patch darf Schutzkonstrukte nicht wegnehmen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-278 Tests in 14 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+279 Tests in 14 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -202,6 +202,12 @@ OpenRouter „kein Key-Limit", nicht „kein Guthaben".
 Eine leere oder nicht parsebare Antwort wird nie angewendet: dieselbe Rolle
 wechselt kontrolliert zum nächsten freigegebenen Modell und bucht auch den
 fehlgeschlagenen Versuch gegen dasselbe Laufbudget.
+Ein Patch darf Schutzkonstrukte nicht **wegnehmen**: entfernte Maskierungen
+(`escHtml`), Fehlerbehandlungen, Speicher-Aufräumzeilen, `noopener` oder
+Identitätsprüfungen werden gezählt und müssen mindestens genauso oft
+zurückkommen. Verschieben ist erlaubt, wegnehmen nicht — die alte Prüfung sah
+nur hinzugefügte Zeilen, und `${escHtml(n)}` → `${n}` trifft dort kein
+verbotenes Muster.
 Das an Provider gesendete JSON-Schema nutzt nur den gemeinsamen Structured-
 Output-Kern; feinere Längen-, Mengen- und Risikogrenzen werden danach lokal
 deterministisch validiert und lösen bei Verstoß ebenfalls den Rollen-Fallback aus.

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-13T10:40:13.025Z",
+  "erzeugt": "2026-08-13T11:03:41.114Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/scripts/openrouter-agents.mjs
+++ b/scripts/openrouter-agents.mjs
@@ -930,6 +930,42 @@ function patchPruefen(patch, erlaubteDateien) {
   for (const muster of verboten) {
     if (muster.test(neu)) throw new Error(`Patch trifft verbotenes Muster ${muster}.`);
   }
+
+  // Was ENTFERNT wird, kann genauso gefaehrlich sein wie was hinzukommt.
+  //
+  // Die Pruefung oben sieht nur additions. Der gefaehrlichste Fall rutscht
+  // damit durch:
+  //
+  //     -  `<div>${escHtml(name)}</div>`
+  //     +  `<div>${name}</div>`
+  //
+  // Die hinzugefuegte Zeile trifft kein verbotenes Muster — sie enthaelt
+  // weder `.innerHTML =` noch `eval`. Die entfernte enthaelt die Maskierung.
+  // Ergebnis: eine XSS-Luecke, mechanisch nicht erkannt. Dasselbe gilt fuer
+  // eine geloeschte Fehlerbehandlung oder ein entferntes Aufraeumen von
+  // Standortdaten.
+  //
+  // Geprueft wird nicht "kommt das Muster in Loeschungen vor" — das wuerde
+  // jede Umformatierung blockieren, die eine Zeile verschiebt. Geprueft wird,
+  // ob es WENIGER wird: verschieben ist erlaubt, wegnehmen nicht.
+  const entfernt = deletions.map((z) => z.slice(1)).join('\n');
+  const schuetzend = [
+    [/\bescHtml\s*\(/g, 'eine HTML-Maskierung'],
+    [/\bencodeURIComponent\s*\(/g, 'eine URL-Maskierung'],
+    [/\.textContent\s*=/g, 'eine textContent-Zuweisung'],
+    [/\b(localStorage|sessionStorage|indexedDB)\b/g, 'einen Speicherzugriff'],
+    [/\bcatch\s*[({]/g, 'eine Fehlerbehandlung'],
+    [/\bnonce\b/gi, 'eine Nonce-Pruefung'],
+    [/\bcurrentUser\b/g, 'eine Identitaetspruefung'],
+    [/\brel\s*=\s*["'][^"']*noopener/gi, 'einen noopener-Schutz'],
+  ];
+  for (const [muster, was] of schuetzend) {
+    const weg = (entfernt.match(muster) || []).length;
+    const zurueck = (neu.match(muster) || []).length;
+    if (weg > zurueck) {
+      throw new Error(`Patch entfernt ${was} (${weg}x weg, nur ${zurueck}x zurueck).`);
+    }
+  }
 }
 
 function nachApplyPruefen(changedFiles, modellDateien) {
@@ -1055,6 +1091,36 @@ function selfTest() {
     validiereAgentenJson('implementer', { ...implRumpf, patch: 'Hier ist mein Vorschlag: ...' }, implKontext);
   } catch { diffAbgewiesen = true; }
   if (!diffAbgewiesen) throw new Error('Ein kaputter Diff loest keinen Modellwechsel aus.');
+
+  // Entfernte Schutzkonstrukte: der Fall, den die additions-Pruefung nicht
+  // sehen kann. Eine weggenommene Maskierung ist eine XSS-Luecke, und die
+  // hinzugefuegte Zeile sieht dabei voellig harmlos aus.
+  const diffMit = (minus, plus) => [
+    'diff --git a/js/modules/ui/43-showcase.js b/js/modules/ui/43-showcase.js',
+    '--- a/js/modules/ui/43-showcase.js',
+    '+++ b/js/modules/ui/43-showcase.js',
+    '@@ -1,1 +1,1 @@',
+    `-${minus}`,
+    `+${plus}`,
+  ].join('\n');
+
+  const mussFallen = [
+    ['Maskierung', 'el.insertAdjacentHTML("beforeend", `<b>${escHtml(name)}</b>`);', 'el.insertAdjacentHTML("beforeend", `<b>${name}</b>`);'],
+    ['Fehlerbehandlung', '} catch (e) { melde(e); }', '}'],
+    ['Aufraeumen', 'localStorage.removeItem(RADAR_SPEICHER);', '// aufgeraeumt wird spaeter'],
+    ['noopener', 'a.rel = "noopener noreferrer";', 'a.rel = "";'],
+  ];
+  for (const [was, minus, plus] of mussFallen) {
+    let gefallen = false;
+    try { patchPruefen(diffMit(minus, plus), ['js/modules/ui/43-showcase.js']); }
+    catch { gefallen = true; }
+    if (!gefallen) throw new Error(`Entfernte ${was} wird nicht erkannt.`);
+  }
+
+  // Verschieben ist erlaubt: dieselbe Maskierung geht weg UND kommt zurueck.
+  patchPruefen(
+    diffMit('const s = escHtml(name);', 'const sicher = escHtml(name);'),
+    ['js/modules/ui/43-showcase.js']);
 
   pruefeDateiliste(['js/modules/ui/43-showcase.js']);
   const gut = [

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -284,6 +284,44 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(runner).toMatch(/if \(!scout\.target_files\.length\)/);
   });
 
+  test('ein Patch darf Schutzkonstrukte nicht wegnehmen', async () => {
+    // Die Musterprüfung sah nur hinzugefügte Zeilen. Der gefährlichste Fall
+    // rutschte damit durch:
+    //
+    //     -  `<b>${escHtml(name)}</b>`
+    //     +  `<b>${name}</b>`
+    //
+    // Die neue Zeile trifft kein verbotenes Muster — weder `.innerHTML =`
+    // noch `eval`. Die entfernte enthält die Maskierung. Ergebnis: eine
+    // XSS-Lücke, mechanisch nicht erkannt.
+    const { patchPruefen } = await import(
+      require('node:url').pathToFileURL(path.join(ROOT, 'scripts', 'openrouter-agents.mjs')).href);
+    const ziel = 'js/modules/ui/43-showcase.js';
+    const diff = (minus, plus) => [
+      `diff --git a/${ziel} b/${ziel}`, `--- a/${ziel}`, `+++ b/${ziel}`,
+      '@@ -1,1 +1,1 @@', `-${minus}`, `+${plus}`,
+    ].join('\n');
+
+    const gefaehrlich = [
+      ['HTML-Maskierung', 'h += `<b>${escHtml(n)}</b>`;', 'h += `<b>${n}</b>`;'],
+      ['Fehlerbehandlung', '} catch (e) { melde(e); }', '}'],
+      ['Aufräumen von Standortdaten', 'localStorage.removeItem(RADAR_SPEICHER);', '// spaeter'],
+      ['noopener-Schutz', 'a.rel = "noopener noreferrer";', 'a.rel = "";'],
+      ['Identitätsprüfung', 'if (!currentUser) return;', '// jeder darf'],
+    ];
+    for (const [was, minus, plus] of gefaehrlich) {
+      expect(() => patchPruefen(diff(minus, plus), [ziel]),
+        `entferntes Schutzkonstrukt bleibt unbemerkt: ${was}`).toThrow();
+    }
+
+    // Verschieben bleibt erlaubt — sonst wäre jede Umformatierung blockiert,
+    // die eine solche Zeile berührt, und der Autopilot in diesen Dateien
+    // praktisch handlungsunfähig.
+    expect(() => patchPruefen(
+      diff('const s = escHtml(n);', 'const sicher = escHtml(n);'), [ziel]))
+      .not.toThrow();
+  });
+
   test('autonomer Scope schließt sensible Dateien und Seiteneffekte aus', () => {
     const whitelist = runner.slice(runner.indexOf('const SICHERE_DATEIEN'), runner.indexOf('const AGENTEN'));
     expect(whitelist).not.toMatch(/functions\.php|payments\/|core\/30-auth|chat\/20-/);

--- a/vault/30-Betrieb/Testing.md
+++ b/vault/30-Betrieb/Testing.md
@@ -7,7 +7,7 @@ share: internal
 
 # Testing
 
-> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 278 Tests
+> Seit 2026-08-01 gibt es eine **automatisierte E2E-Suite** (Playwright, 279 Tests
 > in 13 Suiten) als blockierendes Gate in `pr-check.yml`. Vorher: 0 Tests — die
 > letzten Produktionsfehler (Verlaufsschrift nach Minify, Suche ohne Treffer,
 > doppelte CSS-Regeln) waren alle Regressionen, die diese Suite gefangen hätte.
@@ -20,7 +20,7 @@ share: internal
        │ Manual E2E  │   ← Backend-Flows bei Release (Login, Stripe live)
        └──────┬──────┘
        ┌──────┴───────┐
-       │  Playwright  │   ← 278 Tests, blockierend in pr-check.yml (NEU 2026-08)
+       │  Playwright  │   ← 279 Tests, blockierend in pr-check.yml (NEU 2026-08)
        └──────┬───────┘
        ┌──────┴───────────────┐
        │ Auto-Audit (KI)      │   ← claude-auto-audit.yml

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 278 Tests in 14 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 279 Tests in 14 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes


### PR DESCRIPTION
Schritt 1 vor jeder Rahmen-Erweiterung: **erst der Wächter, dann neue Dateien.**

## Die Lücke

`patchPruefen()` prüfte nur **hinzugefügte** Zeilen:

```js
const neu = additions.map((z) => z.slice(1)).join('\n');
for (const muster of verboten) if (muster.test(neu)) throw ...
```

Der gefährlichste Fall rutscht damit unbemerkt durch:

```diff
-  h += `<b>${escHtml(name)}</b>`;
+  h += `<b>${name}</b>`;
```

Die **hinzugefügte** Zeile trifft kein verbotenes Muster — weder `.innerHTML =` noch `eval`. Die **entfernte** enthält die Maskierung. Ergebnis: eine XSS-Lücke, mechanisch nicht erkannt.

Dasselbe Muster gilt für eine gelöschte Fehlerbehandlung, ein entferntes Aufräumen von Standortdaten, ein weggenommenes `rel="noopener"` oder eine gestrichene Identitätsprüfung.

## Die Regel: Bilanz, nicht Vorkommen

Acht schützende Konstrukte werden in Löschungen **und** Hinzufügungen gezählt; der Patch fällt, wenn eines **weniger** wird:

| Konstrukt | wovor es schützt |
|---|---|
| `escHtml(` | XSS |
| `encodeURIComponent(` | URL-Injection |
| `.textContent =` | die sichere Alternative zu `innerHTML` |
| `localStorage` / `sessionStorage` / `indexedDB` | Aufräumzeilen für Nutzerdaten |
| `catch (` / `catch {` | stille Fehler |
| `nonce` | fehlende Rechteprüfung |
| `currentUser` | fehlende Identitätsprüfung |
| `rel="…noopener…"` | Tabnabbing |

**Verschieben und Umbenennen bleiben erlaubt.** Eine Regel, die jede Umformatierung blockiert, macht den Autopiloten in genau den Dateien handlungsunfähig, in denen er vorsichtig sein soll.

## Wirkt sofort auf den bestehenden Rahmen

Nicht erst auf künftige Dateien. `31-modals-toast-qabot.js` enthält 16 Auth- und 15 Geld-Erwähnungen, `02-router-navigation.js` zwei `localStorage`-Zugriffe — dort war das Löschen bisher frei.

## Tests

Fünf Fälle im Guardrail-Selbsttest **und** in der Playwright-Suite, gegen zwei Mutationen geprüft:

| Mutation | Meldung |
|---|---|
| Bilanzprüfung entschärfen | `entferntes Schutzkonstrukt bleibt unbemerkt: HTML-Maskierung` |
| auf bloßes Vorkommen verschärfen | `Patch entfernt eine HTML-Maskierung (1x weg, nur 1x zurueck)` — am erlaubten Verschieben |

Die zweite Mutation ist die wichtigere: sie zeigt, dass die Regel nicht nur streng, sondern **richtig** streng ist.

279 Tests in 14 Suiten, alle Gates grün.

## Danach

Schritt 2 aus dem Vorschlag — `core/01-demo-daten.js` und `search/13-event-radar.js` in den Rahmen — steht bereit, sobald du das willst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_