### PR TITLE
Board-Prozess sperren und Zahlung nach Erfüllung verschieben

### DIFF
--- a/app-shell.html
+++ b/app-shell.html
@@ -2624,7 +2624,7 @@
         <h2>1. Plattform-, Kunden- und Dienstleisterverhältnis</h2>
         <p>Die Plattform ist ausschließlich Vermittler im Sinne der §§ 652 ff. BGB analog. Der Vertrag über die Eventleistung wird ausschließlich zwischen Kunde und Dienstleister abgeschlossen. Die Plattform ist nicht Erfüllungsgehilfe und nicht Vertreter (§§ 164 ff. BGB).</p>
         <h2>2. Zustandekommen des Eventvertrages</h2>
-        <p>Verbindliches Angebot des Dienstleisters → Annahme durch den Kunden („Buchung verbindlich annehmen") → Auslösung der Stripe-Zahlung → mit erfolgreicher Zahlungsbestätigung ist der Eventvertrag verbindlich abgeschlossen. Beide Parteien erhalten Buchungsbestätigung mit Buchungsnummer, Daten der Gegenseite, Leistungsbeschreibung und Stripe-Transaktions-ID.</p>
+        <p>Verbindliches Angebot des Dienstleisters → Annahme durch den Kunden („Buchung verbindlich annehmen“) → der Eventvertrag ist verbindlich abgeschlossen → nach beidseitiger Bestätigung der erbrachten Leistung wird die Stripe-Zahlung ausgelöst. Beide Parteien erhalten Buchungs- und Zahlungsbestätigungen mit Buchungsnummer, Daten der Gegenseite, Leistungsbeschreibung und Stripe-Transaktions-ID.</p>
         <h2>3. Inhalt der Vermittlungsleistung</h2>
         <ul><li>Bereitstellung Plattformfunktionen (Profile, Suche, Messaging, Angebots-/Annahmeworkflow, Bewertungssystem).</li><li>Technische Vermittlung der Zahlung über Stripe Connect Express.</li><li>Bereitstellung von DSA- und P2B-Beschwerde- und Notice-Mechaniken.</li></ul>
         <h2>4. Was die Plattform nicht leistet</h2>
@@ -3068,7 +3068,7 @@ Datum: ___________________________________________________
             <div class="kanban-column" data-stage="bestaetigt">
               <div class="kanban-col-header">
                 <span class="kanban-col-dot dot-bestaetigt"></span>
-                <h4>Bezahlt</h4>
+                <h4>Erfüllt</h4>
                 <span class="kanban-col-count" id="cntBestaetigt">0</span>
               </div>
               <div class="kanban-cards" id="cardsBestaetigt" ondragover="allowDrop(event)" ondrop="dropCard(event,'bestaetigt')"></div>
@@ -3079,7 +3079,7 @@ Datum: ___________________________________________________
             <div class="kanban-column" data-stage="abgeschlossen">
               <div class="kanban-col-header">
                 <span class="kanban-col-dot dot-abgeschlossen"></span>
-                <h4>Erfüllt</h4>
+                <h4>Bezahlt</h4>
                 <span class="kanban-col-count" id="cntAbgeschlossen">0</span>
               </div>
               <div class="kanban-cards" id="cardsAbgeschlossen" ondragover="allowDrop(event)" ondrop="dropCard(event,'abgeschlossen')"></div>

--- a/app.js
+++ b/app.js
@@ -1501,9 +1501,9 @@ function navigateTo(page, data, skipHistory) {
 var EB_BOARD_STAGE_INFO = {
   geplant:       { label: 'Im Plan',      icon: 'assignment',      cls: 'geplant' },
   kontaktiert:   { label: 'Kontaktiert',  icon: 'forum',           cls: 'kontaktiert' },
-  angebot:       { label: 'Angebot',      icon: 'request_quote',   cls: 'angebot' },
-  bestaetigt:    { label: 'Gebucht',      icon: 'event_available', cls: 'gebucht' },
-  abgeschlossen: { label: 'Abgeschlossen',icon: 'task_alt',        cls: 'abgeschlossen' }
+  angebot:       { label: 'Gebucht',      icon: 'event_available', cls: 'angebot' },
+  bestaetigt:    { label: 'Erfüllt',      icon: 'verified',        cls: 'erfuellt' },
+  abgeschlossen: { label: 'Bezahlt',      icon: 'paid',            cls: 'bezahlt' }
 };
 var EB_BOARD_STAGE_ORDER = ['geplant', 'kontaktiert', 'angebot', 'bestaetigt', 'abgeschlossen'];
 
@@ -15095,6 +15095,77 @@ function _isTombstoned(id) {
   return 0;
 }
 
+var EB_BOARD_STAGE_MODEL_VERSION = 2;
+
+function _cardHasConfirmedPayment(card) {
+  if (!card) return false;
+  return !!(
+    card.paymentIntentId ||
+    card.paymentReference ||
+    (card.paymentStatus && /paid|bezahlt/i.test(String(card.paymentStatus)))
+  );
+}
+
+// Stage-Modell v2:
+// geplant → kontaktiert → gebucht → erfüllt → bezahlt.
+// Frühere Karten verwendeten bestaetigt=Bezahlt und abgeschlossen=Erfüllt.
+// Außerdem schrieb die alte Provider-Annahme ohne echte Stripe-Referenz
+// fälschlich einen Bezahlt-Marker. Beides wird einmalig und verlustarm
+// normalisiert. Manuelle Flow-Koordinaten entfallen, weil die Prozessstruktur
+// ab v2 fest ist.
+function _migrateBoardStageModel(projects) {
+  var changed = false;
+  (projects || []).forEach(function(project) {
+    if (!project) return;
+    if (project.flowLayout) {
+      delete project.flowLayout;
+      changed = true;
+    }
+    if (project.flowLayouts && Object.keys(project.flowLayouts).length) {
+      project.flowLayouts = {};
+      changed = true;
+    }
+    (project.cards || []).forEach(function(card) {
+      if (!card || card._stageModel === EB_BOARD_STAGE_MODEL_VERSION) return;
+
+      // Alte Provider-Annahme war keine Zahlung: ohne Stripe-Referenz und mit
+      // identischem Annahme-/Zahlzeitpunkt den künstlichen Marker entfernen.
+      var acceptanceOnlyPayment = !!(
+        !card.paymentIntentId &&
+        !card.paymentReference &&
+        card.providerAcceptedAt &&
+        card.paidAt &&
+        String(card.providerAcceptedAt) === String(card.paidAt)
+      );
+      if (acceptanceOnlyPayment) {
+        card.paidAt = '';
+        card.paidAmount = 0;
+        card.paymentStatus = '';
+        card.paymentMethod = '';
+      }
+
+      var paid = _cardHasConfirmedPayment(card);
+      var fulfilled = !!(
+        card.fulfilledAt ||
+        (card.userConfirmedAt && card.providerConfirmedAt && card.stage === 'abgeschlossen')
+      );
+      if (fulfilled) {
+        card.fulfilledAt = card.fulfilledAt || card.providerConfirmedAt || card.userConfirmedAt;
+        card.stage = paid ? 'abgeschlossen' : 'bestaetigt';
+      } else if (paid) {
+        // Bereits vorab bezahlt, aber noch nicht erbracht: bleibt gebucht,
+        // bis beide Seiten die Erbringung bestätigen.
+        card.stage = 'angebot';
+      } else if (card.stage === 'bestaetigt' || card.stage === 'abgeschlossen') {
+        card.stage = 'angebot';
+      }
+      card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
+      changed = true;
+    });
+  });
+  return changed;
+}
+
 function _migrateBoardProjects() {
   if (!currentUser) return;
   var newKey = 'eb_board_projects_' + currentUser.id;
@@ -15114,6 +15185,9 @@ function _loadBoardProjects() {
   _loadBoardTombstones();
   // 1) Schneller Cache: lokal geladene Projekte sofort anzeigen
   _boardProjects = key ? JSON.parse(localStorage.getItem(key) || '[]') : [];
+  if (_migrateBoardStageModel(_boardProjects) && key) {
+    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch (e) {}
+  }
   // Lokal bereits getombstoned? Raus damit.
   if (_boardTombstones.length) {
     _boardProjects = _boardProjects.filter(function(p){ return !p || !p.id || !_isTombstoned(p.id); });
@@ -15130,6 +15204,9 @@ function _loadBoardProjects() {
 // Lokale Projekte, die auf dem Server fehlen, werden hochgeladen (Migration / Offline-Sync).
 function _mergeBoardProjects(serverArr, localArr) {
   var byId = {};
+  var serverMigrated = _migrateBoardStageModel(serverArr);
+  var localMigrated = _migrateBoardStageModel(localArr);
+  var uploadNeeded = serverMigrated || localMigrated;
   function ts(p) {
     if (!p) return 0;
     var v = p.updatedAt || p.createdAt || 0;
@@ -15139,7 +15216,6 @@ function _mergeBoardProjects(serverArr, localArr) {
   (serverArr || []).forEach(function(p) {
     if (p && p.id) byId[p.id] = { project: p, source: 'server' };
   });
-  var uploadNeeded = false;
   (localArr || []).forEach(function(p) {
     if (!p || !p.id) return;
     var existing = byId[p.id];
@@ -15200,9 +15276,9 @@ function _snapshotBoardCardStates(projects) {
 /**
  * Vergleicht alten Snapshot mit neuem Board-Stand und sendet Toasts
  * für relevante Server-getriebene Übergänge:
- *  – Anbieter hat Auftrag angenommen (angebot/kontaktiert → bestaetigt)
+ *  – Anbieter hat Auftrag angenommen (providerAcceptedAt)
  *  – Anbieter hat Erbringung bestätigt (providerConfirmedAt neu)
- *  – Projekt erfüllt (→ abgeschlossen)
+ *  – Projekt erfüllt (fulfilledAt neu)
  */
 function _notifyBoardTransitions(prevSnap, newProjects) {
   if (!prevSnap || !newProjects) return;
@@ -15220,10 +15296,6 @@ function _notifyBoardTransitions(prevSnap, newProjects) {
 
       // 1) Anbieter hat Auftrag angenommen
       if (!prev.providerAcceptedAt && c.providerAcceptedAt) {
-        showToast(who + ' hat deine Anfrage für ' + what + when + ' angenommen!', 'verified');
-      } else if (prev.stage !== 'bestaetigt' && prev.stage !== 'abgeschlossen' &&
-                 (c.stage === 'bestaetigt' || c.stage === 'abgeschlossen')) {
-        // Fallback, falls providerAcceptedAt nicht gesetzt wird
         showToast(who + ' hat deine Anfrage für ' + what + when + ' angenommen!', 'verified');
       }
 
@@ -15686,7 +15758,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     '<div style="font-size:14px;line-height:1.7;margin-top:10px;color:var(--text-light)">' +
       '1. Ein Kunde bucht dich verbindlich &rarr; der Auftrag erscheint hier mit Status <em>&bdquo;Gebucht&ldquo;</em>.<br>' +
       '2. Du pr&uuml;fst die Details und klickst auf <strong>&bdquo;Auftrag annehmen&ldquo;</strong> &ndash; damit ist der Deal fix. Vom Buchungsbetrag gehen 3% Eventb&ouml;rse-Provision und die Stripe-Zahlungsgeb&uuml;hr ab &ndash; den Rest bekommst du ausgezahlt.<br>' +
-      '3. Am Event-Tag best&auml;tigt <strong>der Kunde</strong> die Erbringung, <strong>du</strong> best&auml;tigst hier die Abnahme. Erst dann ist der Auftrag <em>erf&uuml;llt</em>.' +
+      '3. Am Event-Tag best&auml;tigt <strong>der Kunde</strong> die Erbringung, <strong>du</strong> best&auml;tigst hier die Abnahme. Erst dann ist der Auftrag <em>erf&uuml;llt</em>.<br>' +
+      '4. Anschlie&szlig;end bezahlt der Kunde sicher &uuml;ber Stripe &ndash; danach steht der Auftrag auf <em>&bdquo;Bezahlt&ldquo;</em>.' +
     '</div>' +
   '</details>';
 
@@ -15711,8 +15784,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
   }
 
   var esc = _escHtml;
-  var stageLabels = { angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erf\u00fcllt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
-  var stageColors = { angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
+  var stageLabels = { angebot:'Gebucht', bestaetigt:'Erf\u00fcllt', abgeschlossen:'Bezahlt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
+  var stageColors = { angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
 
   html += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:16px">';
   jobs.forEach(function(j){
@@ -15721,8 +15794,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     var color = stageColors[stage] || '#9E9E9E';
     var priceStr = c.price ? (parseFloat(c.price).toFixed(2).replace(/\.00$/, '') + ' €') : '—';
     var dateStr = p.date ? _formatDateDe(p.date) : '—';
-    var canConfirm = stage === 'bestaetigt' && !c.providerConfirmedAt;
-    var alreadyConfirmed = !!c.providerConfirmedAt;
+    var canConfirm = stage === 'angebot' && !!c.providerAcceptedAt && !c.providerConfirmedAt;
+    var alreadyConfirmed = !!c.providerConfirmedAt && stage === 'angebot';
     var canAccept = stage === 'angebot' && !c.providerAcceptedAt;
     var priceNum = parseFloat(c.price) || 0;
     var isRemote = !!j.remote;
@@ -15744,7 +15817,10 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     } else if (alreadyConfirmed) {
       actionHtml = '<div style="padding:10px;background:rgba(102,187,106,0.1);border-radius:8px;color:#388e3c;font-size:13px;text-align:center"><span class="material-icons-round" style="vertical-align:middle;font-size:16px">check_circle</span> Deinerseits best&auml;tigt</div>';
     } else {
-      actionHtml = '<div style="padding:10px;background:var(--bg-alt);border-radius:8px;color:var(--text-light);font-size:13px;text-align:center">' + (stage === 'abgeschlossen' ? 'Auftrag erf&uuml;llt' : 'Warten auf n&auml;chsten Schritt') + '</div>';
+      var waitingText = stage === 'abgeschlossen'
+        ? 'Auftrag bezahlt'
+        : (stage === 'bestaetigt' ? 'Leistung erf&uuml;llt &ndash; Zahlung ausstehend' : 'Warten auf n&auml;chsten Schritt');
+      actionHtml = '<div style="padding:10px;background:var(--bg-alt);border-radius:8px;color:var(--text-light);font-size:13px;text-align:center">' + waitingText + '</div>';
     }
 
     html += '<div style="background:var(--bg);border:1px solid var(--border);border-radius:14px;overflow:hidden;box-shadow:var(--shadow-sm)">' +
@@ -15776,13 +15852,14 @@ function confirmAuftragProvider(projectId, cardId) {
   var card = (proj.cards || []).find(function(c){ return c.id === cardId; });
   if (!card) return;
   card.providerConfirmedAt = new Date().toISOString();
-  if (card.userConfirmedAt && card.stage === 'bestaetigt') {
-    card.stage = 'abgeschlossen';
+  if (card.userConfirmedAt && card.stage === 'angebot') {
     card.fulfilledAt = new Date().toISOString();
+    card.stage = _cardHasConfirmedPayment(card) ? 'abgeschlossen' : 'bestaetigt';
     showToast('Auftrag beidseitig best\u00e4tigt – erf\u00fcllt!', 'verified');
   } else {
     showToast('Best\u00e4tigung gespeichert. Wartet auf Kunden-Best\u00e4tigung.', 'hourglass_top');
   }
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   _saveBoardProjects();
   renderAuftraegePage();
   _refreshBoardPageIfActive();
@@ -15842,9 +15919,8 @@ function _refreshBoardPageIfActive() {
 }
 
 /**
- * Provider nimmt einen gebuchten Auftrag an → Zahlung wird freigegeben.
- * Setzt die Karte auf „Bezahlt" (bestaetigt) und erfasst die
- * Plattformprovision plus voraussichtliche Auszahlung.
+ * Provider nimmt einen gebuchten Auftrag an. Die Karte bleibt „Gebucht",
+ * bis beide Seiten die Erbringung bestätigen. Zahlung folgt danach.
  * Der Kunde sieht die Statusänderung beim nächsten Sync automatisch.
  */
 function acceptAuftragProvider(projectId, cardId) {
@@ -15867,11 +15943,8 @@ function acceptAuftragProvider(projectId, cardId) {
 
   var nowIso = new Date().toISOString();
   card.providerAcceptedAt = nowIso;
-  card.stage = 'bestaetigt';
-  card.paidAt = nowIso;
-  card.paymentStatus = 'Bezahlt';
-  if (!card.paymentMethod) card.paymentMethod = 'Stripe';
-  card.paidAmount = priceNum;
+  card.stage = 'angebot';
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   card.grossAmount = payout.grossAmount;
   card.stripeFeeAmount = payout.stripeFeeAmount;
   card.stripeFeePaidBy = payout.stripeFeePaidBy;
@@ -16168,8 +16241,8 @@ function _renderAuftragsboardSectionHtml(state) {
   });
 
   var pendingCount = jobs.filter(function(j){ return (j.card.stage === 'angebot') && !j.card.providerAcceptedAt; }).length;
-  var openCount    = jobs.filter(function(j){ return j.card.stage === 'bestaetigt' && !j.card.providerConfirmedAt; }).length;
-  var doneCount    = jobs.filter(function(j){ return j.card.stage === 'abgeschlossen'; }).length;
+  var openCount    = jobs.filter(function(j){ return j.card.stage === 'angebot' && !!j.card.providerAcceptedAt && !j.card.providerConfirmedAt; }).length;
+  var doneCount    = jobs.filter(function(j){ return j.card.stage === 'bestaetigt' || j.card.stage === 'abgeschlossen'; }).length;
 
   var headerHtml =
     '<div class="board-section-header">' +
@@ -16200,8 +16273,8 @@ function _renderAuftragsboardSectionHtml(state) {
       headerHtml +
       '<div class="board-section-empty">' +
         '<span class="material-icons-round">inbox</span>' +
-        '<p><strong>Noch keine bezahlten Auftr&auml;ge.</strong></p>' +
-        '<p style="font-size:13px;margin-top:-4px">Sobald ein Kunde eines deiner Angebote verbindlich bucht und bezahlt, erscheint sein Event-Board hier &ndash; mit allen Infos, die du f&uuml;r die Erbringung brauchst.</p>' +
+        '<p><strong>Noch keine gebuchten Auftr&auml;ge.</strong></p>' +
+        '<p style="font-size:13px;margin-top:-4px">Sobald ein Kunde eines deiner Angebote verbindlich bucht, erscheint sein Event-Board hier &ndash; mit allen Infos, die du f&uuml;r die Erbringung brauchst.</p>' +
         '<div class="board-section-empty-hints">' +
           '<div class="board-section-hint"><span class="material-icons-round">sync</span>Gerade gebucht worden? Tippe auf <strong>&bdquo;Aktualisieren&ldquo;</strong> &ndash; der Kunde synchronisiert sein Board ggf. erst nach wenigen Sekunden.</div>' +
           '<div class="board-section-hint"><span class="material-icons-round">storefront</span>Keine Auftr&auml;ge erhalten? Pr&uuml;fe, ob deine Angebote sichtbar sind und dein <strong>Stripe-Auszahlungskonto</strong> aktiv ist.</div>' +
@@ -16259,16 +16332,16 @@ function _renderAuftragsboardCardHtml(j) {
   var esc = _escHtml;
   var c = j.card, p = j.project, l = j.listing;
   var stage = c.stage || 'geplant';
-  var stageLabels = { angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erf\u00fcllt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
-  var stageColors = { angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
+  var stageLabels = { angebot:'Gebucht', bestaetigt:'Erf\u00fcllt', abgeschlossen:'Bezahlt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
+  var stageColors = { angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
   var color = stageColors[stage] || '#9E9E9E';
   var priceNum = parseFloat(c.price) || 0;
   var priceStr = priceNum ? priceNum.toFixed(2).replace(/\.00$/, '') + ' \u20ac' : '\u2014';
   var serviceTitle = (l && l.title) || c.listingTitle || c.name || 'Auftrag';
   var category = (l && (l.categoryLabel || l.category)) || c.category || '';
   var canAccept = stage === 'angebot' && !c.providerAcceptedAt;
-  var canConfirm = stage === 'bestaetigt' && !c.providerConfirmedAt;
-  var alreadyConfirmed = !!c.providerConfirmedAt && stage !== 'abgeschlossen';
+  var canConfirm = stage === 'angebot' && !!c.providerAcceptedAt && !c.providerConfirmedAt;
+  var alreadyConfirmed = !!c.providerConfirmedAt && stage === 'angebot';
   var isRemote = !!j.remote;
 
   var actionHtml = '';
@@ -16291,9 +16364,13 @@ function _renderAuftragsboardCardHtml(j) {
     actionHtml = '<div class="board-auftrag-status board-auftrag-status--waiting">' +
       '<span class="material-icons-round">hourglass_top</span> Wartet auf Kunden-Best&auml;tigung' +
     '</div>';
+  } else if (stage === 'bestaetigt') {
+    actionHtml = '<div class="board-auftrag-status board-auftrag-status--done">' +
+      '<span class="material-icons-round">verified</span> Leistung erf&uuml;llt &ndash; Zahlung ausstehend' +
+    '</div>';
   } else if (stage === 'abgeschlossen') {
     actionHtml = '<div class="board-auftrag-status board-auftrag-status--done">' +
-      '<span class="material-icons-round">verified</span> Auftrag erf&uuml;llt' +
+      '<span class="material-icons-round">paid</span> Auftrag bezahlt' +
     '</div>';
   } else {
     actionHtml = '<div class="board-auftrag-status">Warten auf n&auml;chsten Schritt</div>';
@@ -16584,7 +16661,9 @@ function renderKanbanCard(card) {
   if (card.stage === 'kontaktiert') {
     stageBadge = '<div class="kc-waiting"><span class="material-icons-round">hourglass_top</span> Warten auf Antwort</div>';
   } else if (card.stage === 'angebot') {
-    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'angebot\')"><span class="material-icons-round">receipt_long</span> Jetzt buchen</button>';
+    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'angebot\')"><span class="material-icons-round">verified</span> Erbringung bestätigen</button>';
+  } else if (card.stage === 'bestaetigt') {
+    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'bestaetigt\')"><span class="material-icons-round">paid</span> Jetzt bezahlen</button>';
   }
   var _listImg = _cardListingImage(card);
   var _listTitle = _cardListingTitle(card);
@@ -16689,9 +16768,9 @@ function allowDrop(event) {
 // Protected stages: nur über Aktions-/Payment-Flow erreichbar, nicht per Drag&Drop.
 var _PROTECTED_STAGES = ['angebot','bestaetigt','abgeschlossen'];
 function _protectedStageMessage(stage) {
-  if (stage === 'angebot') return 'Diese Spalte wird nur über „Jetzt buchen“ befüllt – so bleibt die Buchung verbindlich.';
-  if (stage === 'bestaetigt') return 'Status „Bezahlt“ wird automatisch gesetzt, sobald der Dienstleister den Auftrag annimmt.';
-  if (stage === 'abgeschlossen') return 'Status „Erfüllt“ wird vom System gesetzt, wenn beide Seiten die Erbringung bestätigen.';
+  if (stage === 'angebot') return 'Status „Gebucht“ wird durch die Annahme des Dienstleisters gesetzt.';
+  if (stage === 'bestaetigt') return 'Status „Erfüllt“ wird gesetzt, wenn beide Seiten die Erbringung bestätigen.';
+  if (stage === 'abgeschlossen') return 'Status „Bezahlt“ wird ausschließlich nach bestätigter Zahlung gesetzt.';
   return 'Dieser Status wird vom System gesetzt.';
 }
 function dropCard(event, toStage) {
@@ -16795,18 +16874,10 @@ function _currentFlowBp() {
   return 'desktop';
 }
 
-// Liefert das gespeicherte Layout für den aktuellen Breakpoint.
-// Migriert die alte Einzel-Struktur `project.flowLayout` nach Desktop.
+// Die Prozessstruktur ist fachlich fest und darf nicht durch versehentliches
+// Ziehen dauerhaft zerlegt werden. Alte gespeicherte Koordinaten werden daher
+// bewusst ignoriert; Karten bleiben weiterhin zwischen Stages verschiebbar.
 function _getFlowLayoutForBp(project, bp) {
-  if (!project) return {};
-  if (project.flowLayouts && project.flowLayouts[bp] && typeof project.flowLayouts[bp] === 'object') {
-    return project.flowLayouts[bp];
-  }
-  // Legacy: alte Variante war ein einzelnes Layout ohne Breakpoint-Zuordnung.
-  // Wir nehmen an, dass diese für Desktop gedacht war.
-  if (!project.flowLayouts && project.flowLayout && bp === 'desktop' && typeof project.flowLayout === 'object') {
-    return project.flowLayout;
-  }
   return {};
 }
 
@@ -16871,8 +16942,8 @@ function _renderBoardFlowImpl() {
     { id: 'geplant',       label: 'Geplant',        color: '#9E9E9E', icon: 'schedule'     },
     { id: 'kontaktiert',   label: 'Kontaktiert',     color: '#FF9800', icon: 'mail'         },
     { id: 'angebot',       label: 'Gebucht',         color: '#AB47BC', icon: 'receipt_long' },
-    { id: 'bestaetigt',    label: 'Bezahlt',         color: '#00A699', icon: 'paid'         },
-    { id: 'abgeschlossen', label: 'Erfüllt',         color: '#FF385C', icon: 'verified'     }
+    { id: 'bestaetigt',    label: 'Erfüllt',         color: '#FF385C', icon: 'verified'     },
+    { id: 'abgeschlossen', label: 'Bezahlt',         color: '#00A699', icon: 'paid'         }
   ];
 
   var cards = project.cards || [];
@@ -16950,12 +17021,8 @@ function _renderBoardFlowImpl() {
   html += '<span class="flow-zoom-pct" id="flowZoomPct" role="button" tabindex="0" title="Zoom-Prozent eingeben" onclick="flowZoomPrompt()">100%</span>';
   html += '<button class="flow-tbtn" onclick="flowZoom(0.10)" title="Vergrößern (Ctrl + +)" aria-label="Vergrößern (Ctrl + +)"><span class="material-icons-round">add</span></button>';
   html += '<div class="flow-tb-divider"></div>';
-  html += '<button class="flow-tbtn" id="flowUndoBtn" onclick="flowUndo()" title="Rückgängig (Ctrl+Z)" aria-label="Rückgängig (Ctrl+Z)" disabled><span class="material-icons-round">undo</span></button>';
-  html += '<button class="flow-tbtn" id="flowRedoBtn" onclick="flowRedo()" title="Wiederherstellen (Ctrl+Y)" aria-label="Wiederherstellen (Ctrl+Y)" disabled><span class="material-icons-round">redo</span></button>';
-  html += '<div class="flow-tb-divider"></div>';
   html += '<button class="flow-tbtn" onclick="flowFitToScreen()" title="An Bildschirm anpassen" aria-label="An Bildschirm anpassen"><span class="material-icons-round">fit_screen</span></button>';
   html += '<button class="flow-tbtn" onclick="flowResetView()" title="Ansicht zurücksetzen" aria-label="Ansicht zurücksetzen"><span class="material-icons-round">center_focus_strong</span></button>';
-  html += '<button class="flow-tbtn" onclick="flowAutoLayout()" title="Struktur neu anordnen" aria-label="Struktur neu anordnen"><span class="material-icons-round">auto_awesome_motion</span></button>';
   html += '<button class="flow-tbtn" id="flowFullscreenBtn" onclick="toggleFlowFullscreen()" title="Vollbild"><span class="material-icons-round" id="flowFullscreenIcon">fullscreen</span></button>';
   html += '<div class="flow-tb-divider"></div>';
   // Progress ring
@@ -17004,12 +17071,12 @@ function _renderBoardFlowImpl() {
   html += '<svg class="flow-svg" id="flowSvg" xmlns="http://www.w3.org/2000/svg"></svg>';
 
   // Trigger node
-  html += '<div class="flow-col flow-drag-handle" data-col-id="start" style="' + colStyle('start') + '">';
-  html += '<div class="flow-node flow-node-trigger" data-nid="start" onclick="if(!_flowDragJustEnded)openFlowProjectModal();_flowDragJustEnded=false">';
+  html += '<div class="flow-col" data-col-id="start" style="' + colStyle('start') + '">';
+  html += '<div class="flow-node flow-node-trigger" data-nid="start" onclick="openFlowProjectModal()">';
   html += '<span class="material-icons-round" style="color:#FF385C;font-size:32px">celebration</span>';
   html += '<strong>' + esc(project.name || 'Event') + '</strong>';
   if (project.date) html += '<small>' + esc(project.date) + '</small>';
-  html += '<span class="flow-node-edit-hint"><span class="material-icons-round" style="font-size:10px;vertical-align:middle">drag_indicator</span> Ziehen &nbsp;<span class="material-icons-round" style="font-size:10px;vertical-align:middle">edit</span> Klicken</span>';
+  html += '<span class="flow-node-edit-hint"><span class="material-icons-round" style="font-size:10px;vertical-align:middle">edit</span> Klicken zum Bearbeiten</span>';
   html += '</div>';
   html += '</div>';
 
@@ -17026,11 +17093,10 @@ function _renderBoardFlowImpl() {
 
     // Stage header node
     html += '<div class="flow-node flow-node-stage" data-nid="stage-' + stage.id + '">';
-    html += '<div class="flow-node-hdr flow-drag-handle" style="background:' + stage.color + ';border-radius:12px 12px 0 0">';
+    html += '<div class="flow-node-hdr" style="background:' + stage.color + ';border-radius:12px 12px 0 0">';
     html += '<span class="material-icons-round">' + stage.icon + '</span>';
     html += '<span>' + stage.label + '</span>';
     if (stageCards.length) html += '<span class="flow-node-badge">' + stageCards.length + '</span>';
-    html += '<span class="material-icons-round flow-drag-icon">drag_indicator</span>';
     html += '</div>';
     html += '<div class="flow-node-body">';
     if (stageCards.length) {
@@ -17085,9 +17151,9 @@ function _renderBoardFlowImpl() {
       if (card.startTime) html += '<span class="flow-prov-time"><span class="material-icons-round" style="font-size:11px">schedule</span>' + esc(card.startTime) + (card.endTime ? ' – ' + esc(card.endTime) : '') + '</span>';
       html += '</div>';
       html += '<div class="flow-prov-actions">';
-      var _saLabels = {geplant:'Kontaktieren',angebot:'Jetzt buchen',bestaetigt:'Erbringung bestätigen'};
-      var _saIcons  = {geplant:'forum',angebot:'receipt_long',bestaetigt:'verified'};
-      var _saColors = {geplant:'#42a5f5',angebot:'#66bb6a',bestaetigt:'#FF385C'};
+      var _saLabels = {geplant:'Kontaktieren',angebot:'Erbringung bestätigen',bestaetigt:'Jetzt bezahlen'};
+      var _saIcons  = {geplant:'forum',angebot:'verified',bestaetigt:'paid'};
+      var _saColors = {geplant:'#42a5f5',angebot:'#FF385C',bestaetigt:'#00A699'};
       if (stage.id === 'kontaktiert') {
         // Locked: waiting for provider response
         html += '<button class="flow-prov-action-btn flow-prov-waiting" style="--sa-clr:#FF9800;opacity:0.85;cursor:default" onclick="event.stopPropagation();openStageAdvanceModal(\'' + card.id + '\',\'' + stage.id + '\')">';
@@ -17111,7 +17177,7 @@ function _renderBoardFlowImpl() {
   });
 
   // End node
-  html += '<div class="flow-col flow-drag-handle" data-col-id="end" style="' + colStyle('end') + '">';
+  html += '<div class="flow-col" data-col-id="end" style="' + colStyle('end') + '">';
   html += '<div class="flow-node flow-node-end" data-nid="end">';
   html += '<span class="material-icons-round" style="color:#4CAF50;font-size:32px">check_circle</span>';
   html += '<strong>Event fertig!</strong>';
@@ -17227,9 +17293,7 @@ function _renderBoardFlowImpl() {
       // haengen und man kann auf Handy nicht bis ganz nach unten scrollen.
       try { _flowApplyZoom(_flowZoom, true); } catch(_) {}
     }
-    _drawFlowConnections(); _initFlowDrag(); _initFlowZoomPan();
-    // Initialer History-Eintrag (idempotent), Buttons aktualisieren
-    try { _flowPushHistory(); _flowUpdateUndoButtons(); } catch(_) {}
+    _drawFlowConnections(); _initFlowZoomPan();
     // Auf Mobile IMMER neu fitten + zum Start scrollen, damit der Nutzer
     // den Start-Node sofort im Fokus hat (und nicht im leeren Raum landet).
     if (_isMobile) {
@@ -17277,7 +17341,6 @@ function _renderBoardFlowImpl() {
 
 /* ─── Flow view extra modals ─────────────────────────────── */
 function openFlowProjectModal() {
-  if (_flowDragJustEnded) { _flowDragJustEnded = false; return; }
   if (!_activeBoardId) return;
   var project = _boardProjects.find(function(p) { return p.id === _activeBoardId; });
   if (!project) return;
@@ -17337,8 +17400,8 @@ function openFlowBudgetModal() {
     { id: 'geplant', label: 'Geplant', color: '#9E9E9E' },
     { id: 'kontaktiert', label: 'Kontaktiert', color: '#FF9800' },
     { id: 'angebot', label: 'Gebucht', color: '#AB47BC' },
-    { id: 'bestaetigt', label: 'Bezahlt', color: '#00A699' },
-    { id: 'abgeschlossen', label: 'Erfüllt', color: '#FF385C' }
+    { id: 'bestaetigt', label: 'Erfüllt', color: '#FF385C' },
+    { id: 'abgeschlossen', label: 'Bezahlt', color: '#00A699' }
   ];
 
   var breakdown = stagesMeta.map(function(s) {
@@ -17590,8 +17653,8 @@ function openFlowCardModal(cardId) {
 
   var stageOptions = [
     { id: 'geplant', label: 'Geplant' }, { id: 'kontaktiert', label: 'Kontaktiert' },
-    { id: 'angebot', label: 'Gebucht' }, { id: 'bestaetigt', label: 'Bezahlt' },
-    { id: 'abgeschlossen', label: 'Erfüllt' }
+    { id: 'angebot', label: 'Gebucht' }, { id: 'bestaetigt', label: 'Erfüllt' },
+    { id: 'abgeschlossen', label: 'Bezahlt' }
   ].map(function(s) {
     return '<option value="' + s.id + '"' + (s.id === card.stage ? ' selected' : '') + '>' + s.label + '</option>';
   }).join('');
@@ -17603,17 +17666,14 @@ function openFlowCardModal(cardId) {
         '<input type="number" id="fcPrice" value="' + _paidAmount + '" readonly /></div>'
     : '<div class="form-group"><label>Preis (€)</label><input type="number" id="fcPrice" value="' + (card.price || '') + '" min="0" step="1" /></div>';
 
-  // Stage nach Zahlung nur noch vorwärts auf "abgeschlossen" erlaubt
+  // Nach einer Zahlung ist die Stage unveränderlich. Vorab bezahlte Karten
+  // bleiben bis zur beidseitigen Erfüllungsbestätigung unter „Gebucht“.
   var _stageField = _isPaid
     ? (function() {
-        var allowed = ['bestaetigt', 'abgeschlossen'];
         return '<div class="form-group"><label>Status / Stage <span class="fc-locked-hint"><span class="material-icons-round">lock</span> Zahlung abgeschlossen</span></label>' +
-          '<select id="fcStage">' +
-            allowed.map(function(s) {
-              var label = s === 'bestaetigt' ? 'Bezahlt' : 'Erfüllt';
-              return '<option value="' + s + '"' + (s === card.stage ? ' selected' : '') + '>' + label + '</option>';
-            }).join('') +
-          '</select></div>';
+          '<select id="fcStage" disabled><option value="' + _escHtml(card.stage) + '">' +
+            _escHtml((FLOW_STAGE_LABELS && FLOW_STAGE_LABELS[card.stage]) || card.stage) +
+          '</option></select></div>';
       })()
     : '<div class="form-group"><label>Status / Stage</label><select id="fcStage">' + stageOptions + '</select></div>';
 
@@ -17661,12 +17721,8 @@ function _saveFlowCard(event, cardId) {
   card.endTime   = document.getElementById('fcTimeEnd') ? document.getElementById('fcTimeEnd').value : '';
   var _newStage = document.getElementById('fcStage').value;
   if (_isPaid) {
-    // Nach Zahlung: Stage darf nur noch auf 'abgeschlossen' gehen
-    if (_newStage !== card.stage && !(['bestaetigt','abgeschlossen'].includes(_newStage) && ['bestaetigt','abgeschlossen'].includes(card.stage))) {
-      showToast('Nach Zahlung ist nur noch "Erfüllt" als nächste Stage erlaubt.', 'warning');
-      return;
-    }
-    card.stage = _newStage;
+    // Zahlungsstatus und Prozessstand dürfen nicht manuell verfälscht werden.
+    card.stage = card.stage;
   } else if (typeof _PROTECTED_STAGES !== 'undefined' && _PROTECTED_STAGES.indexOf(_newStage) !== -1 && card.stage !== _newStage) {
     showToast(_protectedStageMessage(_newStage), 'warning');
   } else {
@@ -17747,7 +17803,6 @@ function _sendInvoiceNotification(card, project, listing) {
     return Promise.reject(e);
   }
 }
-
 /* ─── Pending-Payment Persistenz ─────────────────────────────────
  * Vor jeder Stripe-Zahlung wird die geplante Aktion serialisierbar in
  * localStorage abgelegt. Macht die Buchung redirect-fest: kehrt der
@@ -17808,7 +17863,7 @@ function _applyInstantBookingSuccess(info, res) {
     id: 'bc_' + Date.now(),
     name: info.title || 'Direktbuchung',
     category: info.category || '',
-    stage: 'bestaetigt',
+    stage: 'angebot',
     price: info.amount,
     listingId: info.listingId,
     listingImage: info.image || '',
@@ -17820,7 +17875,8 @@ function _applyInstantBookingSuccess(info, res) {
     bookedAt: nowIso, invoiceSentAt: nowIso, paidAt: nowIso,
     paidAmount: info.amount, paymentMethod: 'Stripe',
     paymentIntentId: piId, paymentReference: piId,
-    paymentStatus: 'paid', createdAt: nowIso
+    paymentStatus: 'paid', providerAcceptedAt: nowIso, createdAt: nowIso,
+    _stageModel: EB_BOARD_STAGE_MODEL_VERSION
   };
   proj.cards = proj.cards || [];
   proj.cards.push(card);
@@ -17856,7 +17912,10 @@ function _applyCardPaymentSuccess(cardId, projectId, amount, res) {
   card.paymentIntentId = piId;
   card.paymentReference = piId;
   card.paymentStatus = 'paid';
-  card.stage = 'bestaetigt';
+  // Bezahlt ist die letzte Prozessstufe. Wurde vorab bezahlt, bleibt die
+  // Karte bis zur beidseitigen Erfüllungsbestätigung unter „Gebucht“.
+  card.stage = card.fulfilledAt ? 'abgeschlossen' : 'angebot';
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   var listing = (typeof LISTINGS !== 'undefined' ? LISTINGS : []).find(function(l) { return l.id === card.listingId; });
   try { _sendInvoiceNotification(card, project, listing).catch(function() {}); } catch (e) {}
   try { _saveBoardProjects && _saveBoardProjects({ immediate: true }); } catch (e) {}
@@ -18013,7 +18072,8 @@ function _handleStripeReturn() {
     card.paymentMethod = 'Stripe';
     card.paymentReference = sessionId || card.paymentReference || '';
     card.stripePending = false;
-    if (card.stage === 'angebot') card.stage = 'bestaetigt';
+    if (card.fulfilledAt) card.stage = 'abgeschlossen';
+    card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
     try { _saveBoardProjects && _saveBoardProjects(); } catch(e) {}
     showToast('Zahlung via Stripe erfolgreich – Status: Bezahlt.', 'paid');
   } else if (status === 'cancel' && card) {
@@ -18064,7 +18124,8 @@ function _reconcileStripePayments() {
             card.paidAt           = card.paidAt || new Date((it.paid_at || 0) * 1000).toISOString();
             card.paidAmount       = card.paidAmount || ((it.amount || 0) / 100);
             card.stripePending    = false;
-            if (card.stage === 'angebot') card.stage = 'bestaetigt';
+            if (card.fulfilledAt) card.stage = 'abgeschlossen';
+            card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
             matched++;
           }
           acked.push(it.pi);
@@ -19005,7 +19066,7 @@ function _formatEuro(n) {
 
 /* ── Flow-Board Stage-Verschieben (Sheet + Drag&Drop) ──────────────────
  * Stages laufen strikt sequenziell:
- *   geplant → kontaktiert → angebot (Gebucht) → bestaetigt (Bezahlt) → abgeschlossen (Erfüllt)
+ *   geplant → kontaktiert → angebot (Gebucht) → bestaetigt (Erfüllt) → abgeschlossen (Bezahlt)
  * Logik:
  *   • Gleiche Stage  → ignorieren
  *   • +1 Schritt     → den vorhandenen Aktions-Flow für die AKTUELLE Stage öffnen
@@ -19014,9 +19075,9 @@ function _formatEuro(n) {
  *   • Rückwärts      → mit Bestätigung erlaubt; setzt nachgelagerte Marker zurück
  */
 var FLOW_STAGE_ORDER  = ['geplant','kontaktiert','angebot','bestaetigt','abgeschlossen'];
-var FLOW_STAGE_LABELS = { geplant:'Geplant', kontaktiert:'Kontaktiert', angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erfüllt' };
-var FLOW_STAGE_ICONS  = { geplant:'schedule', kontaktiert:'mail', angebot:'receipt_long', bestaetigt:'paid', abgeschlossen:'verified' };
-var FLOW_STAGE_COLORS = { geplant:'#9E9E9E', kontaktiert:'#FF9800', angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C' };
+var FLOW_STAGE_LABELS = { geplant:'Geplant', kontaktiert:'Kontaktiert', angebot:'Gebucht', bestaetigt:'Erfüllt', abgeschlossen:'Bezahlt' };
+var FLOW_STAGE_ICONS  = { geplant:'schedule', kontaktiert:'mail', angebot:'receipt_long', bestaetigt:'verified', abgeschlossen:'paid' };
+var FLOW_STAGE_COLORS = { geplant:'#9E9E9E', kontaktiert:'#FF9800', angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699' };
 
 function openStageMoveSheet(cardId) {
   var project = _boardProjects.find(function(p){ return p.id === _activeBoardId; });
@@ -19090,6 +19151,10 @@ function _attemptMoveCardStage(cardId, targetStage) {
   }
   // 3) Rückwärts → mit Bestätigung erlauben (Korrektur)
   if (tgtIdx < curIdx) {
+    if (_cardHasConfirmedPayment(card)) {
+      showToast('Eine bestätigte Zahlung kann nicht auf eine frühere Stage zurückgesetzt werden.', 'lock');
+      return;
+    }
     var ok = window.confirm('Karte von „' + FLOW_STAGE_LABELS[current] + '" zurück auf „' + FLOW_STAGE_LABELS[targetStage] + '" setzen?\n\nBereits gesetzte Bestätigungen ab dieser Stage werden zurückgesetzt.');
     if (!ok) return;
     card.stage = targetStage;
@@ -19160,8 +19225,8 @@ function openStageAdvanceModal(cardId, currentStage) {
   var card = (project.cards || []).find(function(c) { return c.id === cardId; });
   if (!card) return;
 
-  var titles = {geplant:'Kontaktieren',kontaktiert:'Warten auf Antwort',angebot:'Jetzt buchen',bestaetigt:'Erbringung bestätigen'};
-  var icons  = {geplant:'forum',kontaktiert:'hourglass_top',angebot:'receipt_long',bestaetigt:'verified'};
+  var titles = {geplant:'Kontaktieren',kontaktiert:'Warten auf Antwort',angebot:'Erbringung bestätigen',bestaetigt:'Jetzt bezahlen'};
+  var icons  = {geplant:'forum',kontaktiert:'hourglass_top',angebot:'verified',bestaetigt:'paid'};
   var title  = titles[currentStage] || 'Weiter';
   var icon   = icons[currentStage] || 'arrow_forward';
 
@@ -19282,19 +19347,18 @@ function openStageAdvanceModal(cardId, currentStage) {
         'onclick="this.closest(\'.sa-overlay\').remove();navigateTo(\'messages\');' +
         (card.conversationId ? 'setTimeout(function(){try{openChat(' + parseInt(card.conversationId, 10) + ')}catch(e){}},300)' : '') +
         '"><span class="material-icons-round">forum</span> Chat öffnen</button>';
-  } else if (currentStage === 'angebot') {
-    // Stage "Angebot erhalten" → Anbieter hat Ja gesagt → jetzt verbindlich buchen.
-    // Rechnung wird angestoßen (E-Mail an User, Anbieter, kontakt@eventbörse.de).
+  } else if (currentStage === 'bestaetigt') {
+    // Stage „Erfüllt“ → nach beidseitiger Bestätigung sicher bezahlen.
     var _bookPrice = (_listing && _listing.price) || card.price || '';
     var _bookEventDate = (project && project.date) ? _formatDateDe(project.date) : '—';
     fieldsHtml = '' +
       '<div class="sa-info-card" style="background:linear-gradient(135deg,rgba(102,187,106,0.14),rgba(102,187,106,0.04));border:1px solid rgba(102,187,106,0.35);border-radius:12px;padding:14px;margin-bottom:12px">' +
         '<div style="display:flex;gap:10px;align-items:center;margin-bottom:8px">' +
           '<span class="material-icons-round" style="color:#66bb6a">check_circle</span>' +
-          '<strong>Angebot erhalten – jetzt buchen!</strong>' +
+          '<strong>Leistung erfüllt – jetzt bezahlen</strong>' +
         '</div>' +
         '<div style="font-size:13px;color:var(--text-light);line-height:1.5">' +
-          'Der Anbieter hat deine Anfrage angenommen. Mit dem Buchen wird eine Rechnung erstellt und automatisch an <strong>dich</strong>, den <strong>Anbieter</strong> ' +
+          'Beide Seiten haben die Erbringung bestätigt. Mit der Zahlung wird eine Rechnung erstellt und automatisch an <strong>dich</strong>, den <strong>Anbieter</strong> ' +
           'und <strong>eventb&ouml;rse.de</strong> gesendet — f&uuml;r volle Transparenz.' +
         '</div>' +
       '</div>' +
@@ -19306,8 +19370,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       '<input id="saBookPrice" type="number" class="sa-input" step="1" min="0" value="' + _escHtml(String(_bookPrice)) + '">' +
       '<label class="sa-label">Anmerkung f&uuml;r Rechnung <small>(optional)</small></label>' +
       '<textarea id="saBookNote" class="sa-input" rows="2" placeholder="Uhrzeit, Adresse, Besonderheiten…"></textarea>';
-  } else if (currentStage === 'bestaetigt') {
-    // Stage "Bezahlt" → "Erfüllt": Dual-Confirmation am Event-Tag.
+  } else if (currentStage === 'angebot') {
+    // Stage „Gebucht“ → „Erfüllt“: Dual-Confirmation am Event-Tag.
     var _hasProvConfirm = !!card.providerConfirmedAt;
     var _hasUserConfirm = !!card.userConfirmedAt;
     fieldsHtml = '' +
@@ -19537,8 +19601,8 @@ function openStageAdvanceModal(cardId, currentStage) {
     });
   }
 
-  // ── Review-Widget (bestaetigt stage) ──
-  if (currentStage === 'bestaetigt') {
+  // ── Review-Widget (Gebucht → Erfüllt) ──
+  if (currentStage === 'angebot') {
     var _saStarsEl = document.getElementById('saStars');
     var _saRatingInput = document.getElementById('saRating');
     var _saRatingLabel = document.getElementById('saRatingLabel');
@@ -19622,8 +19686,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       // Warten auf Antwort – kein Submit-Action nötig, einfach schließen.
       overlay.remove();
       return;
-    } else if (currentStage === 'angebot') {
-      // Angebot erhalten → echte Stripe-Zahlung starten.
+    } else if (currentStage === 'bestaetigt') {
+      // Leistung erfüllt → echte Stripe-Zahlung starten.
       var _bp = parseFloat((document.getElementById('saBookPrice') || {}).value);
       if (!isNaN(_bp) && _bp > 0) card.price = _bp;
       card.bookingNote = (document.getElementById('saBookNote') || {}).value || '';
@@ -19668,8 +19732,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       });
       });
       return; // Submit-Handler hier beenden – Rest übernimmt onSuccess.
-    } else if (currentStage === 'bestaetigt') {
-      // Stage "Bezahlt" → "Erfuellt": Dual-Confirm (User + Dienstleister)
+    } else if (currentStage === 'angebot') {
+      // Stage „Gebucht“ → „Erfüllt“: Dual-Confirm (User + Dienstleister)
       var _userOk = !!(document.getElementById('saUserConfirm') || {}).checked;
       var _ratingVal = parseInt((document.getElementById('saRating') || {}).value) || 0;
       var _commentVal = ((document.getElementById('saComment') || {}).value || '').trim();
@@ -19731,7 +19795,7 @@ function openStageAdvanceModal(cardId, currentStage) {
               showToast('Bewertung konnte nicht gesendet werden (Netzwerk).', 'error');
             });
         }
-        showToast('Leistung beidseitig best\u00e4tigt – Projekt abgeschlossen!', 'verified');
+        showToast('Leistung beidseitig best\u00e4tigt – jetzt kann bezahlt werden.', 'verified');
       }
     }
 
@@ -19739,7 +19803,12 @@ function openStageAdvanceModal(cardId, currentStage) {
     if (_advance) {
       var stagesOrder = ['geplant','kontaktiert','angebot','bestaetigt','abgeschlossen'];
       var idx = stagesOrder.indexOf(currentStage);
-      if (idx >= 0 && idx < stagesOrder.length - 1) card.stage = stagesOrder[idx + 1];
+      if (idx >= 0 && idx < stagesOrder.length - 1) {
+        card.stage = (currentStage === 'angebot' && card.fulfilledAt && _cardHasConfirmedPayment(card))
+          ? 'abgeschlossen'
+          : stagesOrder[idx + 1];
+      }
+      card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
     }
 
     _saveBoardProjects();
@@ -21425,7 +21494,6 @@ function _getProjectChecklist(project) {
   var saved = Array.isArray(project.checklist) ? project.checklist : [];
   return saved.filter(function(it){ return it && it.text; });
 }
-
 // ========== PLANUNGS-GUIDE (geführte Steps) ==========
 // Macht aus den Checklisten-Templates einen geführten Assistenten:
 // geprüfte Steps in sinnvoller Reihenfolge, pro Step direkt passende
@@ -21519,7 +21587,7 @@ function _guideSteps(project) {
     // Ein Step gilt als erledigt, wenn abgehakt ODER der Dienstleister
     // dafür bereits fest gebucht/abgeschlossen ist.
     var done = doneMap[text.toLowerCase()] === true ||
-      cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
+      cardStage === 'angebot' || cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
     // Empfohlene Deadline: Eventdatum minus Vorlaufzeit (nur mit Datum).
     var deadline = null, overdue = false;
     if (eventDate) {
@@ -24733,7 +24801,7 @@ function _startOfferPayment(msgId, amount) {
 
   // Doppelzahlungs-Schutz: dieses Listing ist bereits verbindlich gebucht
   // und bezahlt → keine zweite Zahlung starten.
-  if (rec.card.paymentStatus === 'paid' || rec.card.stage === 'bestaetigt' || rec.card.stage === 'abgeschlossen') {
+  if (_cardHasConfirmedPayment(rec.card)) {
     showToast('Bereits verbindlich gebucht & bezahlt — siehe Planungsboard.', 'info');
     try { navigateTo('board'); } catch (e) {}
     return;
@@ -24830,7 +24898,6 @@ function _recordBookingToBoard(opts) {
   _saveBoardProjects({ immediate: true });
   return { projectId: project.id, card: card };
 }
-
 /* ==================== PLANUNGS-ASSISTENT (lokale "KI", ChatGPT-Look) ==================== */
 // Regelbasierter Assistent für das Planungs-Board — läuft KOMPLETT im
 // Browser: keine externen KI-Calls, keine Tokens, keine Kosten. Versteht
@@ -25785,7 +25852,7 @@ function _rvPrice(job) {
 }
 function _rvStatus(job) {
   var c = job && job.card || {};
-  return c.stage || (c.providerConfirmedAt ? 'abgeschlossen' : (c.paidAt || c.paymentIntentId ? 'bestaetigt' : 'angebot'));
+  return c.stage || ((c.paidAt || c.paymentIntentId) ? 'abgeschlossen' : (c.fulfilledAt ? 'bestaetigt' : 'angebot'));
 }
 function _rvDate(job) {
   var raw = (job.project && job.project.date) || (job.card && (job.card.bookedAt || job.card.createdAt)) || '';
@@ -25818,9 +25885,10 @@ function _renderBusinessCockpitData(jobs, offline) {
   var root = document.getElementById('businessCockpit');
   if (!root) return;
   _businessJobs = jobs || [];
-  var paidStages = { bestaetigt:1, abgeschlossen:1 };
   var booked = _businessJobs.reduce(function(sum,j){ return sum + _rvPrice(j); }, 0);
-  var paid = _businessJobs.reduce(function(sum,j){ return sum + (paidStages[_rvStatus(j)] ? _rvPrice(j) : 0); }, 0);
+  var paid = _businessJobs.reduce(function(sum,j){
+    return sum + (_cardHasConfirmedPayment(j && j.card) ? _rvPrice(j) : 0);
+  }, 0);
   var open = _businessJobs.filter(function(j){ return _rvStatus(j) !== 'abgeschlossen'; }).length;
   var fee = paid * 0.03;
   var paidOut = Math.max(0, paid - fee);
@@ -25895,7 +25963,7 @@ function _businessInvoiceTable(jobs) {
     return '<div class="business-invoice-row"><span><strong>' + _escHtml(id) + '</strong><small>' + _rvDate(j).toLocaleDateString('de-DE') + '</small></span><span>' + _escHtml(project) + '</span><span><i class="invoice-status ' + _escHtml(status) + '">' + _escHtml(_rvStageLabel(status)) + '</i></span><span>' + _rvMoney(_rvPrice(j)) + '</span><span><button class="btn-outline btn-sm" onclick="downloadBusinessInvoice(' + i + ')"><span class="material-icons-round">picture_as_pdf</span> Vorschau/PDF</button></span></div>';
   }).join('') + '</div>';
 }
-function _rvStageLabel(s){ return ({angebot:'Gebucht',bestaetigt:'Bezahlt',abgeschlossen:'Erfüllt',kontaktiert:'Kontaktiert',geplant:'Geplant'})[s] || s; }
+function _rvStageLabel(s){ return ({angebot:'Gebucht',bestaetigt:'Erfüllt',abgeschlossen:'Bezahlt',kontaktiert:'Kontaktiert',geplant:'Geplant'})[s] || s; }
 function _businessInvoiceNo(job,index){
   var prefix = currentUser && currentUser.taxProfile && currentUser.taxProfile.invoicePrefix || 'EB';
   var stable = String(job && job.card && job.card.id || job && job.project && job.project.id || index+1);

--- a/functions.php
+++ b/functions.php
@@ -1789,18 +1789,57 @@ function eb_board_bookings_update_card( WP_REST_Request $request ) {
                     return new WP_REST_Response( array( 'error' => 'not_your_listing' ), 403 );
                 }
             }
+            // Alte Board-Karten vor der Aktion serverseitig in das neue
+            // Modell (Gebucht → Erfüllt → Bezahlt) überführen. So bleibt die
+            // Dienstleister-Aktion auch dann möglich, wenn der Kunde sein
+            // Board seit dem Deploy noch nicht geöffnet hat.
+            if ( (int) ( $card['_stageModel'] ?? 0 ) < 2 ) {
+                $acceptance_only_payment = empty( $card['paymentIntentId'] )
+                    && empty( $card['paymentReference'] )
+                    && ! empty( $card['providerAcceptedAt'] )
+                    && ! empty( $card['paidAt'] )
+                    && (string) $card['providerAcceptedAt'] === (string) $card['paidAt'];
+                if ( $acceptance_only_payment ) {
+                    $card['paidAt'] = '';
+                    $card['paidAmount'] = 0;
+                    $card['paymentStatus'] = '';
+                    $card['paymentMethod'] = '';
+                }
+                $has_old_payment = ! empty( $card['paymentIntentId'] )
+                    || ! empty( $card['paymentReference'] )
+                    || preg_match( '/paid|bezahlt/i', (string) ( $card['paymentStatus'] ?? '' ) );
+                $was_fulfilled = ! empty( $card['fulfilledAt'] )
+                    || ( ! empty( $card['userConfirmedAt'] )
+                        && ! empty( $card['providerConfirmedAt'] )
+                        && ( $card['stage'] ?? '' ) === 'abgeschlossen' );
+                if ( $was_fulfilled ) {
+                    $card['fulfilledAt'] = ! empty( $card['fulfilledAt'] )
+                        ? $card['fulfilledAt']
+                        : ( $card['providerConfirmedAt'] ?? $card['userConfirmedAt'] );
+                    $card['stage'] = $has_old_payment ? 'abgeschlossen' : 'bestaetigt';
+                } elseif ( $has_old_payment
+                    || in_array( ( $card['stage'] ?? '' ), array( 'bestaetigt', 'abgeschlossen' ), true ) ) {
+                    $card['stage'] = 'angebot';
+                }
+                $card['_stageModel'] = 2;
+            }
             if ( $action === 'accept' ) {
                 $card['providerAcceptedAt'] = $now;
-                $card['stage']              = 'bestaetigt';
-                if ( empty( $card['paidAt'] ) ) $card['paidAt'] = $now;
-                if ( empty( $card['paymentStatus'] ) ) $card['paymentStatus'] = 'Bezahlt';
+                // Die Annahme ist eine Buchungsbestätigung, keine Zahlung.
+                // Die Karte bleibt „Gebucht“, bis beide Seiten die Erbringung
+                // bestätigen; bezahlt wird anschließend.
+                $card['stage'] = 'angebot';
             } elseif ( $action === 'confirm' ) {
                 $card['providerConfirmedAt'] = $now;
-                if ( ! empty( $card['userConfirmedAt'] ) && ( $card['stage'] ?? '' ) === 'bestaetigt' ) {
-                    $card['stage']       = 'abgeschlossen';
+                if ( ! empty( $card['userConfirmedAt'] ) && ( $card['stage'] ?? '' ) === 'angebot' ) {
                     $card['fulfilledAt'] = $now;
+                    $has_payment = ! empty( $card['paymentIntentId'] )
+                        || ! empty( $card['paymentReference'] )
+                        || preg_match( '/paid|bezahlt/i', (string) ( $card['paymentStatus'] ?? '' ) );
+                    $card['stage'] = $has_payment ? 'abgeschlossen' : 'bestaetigt';
                 }
             }
+            $card['_stageModel'] = 2;
             $found = true;
             break 2;
         }

--- a/index.html
+++ b/index.html
@@ -2685,7 +2685,7 @@
         <h2>1. Plattform-, Kunden- und Dienstleisterverhältnis</h2>
         <p>Die Plattform ist ausschließlich Vermittler im Sinne der §§ 652 ff. BGB analog. Der Vertrag über die Eventleistung wird ausschließlich zwischen Kunde und Dienstleister abgeschlossen. Die Plattform ist nicht Erfüllungsgehilfe und nicht Vertreter (§§ 164 ff. BGB).</p>
         <h2>2. Zustandekommen des Eventvertrages</h2>
-        <p>Verbindliches Angebot des Dienstleisters → Annahme durch den Kunden („Buchung verbindlich annehmen") → Auslösung der Stripe-Zahlung → mit erfolgreicher Zahlungsbestätigung ist der Eventvertrag verbindlich abgeschlossen. Beide Parteien erhalten Buchungsbestätigung mit Buchungsnummer, Daten der Gegenseite, Leistungsbeschreibung und Stripe-Transaktions-ID.</p>
+        <p>Verbindliches Angebot des Dienstleisters → Annahme durch den Kunden („Buchung verbindlich annehmen“) → der Eventvertrag ist verbindlich abgeschlossen → nach beidseitiger Bestätigung der erbrachten Leistung wird die Stripe-Zahlung ausgelöst. Beide Parteien erhalten Buchungs- und Zahlungsbestätigungen mit Buchungsnummer, Daten der Gegenseite, Leistungsbeschreibung und Stripe-Transaktions-ID.</p>
         <h2>3. Inhalt der Vermittlungsleistung</h2>
         <ul><li>Bereitstellung Plattformfunktionen (Profile, Suche, Messaging, Angebots-/Annahmeworkflow, Bewertungssystem).</li><li>Technische Vermittlung der Zahlung über Stripe Connect Express.</li><li>Bereitstellung von DSA- und P2B-Beschwerde- und Notice-Mechaniken.</li></ul>
         <h2>4. Was die Plattform nicht leistet</h2>
@@ -3129,7 +3129,7 @@ Datum: ___________________________________________________
             <div class="kanban-column" data-stage="bestaetigt">
               <div class="kanban-col-header">
                 <span class="kanban-col-dot dot-bestaetigt"></span>
-                <h4>Bezahlt</h4>
+                <h4>Erfüllt</h4>
                 <span class="kanban-col-count" id="cntBestaetigt">0</span>
               </div>
               <div class="kanban-cards" id="cardsBestaetigt" ondragover="allowDrop(event)" ondrop="dropCard(event,'bestaetigt')"></div>
@@ -3140,7 +3140,7 @@ Datum: ___________________________________________________
             <div class="kanban-column" data-stage="abgeschlossen">
               <div class="kanban-col-header">
                 <span class="kanban-col-dot dot-abgeschlossen"></span>
-                <h4>Erfüllt</h4>
+                <h4>Bezahlt</h4>
                 <span class="kanban-col-count" id="cntAbgeschlossen">0</span>
               </div>
               <div class="kanban-cards" id="cardsAbgeschlossen" ondragover="allowDrop(event)" ondrop="dropCard(event,'abgeschlossen')"></div>

--- a/js/modules/board/40-board-kanban.js
+++ b/js/modules/board/40-board-kanban.js
@@ -69,6 +69,77 @@ function _isTombstoned(id) {
   return 0;
 }
 
+var EB_BOARD_STAGE_MODEL_VERSION = 2;
+
+function _cardHasConfirmedPayment(card) {
+  if (!card) return false;
+  return !!(
+    card.paymentIntentId ||
+    card.paymentReference ||
+    (card.paymentStatus && /paid|bezahlt/i.test(String(card.paymentStatus)))
+  );
+}
+
+// Stage-Modell v2:
+// geplant → kontaktiert → gebucht → erfüllt → bezahlt.
+// Frühere Karten verwendeten bestaetigt=Bezahlt und abgeschlossen=Erfüllt.
+// Außerdem schrieb die alte Provider-Annahme ohne echte Stripe-Referenz
+// fälschlich einen Bezahlt-Marker. Beides wird einmalig und verlustarm
+// normalisiert. Manuelle Flow-Koordinaten entfallen, weil die Prozessstruktur
+// ab v2 fest ist.
+function _migrateBoardStageModel(projects) {
+  var changed = false;
+  (projects || []).forEach(function(project) {
+    if (!project) return;
+    if (project.flowLayout) {
+      delete project.flowLayout;
+      changed = true;
+    }
+    if (project.flowLayouts && Object.keys(project.flowLayouts).length) {
+      project.flowLayouts = {};
+      changed = true;
+    }
+    (project.cards || []).forEach(function(card) {
+      if (!card || card._stageModel === EB_BOARD_STAGE_MODEL_VERSION) return;
+
+      // Alte Provider-Annahme war keine Zahlung: ohne Stripe-Referenz und mit
+      // identischem Annahme-/Zahlzeitpunkt den künstlichen Marker entfernen.
+      var acceptanceOnlyPayment = !!(
+        !card.paymentIntentId &&
+        !card.paymentReference &&
+        card.providerAcceptedAt &&
+        card.paidAt &&
+        String(card.providerAcceptedAt) === String(card.paidAt)
+      );
+      if (acceptanceOnlyPayment) {
+        card.paidAt = '';
+        card.paidAmount = 0;
+        card.paymentStatus = '';
+        card.paymentMethod = '';
+      }
+
+      var paid = _cardHasConfirmedPayment(card);
+      var fulfilled = !!(
+        card.fulfilledAt ||
+        (card.userConfirmedAt && card.providerConfirmedAt && card.stage === 'abgeschlossen')
+      );
+      if (fulfilled) {
+        card.fulfilledAt = card.fulfilledAt || card.providerConfirmedAt || card.userConfirmedAt;
+        card.stage = paid ? 'abgeschlossen' : 'bestaetigt';
+      } else if (paid) {
+        // Bereits vorab bezahlt, aber noch nicht erbracht: bleibt gebucht,
+        // bis beide Seiten die Erbringung bestätigen.
+        card.stage = 'angebot';
+      } else if (card.stage === 'bestaetigt' || card.stage === 'abgeschlossen') {
+        card.stage = 'angebot';
+      }
+      card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
+      changed = true;
+    });
+  });
+  return changed;
+}
+
 function _migrateBoardProjects() {
   if (!currentUser) return;
   var newKey = 'eb_board_projects_' + currentUser.id;
@@ -88,6 +159,9 @@ function _loadBoardProjects() {
   _loadBoardTombstones();
   // 1) Schneller Cache: lokal geladene Projekte sofort anzeigen
   _boardProjects = key ? JSON.parse(localStorage.getItem(key) || '[]') : [];
+  if (_migrateBoardStageModel(_boardProjects) && key) {
+    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch (e) {}
+  }
   // Lokal bereits getombstoned? Raus damit.
   if (_boardTombstones.length) {
     _boardProjects = _boardProjects.filter(function(p){ return !p || !p.id || !_isTombstoned(p.id); });
@@ -104,6 +178,9 @@ function _loadBoardProjects() {
 // Lokale Projekte, die auf dem Server fehlen, werden hochgeladen (Migration / Offline-Sync).
 function _mergeBoardProjects(serverArr, localArr) {
   var byId = {};
+  var serverMigrated = _migrateBoardStageModel(serverArr);
+  var localMigrated = _migrateBoardStageModel(localArr);
+  var uploadNeeded = serverMigrated || localMigrated;
   function ts(p) {
     if (!p) return 0;
     var v = p.updatedAt || p.createdAt || 0;
@@ -113,7 +190,6 @@ function _mergeBoardProjects(serverArr, localArr) {
   (serverArr || []).forEach(function(p) {
     if (p && p.id) byId[p.id] = { project: p, source: 'server' };
   });
-  var uploadNeeded = false;
   (localArr || []).forEach(function(p) {
     if (!p || !p.id) return;
     var existing = byId[p.id];
@@ -174,9 +250,9 @@ function _snapshotBoardCardStates(projects) {
 /**
  * Vergleicht alten Snapshot mit neuem Board-Stand und sendet Toasts
  * für relevante Server-getriebene Übergänge:
- *  – Anbieter hat Auftrag angenommen (angebot/kontaktiert → bestaetigt)
+ *  – Anbieter hat Auftrag angenommen (providerAcceptedAt)
  *  – Anbieter hat Erbringung bestätigt (providerConfirmedAt neu)
- *  – Projekt erfüllt (→ abgeschlossen)
+ *  – Projekt erfüllt (fulfilledAt neu)
  */
 function _notifyBoardTransitions(prevSnap, newProjects) {
   if (!prevSnap || !newProjects) return;
@@ -194,10 +270,6 @@ function _notifyBoardTransitions(prevSnap, newProjects) {
 
       // 1) Anbieter hat Auftrag angenommen
       if (!prev.providerAcceptedAt && c.providerAcceptedAt) {
-        showToast(who + ' hat deine Anfrage für ' + what + when + ' angenommen!', 'verified');
-      } else if (prev.stage !== 'bestaetigt' && prev.stage !== 'abgeschlossen' &&
-                 (c.stage === 'bestaetigt' || c.stage === 'abgeschlossen')) {
-        // Fallback, falls providerAcceptedAt nicht gesetzt wird
         showToast(who + ' hat deine Anfrage für ' + what + when + ' angenommen!', 'verified');
       }
 
@@ -660,7 +732,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     '<div style="font-size:14px;line-height:1.7;margin-top:10px;color:var(--text-light)">' +
       '1. Ein Kunde bucht dich verbindlich &rarr; der Auftrag erscheint hier mit Status <em>&bdquo;Gebucht&ldquo;</em>.<br>' +
       '2. Du pr&uuml;fst die Details und klickst auf <strong>&bdquo;Auftrag annehmen&ldquo;</strong> &ndash; damit ist der Deal fix. Vom Buchungsbetrag gehen 3% Eventb&ouml;rse-Provision und die Stripe-Zahlungsgeb&uuml;hr ab &ndash; den Rest bekommst du ausgezahlt.<br>' +
-      '3. Am Event-Tag best&auml;tigt <strong>der Kunde</strong> die Erbringung, <strong>du</strong> best&auml;tigst hier die Abnahme. Erst dann ist der Auftrag <em>erf&uuml;llt</em>.' +
+      '3. Am Event-Tag best&auml;tigt <strong>der Kunde</strong> die Erbringung, <strong>du</strong> best&auml;tigst hier die Abnahme. Erst dann ist der Auftrag <em>erf&uuml;llt</em>.<br>' +
+      '4. Anschlie&szlig;end bezahlt der Kunde sicher &uuml;ber Stripe &ndash; danach steht der Auftrag auf <em>&bdquo;Bezahlt&ldquo;</em>.' +
     '</div>' +
   '</details>';
 
@@ -685,8 +758,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
   }
 
   var esc = _escHtml;
-  var stageLabels = { angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erf\u00fcllt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
-  var stageColors = { angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
+  var stageLabels = { angebot:'Gebucht', bestaetigt:'Erf\u00fcllt', abgeschlossen:'Bezahlt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
+  var stageColors = { angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
 
   html += '<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:16px">';
   jobs.forEach(function(j){
@@ -695,8 +768,8 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     var color = stageColors[stage] || '#9E9E9E';
     var priceStr = c.price ? (parseFloat(c.price).toFixed(2).replace(/\.00$/, '') + ' €') : '—';
     var dateStr = p.date ? _formatDateDe(p.date) : '—';
-    var canConfirm = stage === 'bestaetigt' && !c.providerConfirmedAt;
-    var alreadyConfirmed = !!c.providerConfirmedAt;
+    var canConfirm = stage === 'angebot' && !!c.providerAcceptedAt && !c.providerConfirmedAt;
+    var alreadyConfirmed = !!c.providerConfirmedAt && stage === 'angebot';
     var canAccept = stage === 'angebot' && !c.providerAcceptedAt;
     var priceNum = parseFloat(c.price) || 0;
     var isRemote = !!j.remote;
@@ -718,7 +791,10 @@ function _renderAuftraegeJobs(container, jobs, isProvider) {
     } else if (alreadyConfirmed) {
       actionHtml = '<div style="padding:10px;background:rgba(102,187,106,0.1);border-radius:8px;color:#388e3c;font-size:13px;text-align:center"><span class="material-icons-round" style="vertical-align:middle;font-size:16px">check_circle</span> Deinerseits best&auml;tigt</div>';
     } else {
-      actionHtml = '<div style="padding:10px;background:var(--bg-alt);border-radius:8px;color:var(--text-light);font-size:13px;text-align:center">' + (stage === 'abgeschlossen' ? 'Auftrag erf&uuml;llt' : 'Warten auf n&auml;chsten Schritt') + '</div>';
+      var waitingText = stage === 'abgeschlossen'
+        ? 'Auftrag bezahlt'
+        : (stage === 'bestaetigt' ? 'Leistung erf&uuml;llt &ndash; Zahlung ausstehend' : 'Warten auf n&auml;chsten Schritt');
+      actionHtml = '<div style="padding:10px;background:var(--bg-alt);border-radius:8px;color:var(--text-light);font-size:13px;text-align:center">' + waitingText + '</div>';
     }
 
     html += '<div style="background:var(--bg);border:1px solid var(--border);border-radius:14px;overflow:hidden;box-shadow:var(--shadow-sm)">' +
@@ -750,13 +826,14 @@ function confirmAuftragProvider(projectId, cardId) {
   var card = (proj.cards || []).find(function(c){ return c.id === cardId; });
   if (!card) return;
   card.providerConfirmedAt = new Date().toISOString();
-  if (card.userConfirmedAt && card.stage === 'bestaetigt') {
-    card.stage = 'abgeschlossen';
+  if (card.userConfirmedAt && card.stage === 'angebot') {
     card.fulfilledAt = new Date().toISOString();
+    card.stage = _cardHasConfirmedPayment(card) ? 'abgeschlossen' : 'bestaetigt';
     showToast('Auftrag beidseitig best\u00e4tigt – erf\u00fcllt!', 'verified');
   } else {
     showToast('Best\u00e4tigung gespeichert. Wartet auf Kunden-Best\u00e4tigung.', 'hourglass_top');
   }
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   _saveBoardProjects();
   renderAuftraegePage();
   _refreshBoardPageIfActive();
@@ -816,9 +893,8 @@ function _refreshBoardPageIfActive() {
 }
 
 /**
- * Provider nimmt einen gebuchten Auftrag an → Zahlung wird freigegeben.
- * Setzt die Karte auf „Bezahlt" (bestaetigt) und erfasst die
- * Plattformprovision plus voraussichtliche Auszahlung.
+ * Provider nimmt einen gebuchten Auftrag an. Die Karte bleibt „Gebucht",
+ * bis beide Seiten die Erbringung bestätigen. Zahlung folgt danach.
  * Der Kunde sieht die Statusänderung beim nächsten Sync automatisch.
  */
 function acceptAuftragProvider(projectId, cardId) {
@@ -841,11 +917,8 @@ function acceptAuftragProvider(projectId, cardId) {
 
   var nowIso = new Date().toISOString();
   card.providerAcceptedAt = nowIso;
-  card.stage = 'bestaetigt';
-  card.paidAt = nowIso;
-  card.paymentStatus = 'Bezahlt';
-  if (!card.paymentMethod) card.paymentMethod = 'Stripe';
-  card.paidAmount = priceNum;
+  card.stage = 'angebot';
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   card.grossAmount = payout.grossAmount;
   card.stripeFeeAmount = payout.stripeFeeAmount;
   card.stripeFeePaidBy = payout.stripeFeePaidBy;
@@ -1142,8 +1215,8 @@ function _renderAuftragsboardSectionHtml(state) {
   });
 
   var pendingCount = jobs.filter(function(j){ return (j.card.stage === 'angebot') && !j.card.providerAcceptedAt; }).length;
-  var openCount    = jobs.filter(function(j){ return j.card.stage === 'bestaetigt' && !j.card.providerConfirmedAt; }).length;
-  var doneCount    = jobs.filter(function(j){ return j.card.stage === 'abgeschlossen'; }).length;
+  var openCount    = jobs.filter(function(j){ return j.card.stage === 'angebot' && !!j.card.providerAcceptedAt && !j.card.providerConfirmedAt; }).length;
+  var doneCount    = jobs.filter(function(j){ return j.card.stage === 'bestaetigt' || j.card.stage === 'abgeschlossen'; }).length;
 
   var headerHtml =
     '<div class="board-section-header">' +
@@ -1174,8 +1247,8 @@ function _renderAuftragsboardSectionHtml(state) {
       headerHtml +
       '<div class="board-section-empty">' +
         '<span class="material-icons-round">inbox</span>' +
-        '<p><strong>Noch keine bezahlten Auftr&auml;ge.</strong></p>' +
-        '<p style="font-size:13px;margin-top:-4px">Sobald ein Kunde eines deiner Angebote verbindlich bucht und bezahlt, erscheint sein Event-Board hier &ndash; mit allen Infos, die du f&uuml;r die Erbringung brauchst.</p>' +
+        '<p><strong>Noch keine gebuchten Auftr&auml;ge.</strong></p>' +
+        '<p style="font-size:13px;margin-top:-4px">Sobald ein Kunde eines deiner Angebote verbindlich bucht, erscheint sein Event-Board hier &ndash; mit allen Infos, die du f&uuml;r die Erbringung brauchst.</p>' +
         '<div class="board-section-empty-hints">' +
           '<div class="board-section-hint"><span class="material-icons-round">sync</span>Gerade gebucht worden? Tippe auf <strong>&bdquo;Aktualisieren&ldquo;</strong> &ndash; der Kunde synchronisiert sein Board ggf. erst nach wenigen Sekunden.</div>' +
           '<div class="board-section-hint"><span class="material-icons-round">storefront</span>Keine Auftr&auml;ge erhalten? Pr&uuml;fe, ob deine Angebote sichtbar sind und dein <strong>Stripe-Auszahlungskonto</strong> aktiv ist.</div>' +
@@ -1233,16 +1306,16 @@ function _renderAuftragsboardCardHtml(j) {
   var esc = _escHtml;
   var c = j.card, p = j.project, l = j.listing;
   var stage = c.stage || 'geplant';
-  var stageLabels = { angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erf\u00fcllt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
-  var stageColors = { angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
+  var stageLabels = { angebot:'Gebucht', bestaetigt:'Erf\u00fcllt', abgeschlossen:'Bezahlt', geplant:'Geplant', kontaktiert:'Kontaktiert' };
+  var stageColors = { angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699', geplant:'#9E9E9E', kontaktiert:'#FF9800' };
   var color = stageColors[stage] || '#9E9E9E';
   var priceNum = parseFloat(c.price) || 0;
   var priceStr = priceNum ? priceNum.toFixed(2).replace(/\.00$/, '') + ' \u20ac' : '\u2014';
   var serviceTitle = (l && l.title) || c.listingTitle || c.name || 'Auftrag';
   var category = (l && (l.categoryLabel || l.category)) || c.category || '';
   var canAccept = stage === 'angebot' && !c.providerAcceptedAt;
-  var canConfirm = stage === 'bestaetigt' && !c.providerConfirmedAt;
-  var alreadyConfirmed = !!c.providerConfirmedAt && stage !== 'abgeschlossen';
+  var canConfirm = stage === 'angebot' && !!c.providerAcceptedAt && !c.providerConfirmedAt;
+  var alreadyConfirmed = !!c.providerConfirmedAt && stage === 'angebot';
   var isRemote = !!j.remote;
 
   var actionHtml = '';
@@ -1265,9 +1338,13 @@ function _renderAuftragsboardCardHtml(j) {
     actionHtml = '<div class="board-auftrag-status board-auftrag-status--waiting">' +
       '<span class="material-icons-round">hourglass_top</span> Wartet auf Kunden-Best&auml;tigung' +
     '</div>';
+  } else if (stage === 'bestaetigt') {
+    actionHtml = '<div class="board-auftrag-status board-auftrag-status--done">' +
+      '<span class="material-icons-round">verified</span> Leistung erf&uuml;llt &ndash; Zahlung ausstehend' +
+    '</div>';
   } else if (stage === 'abgeschlossen') {
     actionHtml = '<div class="board-auftrag-status board-auftrag-status--done">' +
-      '<span class="material-icons-round">verified</span> Auftrag erf&uuml;llt' +
+      '<span class="material-icons-round">paid</span> Auftrag bezahlt' +
     '</div>';
   } else {
     actionHtml = '<div class="board-auftrag-status">Warten auf n&auml;chsten Schritt</div>';
@@ -1558,7 +1635,9 @@ function renderKanbanCard(card) {
   if (card.stage === 'kontaktiert') {
     stageBadge = '<div class="kc-waiting"><span class="material-icons-round">hourglass_top</span> Warten auf Antwort</div>';
   } else if (card.stage === 'angebot') {
-    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'angebot\')"><span class="material-icons-round">receipt_long</span> Jetzt buchen</button>';
+    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'angebot\')"><span class="material-icons-round">verified</span> Erbringung bestätigen</button>';
+  } else if (card.stage === 'bestaetigt') {
+    stageBadge = '<button class="kc-book-now" onclick="event.stopPropagation();openStageAdvanceModal(\''+card.id+'\',\'bestaetigt\')"><span class="material-icons-round">paid</span> Jetzt bezahlen</button>';
   }
   var _listImg = _cardListingImage(card);
   var _listTitle = _cardListingTitle(card);
@@ -1663,9 +1742,9 @@ function allowDrop(event) {
 // Protected stages: nur über Aktions-/Payment-Flow erreichbar, nicht per Drag&Drop.
 var _PROTECTED_STAGES = ['angebot','bestaetigt','abgeschlossen'];
 function _protectedStageMessage(stage) {
-  if (stage === 'angebot') return 'Diese Spalte wird nur über „Jetzt buchen“ befüllt – so bleibt die Buchung verbindlich.';
-  if (stage === 'bestaetigt') return 'Status „Bezahlt“ wird automatisch gesetzt, sobald der Dienstleister den Auftrag annimmt.';
-  if (stage === 'abgeschlossen') return 'Status „Erfüllt“ wird vom System gesetzt, wenn beide Seiten die Erbringung bestätigen.';
+  if (stage === 'angebot') return 'Status „Gebucht“ wird durch die Annahme des Dienstleisters gesetzt.';
+  if (stage === 'bestaetigt') return 'Status „Erfüllt“ wird gesetzt, wenn beide Seiten die Erbringung bestätigen.';
+  if (stage === 'abgeschlossen') return 'Status „Bezahlt“ wird ausschließlich nach bestätigter Zahlung gesetzt.';
   return 'Dieser Status wird vom System gesetzt.';
 }
 function dropCard(event, toStage) {
@@ -1769,18 +1848,10 @@ function _currentFlowBp() {
   return 'desktop';
 }
 
-// Liefert das gespeicherte Layout für den aktuellen Breakpoint.
-// Migriert die alte Einzel-Struktur `project.flowLayout` nach Desktop.
+// Die Prozessstruktur ist fachlich fest und darf nicht durch versehentliches
+// Ziehen dauerhaft zerlegt werden. Alte gespeicherte Koordinaten werden daher
+// bewusst ignoriert; Karten bleiben weiterhin zwischen Stages verschiebbar.
 function _getFlowLayoutForBp(project, bp) {
-  if (!project) return {};
-  if (project.flowLayouts && project.flowLayouts[bp] && typeof project.flowLayouts[bp] === 'object') {
-    return project.flowLayouts[bp];
-  }
-  // Legacy: alte Variante war ein einzelnes Layout ohne Breakpoint-Zuordnung.
-  // Wir nehmen an, dass diese für Desktop gedacht war.
-  if (!project.flowLayouts && project.flowLayout && bp === 'desktop' && typeof project.flowLayout === 'object') {
-    return project.flowLayout;
-  }
   return {};
 }
 
@@ -1845,8 +1916,8 @@ function _renderBoardFlowImpl() {
     { id: 'geplant',       label: 'Geplant',        color: '#9E9E9E', icon: 'schedule'     },
     { id: 'kontaktiert',   label: 'Kontaktiert',     color: '#FF9800', icon: 'mail'         },
     { id: 'angebot',       label: 'Gebucht',         color: '#AB47BC', icon: 'receipt_long' },
-    { id: 'bestaetigt',    label: 'Bezahlt',         color: '#00A699', icon: 'paid'         },
-    { id: 'abgeschlossen', label: 'Erfüllt',         color: '#FF385C', icon: 'verified'     }
+    { id: 'bestaetigt',    label: 'Erfüllt',         color: '#FF385C', icon: 'verified'     },
+    { id: 'abgeschlossen', label: 'Bezahlt',         color: '#00A699', icon: 'paid'         }
   ];
 
   var cards = project.cards || [];
@@ -1924,12 +1995,8 @@ function _renderBoardFlowImpl() {
   html += '<span class="flow-zoom-pct" id="flowZoomPct" role="button" tabindex="0" title="Zoom-Prozent eingeben" onclick="flowZoomPrompt()">100%</span>';
   html += '<button class="flow-tbtn" onclick="flowZoom(0.10)" title="Vergrößern (Ctrl + +)" aria-label="Vergrößern (Ctrl + +)"><span class="material-icons-round">add</span></button>';
   html += '<div class="flow-tb-divider"></div>';
-  html += '<button class="flow-tbtn" id="flowUndoBtn" onclick="flowUndo()" title="Rückgängig (Ctrl+Z)" aria-label="Rückgängig (Ctrl+Z)" disabled><span class="material-icons-round">undo</span></button>';
-  html += '<button class="flow-tbtn" id="flowRedoBtn" onclick="flowRedo()" title="Wiederherstellen (Ctrl+Y)" aria-label="Wiederherstellen (Ctrl+Y)" disabled><span class="material-icons-round">redo</span></button>';
-  html += '<div class="flow-tb-divider"></div>';
   html += '<button class="flow-tbtn" onclick="flowFitToScreen()" title="An Bildschirm anpassen" aria-label="An Bildschirm anpassen"><span class="material-icons-round">fit_screen</span></button>';
   html += '<button class="flow-tbtn" onclick="flowResetView()" title="Ansicht zurücksetzen" aria-label="Ansicht zurücksetzen"><span class="material-icons-round">center_focus_strong</span></button>';
-  html += '<button class="flow-tbtn" onclick="flowAutoLayout()" title="Struktur neu anordnen" aria-label="Struktur neu anordnen"><span class="material-icons-round">auto_awesome_motion</span></button>';
   html += '<button class="flow-tbtn" id="flowFullscreenBtn" onclick="toggleFlowFullscreen()" title="Vollbild"><span class="material-icons-round" id="flowFullscreenIcon">fullscreen</span></button>';
   html += '<div class="flow-tb-divider"></div>';
   // Progress ring
@@ -1978,12 +2045,12 @@ function _renderBoardFlowImpl() {
   html += '<svg class="flow-svg" id="flowSvg" xmlns="http://www.w3.org/2000/svg"></svg>';
 
   // Trigger node
-  html += '<div class="flow-col flow-drag-handle" data-col-id="start" style="' + colStyle('start') + '">';
-  html += '<div class="flow-node flow-node-trigger" data-nid="start" onclick="if(!_flowDragJustEnded)openFlowProjectModal();_flowDragJustEnded=false">';
+  html += '<div class="flow-col" data-col-id="start" style="' + colStyle('start') + '">';
+  html += '<div class="flow-node flow-node-trigger" data-nid="start" onclick="openFlowProjectModal()">';
   html += '<span class="material-icons-round" style="color:#FF385C;font-size:32px">celebration</span>';
   html += '<strong>' + esc(project.name || 'Event') + '</strong>';
   if (project.date) html += '<small>' + esc(project.date) + '</small>';
-  html += '<span class="flow-node-edit-hint"><span class="material-icons-round" style="font-size:10px;vertical-align:middle">drag_indicator</span> Ziehen &nbsp;<span class="material-icons-round" style="font-size:10px;vertical-align:middle">edit</span> Klicken</span>';
+  html += '<span class="flow-node-edit-hint"><span class="material-icons-round" style="font-size:10px;vertical-align:middle">edit</span> Klicken zum Bearbeiten</span>';
   html += '</div>';
   html += '</div>';
 
@@ -2000,11 +2067,10 @@ function _renderBoardFlowImpl() {
 
     // Stage header node
     html += '<div class="flow-node flow-node-stage" data-nid="stage-' + stage.id + '">';
-    html += '<div class="flow-node-hdr flow-drag-handle" style="background:' + stage.color + ';border-radius:12px 12px 0 0">';
+    html += '<div class="flow-node-hdr" style="background:' + stage.color + ';border-radius:12px 12px 0 0">';
     html += '<span class="material-icons-round">' + stage.icon + '</span>';
     html += '<span>' + stage.label + '</span>';
     if (stageCards.length) html += '<span class="flow-node-badge">' + stageCards.length + '</span>';
-    html += '<span class="material-icons-round flow-drag-icon">drag_indicator</span>';
     html += '</div>';
     html += '<div class="flow-node-body">';
     if (stageCards.length) {
@@ -2059,9 +2125,9 @@ function _renderBoardFlowImpl() {
       if (card.startTime) html += '<span class="flow-prov-time"><span class="material-icons-round" style="font-size:11px">schedule</span>' + esc(card.startTime) + (card.endTime ? ' – ' + esc(card.endTime) : '') + '</span>';
       html += '</div>';
       html += '<div class="flow-prov-actions">';
-      var _saLabels = {geplant:'Kontaktieren',angebot:'Jetzt buchen',bestaetigt:'Erbringung bestätigen'};
-      var _saIcons  = {geplant:'forum',angebot:'receipt_long',bestaetigt:'verified'};
-      var _saColors = {geplant:'#42a5f5',angebot:'#66bb6a',bestaetigt:'#FF385C'};
+      var _saLabels = {geplant:'Kontaktieren',angebot:'Erbringung bestätigen',bestaetigt:'Jetzt bezahlen'};
+      var _saIcons  = {geplant:'forum',angebot:'verified',bestaetigt:'paid'};
+      var _saColors = {geplant:'#42a5f5',angebot:'#FF385C',bestaetigt:'#00A699'};
       if (stage.id === 'kontaktiert') {
         // Locked: waiting for provider response
         html += '<button class="flow-prov-action-btn flow-prov-waiting" style="--sa-clr:#FF9800;opacity:0.85;cursor:default" onclick="event.stopPropagation();openStageAdvanceModal(\'' + card.id + '\',\'' + stage.id + '\')">';
@@ -2085,7 +2151,7 @@ function _renderBoardFlowImpl() {
   });
 
   // End node
-  html += '<div class="flow-col flow-drag-handle" data-col-id="end" style="' + colStyle('end') + '">';
+  html += '<div class="flow-col" data-col-id="end" style="' + colStyle('end') + '">';
   html += '<div class="flow-node flow-node-end" data-nid="end">';
   html += '<span class="material-icons-round" style="color:#4CAF50;font-size:32px">check_circle</span>';
   html += '<strong>Event fertig!</strong>';
@@ -2201,9 +2267,7 @@ function _renderBoardFlowImpl() {
       // haengen und man kann auf Handy nicht bis ganz nach unten scrollen.
       try { _flowApplyZoom(_flowZoom, true); } catch(_) {}
     }
-    _drawFlowConnections(); _initFlowDrag(); _initFlowZoomPan();
-    // Initialer History-Eintrag (idempotent), Buttons aktualisieren
-    try { _flowPushHistory(); _flowUpdateUndoButtons(); } catch(_) {}
+    _drawFlowConnections(); _initFlowZoomPan();
     // Auf Mobile IMMER neu fitten + zum Start scrollen, damit der Nutzer
     // den Start-Node sofort im Fokus hat (und nicht im leeren Raum landet).
     if (_isMobile) {
@@ -2251,7 +2315,6 @@ function _renderBoardFlowImpl() {
 
 /* ─── Flow view extra modals ─────────────────────────────── */
 function openFlowProjectModal() {
-  if (_flowDragJustEnded) { _flowDragJustEnded = false; return; }
   if (!_activeBoardId) return;
   var project = _boardProjects.find(function(p) { return p.id === _activeBoardId; });
   if (!project) return;
@@ -2311,8 +2374,8 @@ function openFlowBudgetModal() {
     { id: 'geplant', label: 'Geplant', color: '#9E9E9E' },
     { id: 'kontaktiert', label: 'Kontaktiert', color: '#FF9800' },
     { id: 'angebot', label: 'Gebucht', color: '#AB47BC' },
-    { id: 'bestaetigt', label: 'Bezahlt', color: '#00A699' },
-    { id: 'abgeschlossen', label: 'Erfüllt', color: '#FF385C' }
+    { id: 'bestaetigt', label: 'Erfüllt', color: '#FF385C' },
+    { id: 'abgeschlossen', label: 'Bezahlt', color: '#00A699' }
   ];
 
   var breakdown = stagesMeta.map(function(s) {
@@ -2564,8 +2627,8 @@ function openFlowCardModal(cardId) {
 
   var stageOptions = [
     { id: 'geplant', label: 'Geplant' }, { id: 'kontaktiert', label: 'Kontaktiert' },
-    { id: 'angebot', label: 'Gebucht' }, { id: 'bestaetigt', label: 'Bezahlt' },
-    { id: 'abgeschlossen', label: 'Erfüllt' }
+    { id: 'angebot', label: 'Gebucht' }, { id: 'bestaetigt', label: 'Erfüllt' },
+    { id: 'abgeschlossen', label: 'Bezahlt' }
   ].map(function(s) {
     return '<option value="' + s.id + '"' + (s.id === card.stage ? ' selected' : '') + '>' + s.label + '</option>';
   }).join('');
@@ -2577,17 +2640,14 @@ function openFlowCardModal(cardId) {
         '<input type="number" id="fcPrice" value="' + _paidAmount + '" readonly /></div>'
     : '<div class="form-group"><label>Preis (€)</label><input type="number" id="fcPrice" value="' + (card.price || '') + '" min="0" step="1" /></div>';
 
-  // Stage nach Zahlung nur noch vorwärts auf "abgeschlossen" erlaubt
+  // Nach einer Zahlung ist die Stage unveränderlich. Vorab bezahlte Karten
+  // bleiben bis zur beidseitigen Erfüllungsbestätigung unter „Gebucht“.
   var _stageField = _isPaid
     ? (function() {
-        var allowed = ['bestaetigt', 'abgeschlossen'];
         return '<div class="form-group"><label>Status / Stage <span class="fc-locked-hint"><span class="material-icons-round">lock</span> Zahlung abgeschlossen</span></label>' +
-          '<select id="fcStage">' +
-            allowed.map(function(s) {
-              var label = s === 'bestaetigt' ? 'Bezahlt' : 'Erfüllt';
-              return '<option value="' + s + '"' + (s === card.stage ? ' selected' : '') + '>' + label + '</option>';
-            }).join('') +
-          '</select></div>';
+          '<select id="fcStage" disabled><option value="' + _escHtml(card.stage) + '">' +
+            _escHtml((FLOW_STAGE_LABELS && FLOW_STAGE_LABELS[card.stage]) || card.stage) +
+          '</option></select></div>';
       })()
     : '<div class="form-group"><label>Status / Stage</label><select id="fcStage">' + stageOptions + '</select></div>';
 
@@ -2635,12 +2695,8 @@ function _saveFlowCard(event, cardId) {
   card.endTime   = document.getElementById('fcTimeEnd') ? document.getElementById('fcTimeEnd').value : '';
   var _newStage = document.getElementById('fcStage').value;
   if (_isPaid) {
-    // Nach Zahlung: Stage darf nur noch auf 'abgeschlossen' gehen
-    if (_newStage !== card.stage && !(['bestaetigt','abgeschlossen'].includes(_newStage) && ['bestaetigt','abgeschlossen'].includes(card.stage))) {
-      showToast('Nach Zahlung ist nur noch "Erfüllt" als nächste Stage erlaubt.', 'warning');
-      return;
-    }
-    card.stage = _newStage;
+    // Zahlungsstatus und Prozessstand dürfen nicht manuell verfälscht werden.
+    card.stage = card.stage;
   } else if (typeof _PROTECTED_STAGES !== 'undefined' && _PROTECTED_STAGES.indexOf(_newStage) !== -1 && card.stage !== _newStage) {
     showToast(_protectedStageMessage(_newStage), 'warning');
   } else {
@@ -2721,4 +2777,3 @@ function _sendInvoiceNotification(card, project, listing) {
     return Promise.reject(e);
   }
 }
-

--- a/js/modules/board/41-flow-zahlung.js
+++ b/js/modules/board/41-flow-zahlung.js
@@ -58,7 +58,7 @@ function _applyInstantBookingSuccess(info, res) {
     id: 'bc_' + Date.now(),
     name: info.title || 'Direktbuchung',
     category: info.category || '',
-    stage: 'bestaetigt',
+    stage: 'angebot',
     price: info.amount,
     listingId: info.listingId,
     listingImage: info.image || '',
@@ -70,7 +70,8 @@ function _applyInstantBookingSuccess(info, res) {
     bookedAt: nowIso, invoiceSentAt: nowIso, paidAt: nowIso,
     paidAmount: info.amount, paymentMethod: 'Stripe',
     paymentIntentId: piId, paymentReference: piId,
-    paymentStatus: 'paid', createdAt: nowIso
+    paymentStatus: 'paid', providerAcceptedAt: nowIso, createdAt: nowIso,
+    _stageModel: EB_BOARD_STAGE_MODEL_VERSION
   };
   proj.cards = proj.cards || [];
   proj.cards.push(card);
@@ -106,7 +107,10 @@ function _applyCardPaymentSuccess(cardId, projectId, amount, res) {
   card.paymentIntentId = piId;
   card.paymentReference = piId;
   card.paymentStatus = 'paid';
-  card.stage = 'bestaetigt';
+  // Bezahlt ist die letzte Prozessstufe. Wurde vorab bezahlt, bleibt die
+  // Karte bis zur beidseitigen Erfüllungsbestätigung unter „Gebucht“.
+  card.stage = card.fulfilledAt ? 'abgeschlossen' : 'angebot';
+  card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
   var listing = (typeof LISTINGS !== 'undefined' ? LISTINGS : []).find(function(l) { return l.id === card.listingId; });
   try { _sendInvoiceNotification(card, project, listing).catch(function() {}); } catch (e) {}
   try { _saveBoardProjects && _saveBoardProjects({ immediate: true }); } catch (e) {}
@@ -263,7 +267,8 @@ function _handleStripeReturn() {
     card.paymentMethod = 'Stripe';
     card.paymentReference = sessionId || card.paymentReference || '';
     card.stripePending = false;
-    if (card.stage === 'angebot') card.stage = 'bestaetigt';
+    if (card.fulfilledAt) card.stage = 'abgeschlossen';
+    card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
     try { _saveBoardProjects && _saveBoardProjects(); } catch(e) {}
     showToast('Zahlung via Stripe erfolgreich – Status: Bezahlt.', 'paid');
   } else if (status === 'cancel' && card) {
@@ -314,7 +319,8 @@ function _reconcileStripePayments() {
             card.paidAt           = card.paidAt || new Date((it.paid_at || 0) * 1000).toISOString();
             card.paidAmount       = card.paidAmount || ((it.amount || 0) / 100);
             card.stripePending    = false;
-            if (card.stage === 'angebot') card.stage = 'bestaetigt';
+            if (card.fulfilledAt) card.stage = 'abgeschlossen';
+            card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
             matched++;
           }
           acked.push(it.pi);
@@ -1255,7 +1261,7 @@ function _formatEuro(n) {
 
 /* ── Flow-Board Stage-Verschieben (Sheet + Drag&Drop) ──────────────────
  * Stages laufen strikt sequenziell:
- *   geplant → kontaktiert → angebot (Gebucht) → bestaetigt (Bezahlt) → abgeschlossen (Erfüllt)
+ *   geplant → kontaktiert → angebot (Gebucht) → bestaetigt (Erfüllt) → abgeschlossen (Bezahlt)
  * Logik:
  *   • Gleiche Stage  → ignorieren
  *   • +1 Schritt     → den vorhandenen Aktions-Flow für die AKTUELLE Stage öffnen
@@ -1264,9 +1270,9 @@ function _formatEuro(n) {
  *   • Rückwärts      → mit Bestätigung erlaubt; setzt nachgelagerte Marker zurück
  */
 var FLOW_STAGE_ORDER  = ['geplant','kontaktiert','angebot','bestaetigt','abgeschlossen'];
-var FLOW_STAGE_LABELS = { geplant:'Geplant', kontaktiert:'Kontaktiert', angebot:'Gebucht', bestaetigt:'Bezahlt', abgeschlossen:'Erfüllt' };
-var FLOW_STAGE_ICONS  = { geplant:'schedule', kontaktiert:'mail', angebot:'receipt_long', bestaetigt:'paid', abgeschlossen:'verified' };
-var FLOW_STAGE_COLORS = { geplant:'#9E9E9E', kontaktiert:'#FF9800', angebot:'#AB47BC', bestaetigt:'#00A699', abgeschlossen:'#FF385C' };
+var FLOW_STAGE_LABELS = { geplant:'Geplant', kontaktiert:'Kontaktiert', angebot:'Gebucht', bestaetigt:'Erfüllt', abgeschlossen:'Bezahlt' };
+var FLOW_STAGE_ICONS  = { geplant:'schedule', kontaktiert:'mail', angebot:'receipt_long', bestaetigt:'verified', abgeschlossen:'paid' };
+var FLOW_STAGE_COLORS = { geplant:'#9E9E9E', kontaktiert:'#FF9800', angebot:'#AB47BC', bestaetigt:'#FF385C', abgeschlossen:'#00A699' };
 
 function openStageMoveSheet(cardId) {
   var project = _boardProjects.find(function(p){ return p.id === _activeBoardId; });
@@ -1340,6 +1346,10 @@ function _attemptMoveCardStage(cardId, targetStage) {
   }
   // 3) Rückwärts → mit Bestätigung erlauben (Korrektur)
   if (tgtIdx < curIdx) {
+    if (_cardHasConfirmedPayment(card)) {
+      showToast('Eine bestätigte Zahlung kann nicht auf eine frühere Stage zurückgesetzt werden.', 'lock');
+      return;
+    }
     var ok = window.confirm('Karte von „' + FLOW_STAGE_LABELS[current] + '" zurück auf „' + FLOW_STAGE_LABELS[targetStage] + '" setzen?\n\nBereits gesetzte Bestätigungen ab dieser Stage werden zurückgesetzt.');
     if (!ok) return;
     card.stage = targetStage;
@@ -1410,8 +1420,8 @@ function openStageAdvanceModal(cardId, currentStage) {
   var card = (project.cards || []).find(function(c) { return c.id === cardId; });
   if (!card) return;
 
-  var titles = {geplant:'Kontaktieren',kontaktiert:'Warten auf Antwort',angebot:'Jetzt buchen',bestaetigt:'Erbringung bestätigen'};
-  var icons  = {geplant:'forum',kontaktiert:'hourglass_top',angebot:'receipt_long',bestaetigt:'verified'};
+  var titles = {geplant:'Kontaktieren',kontaktiert:'Warten auf Antwort',angebot:'Erbringung bestätigen',bestaetigt:'Jetzt bezahlen'};
+  var icons  = {geplant:'forum',kontaktiert:'hourglass_top',angebot:'verified',bestaetigt:'paid'};
   var title  = titles[currentStage] || 'Weiter';
   var icon   = icons[currentStage] || 'arrow_forward';
 
@@ -1532,19 +1542,18 @@ function openStageAdvanceModal(cardId, currentStage) {
         'onclick="this.closest(\'.sa-overlay\').remove();navigateTo(\'messages\');' +
         (card.conversationId ? 'setTimeout(function(){try{openChat(' + parseInt(card.conversationId, 10) + ')}catch(e){}},300)' : '') +
         '"><span class="material-icons-round">forum</span> Chat öffnen</button>';
-  } else if (currentStage === 'angebot') {
-    // Stage "Angebot erhalten" → Anbieter hat Ja gesagt → jetzt verbindlich buchen.
-    // Rechnung wird angestoßen (E-Mail an User, Anbieter, kontakt@eventbörse.de).
+  } else if (currentStage === 'bestaetigt') {
+    // Stage „Erfüllt“ → nach beidseitiger Bestätigung sicher bezahlen.
     var _bookPrice = (_listing && _listing.price) || card.price || '';
     var _bookEventDate = (project && project.date) ? _formatDateDe(project.date) : '—';
     fieldsHtml = '' +
       '<div class="sa-info-card" style="background:linear-gradient(135deg,rgba(102,187,106,0.14),rgba(102,187,106,0.04));border:1px solid rgba(102,187,106,0.35);border-radius:12px;padding:14px;margin-bottom:12px">' +
         '<div style="display:flex;gap:10px;align-items:center;margin-bottom:8px">' +
           '<span class="material-icons-round" style="color:#66bb6a">check_circle</span>' +
-          '<strong>Angebot erhalten – jetzt buchen!</strong>' +
+          '<strong>Leistung erfüllt – jetzt bezahlen</strong>' +
         '</div>' +
         '<div style="font-size:13px;color:var(--text-light);line-height:1.5">' +
-          'Der Anbieter hat deine Anfrage angenommen. Mit dem Buchen wird eine Rechnung erstellt und automatisch an <strong>dich</strong>, den <strong>Anbieter</strong> ' +
+          'Beide Seiten haben die Erbringung bestätigt. Mit der Zahlung wird eine Rechnung erstellt und automatisch an <strong>dich</strong>, den <strong>Anbieter</strong> ' +
           'und <strong>eventb&ouml;rse.de</strong> gesendet — f&uuml;r volle Transparenz.' +
         '</div>' +
       '</div>' +
@@ -1556,8 +1565,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       '<input id="saBookPrice" type="number" class="sa-input" step="1" min="0" value="' + _escHtml(String(_bookPrice)) + '">' +
       '<label class="sa-label">Anmerkung f&uuml;r Rechnung <small>(optional)</small></label>' +
       '<textarea id="saBookNote" class="sa-input" rows="2" placeholder="Uhrzeit, Adresse, Besonderheiten…"></textarea>';
-  } else if (currentStage === 'bestaetigt') {
-    // Stage "Bezahlt" → "Erfüllt": Dual-Confirmation am Event-Tag.
+  } else if (currentStage === 'angebot') {
+    // Stage „Gebucht“ → „Erfüllt“: Dual-Confirmation am Event-Tag.
     var _hasProvConfirm = !!card.providerConfirmedAt;
     var _hasUserConfirm = !!card.userConfirmedAt;
     fieldsHtml = '' +
@@ -1787,8 +1796,8 @@ function openStageAdvanceModal(cardId, currentStage) {
     });
   }
 
-  // ── Review-Widget (bestaetigt stage) ──
-  if (currentStage === 'bestaetigt') {
+  // ── Review-Widget (Gebucht → Erfüllt) ──
+  if (currentStage === 'angebot') {
     var _saStarsEl = document.getElementById('saStars');
     var _saRatingInput = document.getElementById('saRating');
     var _saRatingLabel = document.getElementById('saRatingLabel');
@@ -1872,8 +1881,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       // Warten auf Antwort – kein Submit-Action nötig, einfach schließen.
       overlay.remove();
       return;
-    } else if (currentStage === 'angebot') {
-      // Angebot erhalten → echte Stripe-Zahlung starten.
+    } else if (currentStage === 'bestaetigt') {
+      // Leistung erfüllt → echte Stripe-Zahlung starten.
       var _bp = parseFloat((document.getElementById('saBookPrice') || {}).value);
       if (!isNaN(_bp) && _bp > 0) card.price = _bp;
       card.bookingNote = (document.getElementById('saBookNote') || {}).value || '';
@@ -1918,8 +1927,8 @@ function openStageAdvanceModal(cardId, currentStage) {
       });
       });
       return; // Submit-Handler hier beenden – Rest übernimmt onSuccess.
-    } else if (currentStage === 'bestaetigt') {
-      // Stage "Bezahlt" → "Erfuellt": Dual-Confirm (User + Dienstleister)
+    } else if (currentStage === 'angebot') {
+      // Stage „Gebucht“ → „Erfüllt“: Dual-Confirm (User + Dienstleister)
       var _userOk = !!(document.getElementById('saUserConfirm') || {}).checked;
       var _ratingVal = parseInt((document.getElementById('saRating') || {}).value) || 0;
       var _commentVal = ((document.getElementById('saComment') || {}).value || '').trim();
@@ -1981,7 +1990,7 @@ function openStageAdvanceModal(cardId, currentStage) {
               showToast('Bewertung konnte nicht gesendet werden (Netzwerk).', 'error');
             });
         }
-        showToast('Leistung beidseitig best\u00e4tigt – Projekt abgeschlossen!', 'verified');
+        showToast('Leistung beidseitig best\u00e4tigt – jetzt kann bezahlt werden.', 'verified');
       }
     }
 
@@ -1989,7 +1998,12 @@ function openStageAdvanceModal(cardId, currentStage) {
     if (_advance) {
       var stagesOrder = ['geplant','kontaktiert','angebot','bestaetigt','abgeschlossen'];
       var idx = stagesOrder.indexOf(currentStage);
-      if (idx >= 0 && idx < stagesOrder.length - 1) card.stage = stagesOrder[idx + 1];
+      if (idx >= 0 && idx < stagesOrder.length - 1) {
+        card.stage = (currentStage === 'angebot' && card.fulfilledAt && _cardHasConfirmedPayment(card))
+          ? 'abgeschlossen'
+          : stagesOrder[idx + 1];
+      }
+      card._stageModel = EB_BOARD_STAGE_MODEL_VERSION;
     }
 
     _saveBoardProjects();
@@ -3675,4 +3689,3 @@ function _getProjectChecklist(project) {
   var saved = Array.isArray(project.checklist) ? project.checklist : [];
   return saved.filter(function(it){ return it && it.text; });
 }
-

--- a/js/modules/board/42-guide-social-feed.js
+++ b/js/modules/board/42-guide-social-feed.js
@@ -91,7 +91,7 @@ function _guideSteps(project) {
     // Ein Step gilt als erledigt, wenn abgehakt ODER der Dienstleister
     // dafür bereits fest gebucht/abgeschlossen ist.
     var done = doneMap[text.toLowerCase()] === true ||
-      cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
+      cardStage === 'angebot' || cardStage === 'bestaetigt' || cardStage === 'abgeschlossen';
     // Empfohlene Deadline: Eventdatum minus Vorlaufzeit (nur mit Datum).
     var deadline = null, overdue = false;
     if (eventDate) {

--- a/js/modules/core/02-router-navigation.js
+++ b/js/modules/core/02-router-navigation.js
@@ -535,9 +535,9 @@ function navigateTo(page, data, skipHistory) {
 var EB_BOARD_STAGE_INFO = {
   geplant:       { label: 'Im Plan',      icon: 'assignment',      cls: 'geplant' },
   kontaktiert:   { label: 'Kontaktiert',  icon: 'forum',           cls: 'kontaktiert' },
-  angebot:       { label: 'Angebot',      icon: 'request_quote',   cls: 'angebot' },
-  bestaetigt:    { label: 'Gebucht',      icon: 'event_available', cls: 'gebucht' },
-  abgeschlossen: { label: 'Abgeschlossen',icon: 'task_alt',        cls: 'abgeschlossen' }
+  angebot:       { label: 'Gebucht',      icon: 'event_available', cls: 'angebot' },
+  bestaetigt:    { label: 'Erfüllt',      icon: 'verified',        cls: 'erfuellt' },
+  abgeschlossen: { label: 'Bezahlt',      icon: 'paid',            cls: 'bezahlt' }
 };
 var EB_BOARD_STAGE_ORDER = ['geplant', 'kontaktiert', 'angebot', 'bestaetigt', 'abgeschlossen'];
 

--- a/js/modules/payments/44-kv-buchung.js
+++ b/js/modules/payments/44-kv-buchung.js
@@ -228,7 +228,7 @@ function _startOfferPayment(msgId, amount) {
 
   // Doppelzahlungs-Schutz: dieses Listing ist bereits verbindlich gebucht
   // und bezahlt → keine zweite Zahlung starten.
-  if (rec.card.paymentStatus === 'paid' || rec.card.stage === 'bestaetigt' || rec.card.stage === 'abgeschlossen') {
+  if (_cardHasConfirmedPayment(rec.card)) {
     showToast('Bereits verbindlich gebucht & bezahlt — siehe Planungsboard.', 'info');
     try { navigateTo('board'); } catch (e) {}
     return;
@@ -325,4 +325,3 @@ function _recordBookingToBoard(opts) {
   _saveBoardProjects({ immediate: true });
   return { projectId: project.id, card: card };
 }
-

--- a/js/modules/ui/52-release-vision.js
+++ b/js/modules/ui/52-release-vision.js
@@ -18,7 +18,7 @@ function _rvPrice(job) {
 }
 function _rvStatus(job) {
   var c = job && job.card || {};
-  return c.stage || (c.providerConfirmedAt ? 'abgeschlossen' : (c.paidAt || c.paymentIntentId ? 'bestaetigt' : 'angebot'));
+  return c.stage || ((c.paidAt || c.paymentIntentId) ? 'abgeschlossen' : (c.fulfilledAt ? 'bestaetigt' : 'angebot'));
 }
 function _rvDate(job) {
   var raw = (job.project && job.project.date) || (job.card && (job.card.bookedAt || job.card.createdAt)) || '';
@@ -51,9 +51,10 @@ function _renderBusinessCockpitData(jobs, offline) {
   var root = document.getElementById('businessCockpit');
   if (!root) return;
   _businessJobs = jobs || [];
-  var paidStages = { bestaetigt:1, abgeschlossen:1 };
   var booked = _businessJobs.reduce(function(sum,j){ return sum + _rvPrice(j); }, 0);
-  var paid = _businessJobs.reduce(function(sum,j){ return sum + (paidStages[_rvStatus(j)] ? _rvPrice(j) : 0); }, 0);
+  var paid = _businessJobs.reduce(function(sum,j){
+    return sum + (_cardHasConfirmedPayment(j && j.card) ? _rvPrice(j) : 0);
+  }, 0);
   var open = _businessJobs.filter(function(j){ return _rvStatus(j) !== 'abgeschlossen'; }).length;
   var fee = paid * 0.03;
   var paidOut = Math.max(0, paid - fee);
@@ -128,7 +129,7 @@ function _businessInvoiceTable(jobs) {
     return '<div class="business-invoice-row"><span><strong>' + _escHtml(id) + '</strong><small>' + _rvDate(j).toLocaleDateString('de-DE') + '</small></span><span>' + _escHtml(project) + '</span><span><i class="invoice-status ' + _escHtml(status) + '">' + _escHtml(_rvStageLabel(status)) + '</i></span><span>' + _rvMoney(_rvPrice(j)) + '</span><span><button class="btn-outline btn-sm" onclick="downloadBusinessInvoice(' + i + ')"><span class="material-icons-round">picture_as_pdf</span> Vorschau/PDF</button></span></div>';
   }).join('') + '</div>';
 }
-function _rvStageLabel(s){ return ({angebot:'Gebucht',bestaetigt:'Bezahlt',abgeschlossen:'Erfüllt',kontaktiert:'Kontaktiert',geplant:'Geplant'})[s] || s; }
+function _rvStageLabel(s){ return ({angebot:'Gebucht',bestaetigt:'Erfüllt',abgeschlossen:'Bezahlt',kontaktiert:'Kontaktiert',geplant:'Geplant'})[s] || s; }
 function _businessInvoiceNo(job,index){
   var prefix = currentUser && currentUser.taxProfile && currentUser.taxProfile.invoicePrefix || 'EB';
   var stable = String(job && job.card && job.card.id || job && job.project && job.project.id || index+1);

--- a/styles.css
+++ b/styles.css
@@ -3287,6 +3287,8 @@ body.dark-mode .ai-sug-chip:hover { background: rgba(255,56,92,0.15); }
 .board-status-badge.bsb-angebot       { background: #8b5cf6; }
 .board-status-badge.bsb-gebucht       { background: #16a34a; }
 .board-status-badge.bsb-abgeschlossen { background: #64748b; }
+.board-status-badge.bsb-erfuellt      { background: #FF385C; }
+.board-status-badge.bsb-bezahlt       { background: #00A699; }
 /* Auf der Browse-Karte: unten links im Bild (Badge oben links bleibt frei) */
 .board-status-badge.bsb-on-card {
   position: absolute;
@@ -10456,8 +10458,8 @@ body.dark-mode .bpc-delete-btn:hover {
 .bpp-stage.filled.stage-geplant       { background: #9E9E9E; }
 .bpp-stage.filled.stage-kontaktiert   { background: #FF9800; }
 .bpp-stage.filled.stage-angebot       { background: #AB47BC; }
-.bpp-stage.filled.stage-bestaetigt    { background: #00A699; }
-.bpp-stage.filled.stage-abgeschlossen { background: #FF385C; }
+.bpp-stage.filled.stage-bestaetigt    { background: #FF385C; }
+.bpp-stage.filled.stage-abgeschlossen { background: #00A699; }
 .board-project-footer {
   display: flex;
   justify-content: space-between;
@@ -11056,6 +11058,8 @@ body.dark-mode .bpc-edit-btn:hover { background: var(--primary); border-color: v
 .bguide-stage.bsb-angebot       { background: #8b5cf6; }
 .bguide-stage.bsb-gebucht       { background: #16a34a; }
 .bguide-stage.bsb-abgeschlossen { background: #64748b; }
+.bguide-stage.bsb-erfuellt      { background: #FF385C; }
+.bguide-stage.bsb-bezahlt       { background: #00A699; }
 .bguide-find {
   display: inline-flex;
   align-items: center;
@@ -11246,8 +11250,8 @@ body.dark-mode .bcl-add-form input { background: #1c1c1c; border-color: #2e2e2e;
 .dot-geplant      { background: #9E9E9E; }
 .dot-kontaktiert  { background: #FF9800; }
 .dot-angebot      { background: #AB47BC; }
-.dot-bestaetigt   { background: var(--accent); }
-.dot-abgeschlossen{ background: var(--primary); }
+.dot-bestaetigt   { background: var(--primary); }
+.dot-abgeschlossen{ background: var(--accent); }
 
 .kanban-col-count {
   margin-left: auto;

--- a/tests/e2e/board-flow.spec.js
+++ b/tests/e2e/board-flow.spec.js
@@ -1,0 +1,89 @@
+const { test, expect } = require('@playwright/test');
+const { openApp, expectNoPageErrors } = require('./helpers');
+
+test.describe('Board-Prozess', () => {
+  test('Prozessstruktur bleibt fest und zeigt Erfüllt vor Bezahlt', async ({ page }) => {
+    const errors = await openApp(page);
+
+    const state = await page.evaluate(() => {
+      isLoggedIn = true;
+      currentUser = { id: 4242, name: 'Board Test', role: 'Eventplaner', baseRole: 'Eventplaner' };
+      _activeBoardId = 'bp_locked';
+      _boardProjects = [{
+        id: 'bp_locked',
+        name: 'Festes Board',
+        date: '2026-09-12',
+        budget: 1000,
+        flowLayout: { bestaetigt: { x: 900, y: 420 } },
+        flowLayouts: {
+          desktop: {
+            geplant: { x: 90, y: 350 },
+            bestaetigt: { x: 900, y: 520 },
+            abgeschlossen: { x: 300, y: 680 },
+          },
+        },
+        cards: [
+          { id: 'c_booked', name: 'Gebuchte Leistung', stage: 'angebot', providerAcceptedAt: '2026-08-13T10:00:00Z', _stageModel: 2 },
+          { id: 'c_fulfilled', name: 'Erfüllte Leistung', stage: 'bestaetigt', fulfilledAt: '2026-08-13T11:00:00Z', _stageModel: 2 },
+          { id: 'c_paid', name: 'Bezahlte Leistung', stage: 'abgeschlossen', fulfilledAt: '2026-08-13T11:00:00Z', paymentIntentId: 'pi_test', paymentStatus: 'paid', _stageModel: 2 },
+        ],
+      }];
+
+      const view = document.getElementById('boardFlowView');
+      view.style.display = 'block';
+      renderBoardFlow();
+
+      const stageLabels = [...document.querySelectorAll('.flow-node-stage .flow-node-hdr > span:nth-child(2)')]
+        .map((el) => el.textContent.trim());
+      const stageTops = [...document.querySelectorAll('.flow-col[data-col-id]:not([data-col-id="start"]):not([data-col-id="end"])')]
+        .map((el) => el.style.top);
+      return {
+        stageLabels,
+        stageTops,
+        dragHandles: document.querySelectorAll('.flow-drag-handle').length,
+        dragIcons: document.querySelectorAll('.flow-drag-icon').length,
+        actions: [...document.querySelectorAll('.flow-prov-action-btn')].map((el) => el.textContent.trim()),
+      };
+    });
+
+    expect(state.stageLabels).toEqual(['Geplant', 'Kontaktiert', 'Gebucht', 'Erfüllt', 'Bezahlt']);
+    expect(new Set(state.stageTops).size, 'alte kaputte Koordinaten dürfen das Layout nicht beeinflussen').toBe(1);
+    expect(state.dragHandles, 'Prozessspalten dürfen nicht verschiebbar sein').toBe(0);
+    expect(state.dragIcons).toBe(0);
+    expect(state.actions.some((label) => label.includes('Erbringung bestätigen'))).toBe(true);
+    expect(state.actions.some((label) => label.includes('Jetzt bezahlen'))).toBe(true);
+    expectNoPageErrors(errors, 'festes Board-Layout');
+  });
+
+  test('alte Karten werden in die neue Reihenfolge migriert', async ({ page }) => {
+    const errors = await openApp(page);
+    const migrated = await page.evaluate(() => {
+      const projects = [{
+        id: 'legacy',
+        flowLayout: { bestaetigt: { x: 999, y: 999 } },
+        flowLayouts: { desktop: { abgeschlossen: { x: 10, y: 700 } } },
+        cards: [
+          { id: 'paid_open', stage: 'bestaetigt', paymentIntentId: 'pi_old', paymentStatus: 'paid' },
+          { id: 'fulfilled_paid', stage: 'abgeschlossen', fulfilledAt: '2026-08-12T10:00:00Z', paymentReference: 'pi_done', paymentStatus: 'paid' },
+          { id: 'fulfilled_unpaid', stage: 'abgeschlossen', fulfilledAt: '2026-08-12T10:00:00Z' },
+          { id: 'accepted_only', stage: 'bestaetigt', providerAcceptedAt: '2026-08-10T10:00:00Z', paidAt: '2026-08-10T10:00:00Z', paymentStatus: 'Bezahlt', paymentMethod: 'Stripe' },
+        ],
+      }];
+      const changed = _migrateBoardStageModel(projects);
+      return {
+        changed,
+        stages: projects[0].cards.map((card) => card.stage),
+        fakePaidCleared: !projects[0].cards[3].paymentStatus && !projects[0].cards[3].paidAt,
+        legacyLayoutRemoved: !projects[0].flowLayout && Object.keys(projects[0].flowLayouts).length === 0,
+        versions: projects[0].cards.map((card) => card._stageModel),
+      };
+    });
+
+    expect(migrated.changed).toBe(true);
+    expect(migrated.stages).toEqual(['angebot', 'abgeschlossen', 'bestaetigt', 'angebot']);
+    expect(migrated.fakePaidCleared).toBe(true);
+    expect(migrated.legacyLayoutRemoved).toBe(true);
+    expect(migrated.versions).toEqual([2, 2, 2, 2]);
+    expectNoPageErrors(errors, 'Board-Stage-Migration');
+  });
+});

--- a/vault/50-Evolution/AI-Gedaechtnis/Code-Beziehungen.md
+++ b/vault/50-Evolution/AI-Gedaechtnis/Code-Beziehungen.md
@@ -122,15 +122,13 @@ Dienstleister sendet Angebot (offer message)
     ↓
 Event-Planer akzeptiert (PUT /messages/{id}/offer-status)
     ↓
-Dienstleister sendet Rechnung (POST /send-invoice)
+Event stattgefunden → Board: "Erfüllt"
     ↓
 Event-Planer bezahlt (Stripe Checkout)
     ↓
 Webhook empfangen (POST /stripe/webhook)
     ↓
 Status Update → Board: "Bezahlt"
-    ↓
-Event stattgefunden → Board: "Erfüllt"
     ↓
 Event-Planer schreibt Bewertung (POST /reviews/{id})
 ```

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -403,6 +403,10 @@ YouTube-Transkripte (das Tor steht, es fehlt nur der Abholer).
   - [x] Provider ohne Inserate bleiben reine Profile: Profil-Fallbacks landen
     nicht mehr in `LISTINGS`, zählen als 0 und erzeugen keine Inseratkarte.
     Ein Smoke-Test bildet den konkreten Fall „Maria Heilig, `listings: []`“ ab.
+  - [x] Flow-Struktur ist unverrückbar: Prozessspalten ignorieren alte manuelle
+    Koordinaten und können nicht mehr versehentlich auseinandergezogen werden;
+    nur Dienstleisterkarten wechseln weiterhin die Stage. Die fachliche Abfolge
+    endet jetzt mit „Erfüllt → Bezahlt“ und migriert bestehende Karten defensiv.
 - [x] **KI-Änderungs-Guardrails operationalisieren** *(2026-08-04, OpenRouter-Autopilot)*
   - Vier getrennte Rollen: Scout → Architektur → Implementierung → unabhängiges Review.
   - Feste Whitelist kleiner Frontend-Dateien; max. 2 Dateien/260 Diff-Zeilen;


### PR DESCRIPTION
## Was geändert wurde

- Die Prozessspalten sind fest angeordnet und können nicht mehr versehentlich verschoben werden; Karten bleiben zwischen den Stufen beweglich.
- Gespeicherte, beschädigte Layout-Koordinaten werden beim Laden verworfen.
- Die fachliche Reihenfolge lautet jetzt `Geplant → Kontaktiert → Gebucht → Erfüllt → Bezahlt`.
- Zahlung und Statuslogik wurden angepasst: Erfüllung wird zuerst bestätigt, anschließend wird bezahlt.
- Bestehende Karten werden einmalig und anhand echter Zahlungs-/Erfüllungsnachweise migriert.
- Backend-Aktionen, Statusanzeigen, KPIs, Hilfetexte und Prozessdokumentation verwenden dasselbe Modell.

## Ursache

Die Überschriften der Prozessspalten waren als Drag-Handles verdrahtet. Ihre frei gesetzten Koordinaten wurden dauerhaft im Board gespeichert, wodurch die fachliche Prozessfolge optisch auseinandergezogen werden konnte.

## Wirkung

Das Board repariert alte, verschobene Layouts automatisch. Die Prozessstruktur ist nicht mehr zerstörbar; nur die eigentlichen Auftragskarten können weiter verschoben werden.

## Prüfung

- PHP-Syntaxprüfung: grün
- Generierungs- und Repository-Gate: grün
- Playwright: 286/289 im parallelen Gesamtlauf; die drei bekannten Dark-Mode-Race-Fälle anschließend seriell 4/4 grün
- Neue Board-Regressionstests: 2/2 grün
- `git diff --check`: grün