### PR TITLE
Hotfix: Interne HQ-Wissenspfade vollständig redigieren

### DIFF
--- a/hq.html
+++ b/hq.html
@@ -1101,7 +1101,22 @@ function humanDate(iso) {
   if (diff < 604800) return `vor ${Math.floor(diff/86400)} Tagen`;
   return d.toLocaleDateString('de-DE', { day: '2-digit', month: 'short', year: 'numeric' });
 }
-function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+/**
+ * Interne Wissenspfade gehören nicht in die Bedienoberfläche.
+ *
+ * Betriebsdaten und Agentenergebnisse kommen aus mehreren Quellen. Ein
+ * einzelner Bericht kann deshalb trotz gefilterter Dateilisten noch einen
+ * privaten Ordner- oder Markdown-Pfad im Fließtext tragen. Vor jeder
+ * Darstellung werden solche Hinweise auf eine neutrale Bezeichnung reduziert.
+ */
+function ebSichtbarerText(s) {
+  return String(s == null ? '' : s)
+    .replace(/(?:[A-Za-z0-9._-]+\/)*vault(?:\/[^\s,;:)"'<>]+)+/gi, 'interne Wissensquelle')
+    .replace(/\b(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.md\b/gi, 'interne Notiz')
+    .replace(/\bVault\b/gi, 'interner Wissensbereich');
+}
+
+function escHtml(s) { return ebSichtbarerText(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
 /* ─── Data loaders ─────────────────────────────────────────────── */
 function parseLastPage(link) {

--- a/tests/e2e/vision-release.spec.js
+++ b/tests/e2e/vision-release.spec.js
@@ -58,4 +58,14 @@ test.describe('Vision Release', () => {
     await expect(page.locator('#modelle-grid')).toBeHidden();
     await expect(page.locator('#conn-obsidian')).toHaveCount(0);
   });
+
+  test('HQ redigiert interne Wissens- und Markdown-Pfade aus Agententexten', async ({ page }) => {
+    await page.goto('/hq.html');
+    const redigiert = await page.evaluate(() => ebSichtbarerText(
+      'Quelle vault/10-Produkt/Wissen/Strategie.md und docs/Geheimer-Plan.md'
+    ));
+    expect(redigiert).not.toMatch(/vault|\.md/i);
+    expect(redigiert).toContain('interne Wissensquelle');
+    expect(redigiert).toContain('interne Notiz');
+  });
 });


### PR DESCRIPTION
## Befund

Der finale angemeldete Produktionscheck zeigte, dass dynamische Agenten-/Betriebstexte trotz ausgeblendeter Obsidian-Karte noch einen privaten `vault/`- oder Markdown-Pfad enthalten konnten.

## Fix

- zentraler Darstellungsfilter für dynamische HQ-Texte
- interne Wissensordner werden neutral als „interne Wissensquelle“ bezeichnet
- Markdown-Dateipfade werden als „interne Notiz“ redigiert
- bestehendes HTML-Escaping bleibt danach vollständig aktiv
- E2E-Regressionstest mit Ordner- und Markdown-Pfad

## Prüfung

- alle HQ-Inline-Skripte syntaktisch gültig
- Redaktionsprobe enthält weder Ordnerbegriff noch `.md`
- PHP-Syntax und App-Drift grün

Dieser Hotfix verändert keine gespeicherten Betriebsdaten; er begrenzt ausschließlich ihre Darstellung im HQ.