### PR TITLE
Verpflichtende KI-Transparenz für Inserate

### DIFF
--- a/app-shell.html
+++ b/app-shell.html
@@ -1332,6 +1332,7 @@
               <span id="detailLocation">Berlin, Deutschland</span>
             </span>
           </div>
+          <div id="detailAiDisclosure" class="detail-ai-disclosure" aria-live="polite"></div>
         </div>
         <div class="detail-gallery" id="detailGallery">
           <!-- Images loaded by JS -->
@@ -1344,6 +1345,7 @@
           </div>
           <button id="detailEditBtn" class="btn-primary btn-sm" style="display:none" onclick="editListing(currentListing?.id)"><span class="material-icons-round">edit</span> Bearbeiten</button>
           <button class="btn-outline" onclick="navigateTo('provider', currentListing?.providerId)">Profil ansehen</button>
+          <button id="detailReportBtn" class="btn-outline btn-sm" onclick="openListingReport()"><span class="material-icons-round">flag</span> Inhalt melden</button>
         </div>
         <div id="detailCollaborationSuggestions" class="detail-collaboration-suggestions" aria-live="polite"></div>
         <div class="detail-layout">
@@ -2348,6 +2350,28 @@
           <div class="form-section" id="step3">
             <h2><span class="fs-num">3</span> Fotos &amp; Galerie</h2>
             <p class="step-intro" id="clPhotosIntro">Inserate mit hochwertigen Fotos werden bis zu <strong>3&times; h&auml;ufiger</strong> angefragt. Lade mind. 3 Bilder hoch.</p>
+            <section class="ai-declaration" id="aiDisclosureSection" aria-labelledby="aiDisclosureHeading">
+              <div class="ai-declaration-head">
+                <span class="material-icons-round" aria-hidden="true">verified_user</span>
+                <div>
+                  <h3 id="aiDisclosureHeading">KI-Transparenz <span>Pflichtangabe</span></h3>
+                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Bei KI-Medien setzt Eventbörse zusätzlich ein sichtbares Wasserzeichen.</p>
+                </div>
+              </div>
+              <fieldset class="ai-declaration-group">
+                <legend>Text und Angaben</legend>
+                <label><input type="radio" name="createAiTextDisclosure" value="none" required onchange="_aiDisclosureFormChanged()"><span><strong>Ohne generative KI</strong><small>Text und Angaben selbst erstellt.</small></span></label>
+                <label><input type="radio" name="createAiTextDisclosure" value="assisted" onchange="_aiDisclosureFormChanged()"><span><strong>Mit KI unterstützt</strong><small>KI hat wesentliche Formulierungen bearbeitet.</small></span></label>
+                <label><input type="radio" name="createAiTextDisclosure" value="generated" onchange="_aiDisclosureFormChanged()"><span><strong>KI-generiert</strong><small>Text wurde ganz oder überwiegend mit KI erzeugt.</small></span></label>
+              </fieldset>
+              <fieldset class="ai-declaration-group">
+                <legend>Bilder und Medien</legend>
+                <label><input type="radio" name="createAiMediaDisclosure" value="none" required onchange="_aiDisclosureFormChanged()"><span><strong>Ohne generative KI</strong><small>Keine wesentliche KI-Erzeugung oder -Manipulation.</small></span></label>
+                <label><input type="radio" name="createAiMediaDisclosure" value="assisted" onchange="_aiDisclosureFormChanged()"><span><strong>KI-bearbeitet</strong><small>Medien wurden wesentlich mit KI verändert.</small></span></label>
+                <label><input type="radio" name="createAiMediaDisclosure" value="generated" onchange="_aiDisclosureFormChanged()"><span><strong>KI-generiert</strong><small>Medien wurden ganz oder überwiegend mit KI erzeugt.</small></span></label>
+              </fieldset>
+              <p class="ai-declaration-legal">Normale Farb-, Größen- oder Zuschnittkorrekturen gelten nicht als generative KI. Falsche Angaben können zur Entfernung führen. Details: <a href="#" onclick="navigateTo('upload');return false;">Upload-Richtlinie</a>.</p>
+            </section>
             <div class="upload-zone" id="uploadZone" onclick="document.getElementById('fileInput').click()">
               <span class="material-icons-round">cloud_upload</span>
               <h3>Bilder hochladen</h3>
@@ -2716,13 +2740,13 @@ Datum: ___________________________________________________
     <section id="page-community" class="page">
       <div class="container legal-page">
         <h1>Nutzungs- und Community-Richtlinien</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinien sind als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und werden mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinien sind als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und werden mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <p>Diese Richtlinien gelten verbindlich für alle Nutzer und erfüllen die AGB-Pflichtinhalte gemäß <strong>Art. 14 DSA</strong> (VO (EU) 2022/2065).</p>
         <h2>1. Grundsätze</h2>
         <ul><li>Respektvoller, sachlicher und professioneller Umgang.</li><li>Wahrhaftige Profil- und Leistungsangaben.</li><li>Keine Diskriminierung.</li><li>Beachtung des deutschen und europäischen Rechts.</li></ul>
         <h2>2. Verbotene Inhalte und Verhaltensweisen</h2>
-        <ul><li>Beleidigung, Verleumdung, Hassrede, Volksverhetzung.</li><li>Sexuell explizite oder pornografische Inhalte; Inhalte zum Nachteil Minderjähriger.</li><li>Verstoß gegen Urheber-, Marken-, Persönlichkeits- oder Datenschutzrechte.</li><li>Manipulation des Bewertungs- oder Rankingsystems (Fake-Bewertungen, Sockenpuppen).</li><li>Spam, Phishing, Malware, Identitätsdiebstahl.</li><li>Umgehung der Plattformfunktionen.</li><li>Scraping/Bots ohne Erlaubnis.</li></ul>
+        <ul><li>Beleidigung, Verleumdung, Hassrede, Volksverhetzung.</li><li>Sexuell explizite oder pornografische Inhalte; Inhalte zum Nachteil Minderjähriger.</li><li>Verstoß gegen Urheber-, Marken-, Persönlichkeits- oder Datenschutzrechte.</li><li>Manipulation des Bewertungs- oder Rankingsystems (Fake-Bewertungen, Sockenpuppen).</li><li>Nicht oder falsch deklarierte KI-generierte bzw. wesentlich KI-bearbeitete Texte, Bilder, Audio- oder Videoinhalte.</li><li>Spam, Phishing, Malware, Identitätsdiebstahl.</li><li>Umgehung der Plattformfunktionen.</li><li>Scraping/Bots ohne Erlaubnis.</li></ul>
         <h2>3. Profil- und Account-Regeln</h2>
         <p>Nur ein Account pro Person bzw. rechtlich eigenständigem Träger. Profilangaben müssen wahrhaftig, aktuell und vollständig sein. Demo-/Test-Profile (Beta-Betrieb) sind als solche zu kennzeichnen.</p>
         <h2>4. Kommunikationsregeln</h2>
@@ -2777,21 +2801,24 @@ Datum: ___________________________________________________
     <section id="page-upload" class="page">
       <div class="container legal-page">
         <h1>Upload- und Inhaltsrichtlinie / UGC-Lizenz</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Was sind Inhalte?</h2>
         <p>Profilbilder, Profilbeschreibungen, Logos, Texte, Bilder, Videos (z.&nbsp;B. Portfolio-Fotos, Eventfotos in Bewertungen), Audio (z.&nbsp;B. DJ-Mixe), sonstige hochgeladene Dateien.</p>
         <h2>2. Pflichten des Hochladenden</h2>
         <ul><li>Du verfügst über alle erforderlichen Rechte (Urheberrechte, Nutzungsrechte, Persönlichkeitsrechte, Markenrechte).</li><li>Einwilligung aller abgebildeten Personen (Art. 6, 9 DSGVO; KUG).</li><li>Bei Minderjährigen Einwilligung der Erziehungsberechtigten; im Zweifel keine Veröffentlichung.</li><li>Beachtung der Community-Richtlinien.</li></ul>
-        <h2>3. Lizenzeinräumung an die Plattform</h2>
+        <h2>3. KI-generierte und KI-bearbeitete Inhalte</h2>
+        <p>Beim Veröffentlichen ist getrennt für Text und Medien anzugeben, ob generative KI nicht genutzt, wesentlich unterstützend eingesetzt oder der Inhalt ganz bzw. überwiegend KI-generiert wurde. Normale Farb-, Größen- und Zuschnittkorrekturen zählen nicht als generative KI-Nutzung.</p>
+        <ul><li>KI-generierte und wesentlich KI-bearbeitete Medien erhalten auf Eventbörse ein dauerhaft sichtbares Wasserzeichen; neue lokale Bild-Uploads werden zusätzlich in den Bildpixeln gekennzeichnet.</li><li>Die Erklärung wird maschinenlesbar am Inserat und in der Schnittstelle gespeichert. Die Kennzeichnung muss beim Teilen oder Exportieren erhalten bleiben.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
+        <h2>4. Lizenzeinräumung an die Plattform</h2>
         <p>Mit dem Upload räumst du der Eventbörse UG (haftungsbeschränkt) ein einfaches, weltweites, zeitlich auf die Dauer der Profil-/Inhaltsverfügbarkeit auf der Plattform begrenztes, unentgeltliches und übertragbares Nutzungsrecht ein, deine Inhalte auf der Plattform öffentlich zugänglich zu machen, zu speichern, zu skalieren, zu transcodieren, in Vorschauen darzustellen und in Profilen, Suchergebnissen, Kommunikation und Bewertungen anzuzeigen. Eine Übertragung von Urheberrechten findet nicht statt; alle Rechte verbleiben beim Hochladenden.</p>
-        <h2>4. Recht zur Entfernung und Sperrung</h2>
+        <h2>5. Recht zur Entfernung und Sperrung</h2>
         <p>Inhalte können bei begründetem Verdacht eines Rechtsverstoßes oder Eingang einer Beschwerde nach DSA Art. 16 entfernt oder gesperrt werden; jeweils mit Statement of Reasons. Beschwerde nach DSA Art. 20 möglich.</p>
-        <h2>5. Verantwortung für Inhalte</h2>
-        <p>Die Plattform haftet als Diensteanbieter für fremde Inhalte erst ab Kenntnis (§§ 7–10 DDG). Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
-        <h2>6. Datenformate und Größenlimits</h2>
+        <h2>6. Verantwortung für Inhalte</h2>
+        <p>Der Hochladende bleibt für die Rechtmäßigkeit und Richtigkeit seiner Inhalte verantwortlich. Für fremde gespeicherte Inhalte gelten die Voraussetzungen des Art. 6 DSA; erhält die Plattform hinreichende Kenntnis von rechtswidrigen Inhalten, prüft sie die Meldung und sperrt oder entfernt rechtswidrige Inhalte zügig. Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
+        <h2>7. Datenformate und Größenlimits</h2>
         <ul><li>Bilder: JPG, PNG, WEBP — max. 10 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
-        <h2>7. Speicherort und Datenschutz</h2>
+        <h2>8. Speicherort und Datenschutz</h2>
         <p>Speicherung auf den IONOS-Servern in Deutschland. Verarbeitung gemäß Datenschutzerklärung. Bei Löschung des Accounts werden Inhalte gemäß Löschkonzept entfernt.</p>
       </div>
     </section>
@@ -2800,14 +2827,14 @@ Datum: ___________________________________________________
     <section id="page-dsa" class="page">
       <div class="container legal-page">
         <h1>DSA — Notice-and-Action-Verfahren</h1>
-        <p class="legal-date">Art. 16, 17, 22 VO (EU) 2022/2065 · Stand: 04. Mai 2026</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Dieses Verfahren ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Art. 16, 17, 22 VO (EU) 2022/2065 · Stand: 14. August 2026</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Dieses Verfahren ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Wer kann melden?</h2>
         <p>Jede natürliche oder juristische Person; Trusted Flagger (Art. 22 DSA); Behörden im Rahmen ihrer Zuständigkeit.</p>
         <h2>2. Was kann gemeldet werden?</h2>
         <p>Profile, Inhalte, Bewertungen, Nachrichten, Bilder, Videos. Mutmaßlich rechtswidrige Inhalte: Beleidigung, Verleumdung, Hassrede, Volksverhetzung, Urheber-/Marken-/Persönlichkeitsrechtsverletzung, Betrug, Phishing, Malware, jugendgefährdende Inhalte, Verstoß gegen JuSchG/JMStV, Schwarzarbeit, unzulässige Werbung.</p>
         <h2>3. Wie melden?</h2>
-        <ul><li>In-Product-Meldebutton „Inhalt melden" auf jedem Profil/Bewertung/Nachricht.</li><li>E-Mail an <strong>dsa-meldung@eventbörse.de</strong>.</li><li>Postalisch: Eventbörse UG (haftungsbeschränkt) i.&nbsp;G., Nonnenberger Str. 95a, 53639 Königswinter.</li></ul>
+        <ul><li>In-Product-Meldebutton „Inhalt melden" direkt an jedem Inserat; die genaue URL und Inserat-ID werden automatisch übernommen.</li><li>E-Mail an <strong>dsa-meldung@eventbörse.de</strong> für andere Inhalte oder ergänzende Unterlagen.</li><li>Postalisch: Eventbörse UG (haftungsbeschränkt) i.&nbsp;G., Nonnenberger Str. 95a, 53639 Königswinter.</li></ul>
         <h2>4. Pflichtangaben (Art. 16 Abs. 2 DSA)</h2>
         <ul><li>Begründung der Rechtswidrigkeit (Norm).</li><li>Eindeutige URL/Bezeichnung des Inhalts (Profil-, Bewertungs-, Nachrichten-ID).</li><li>Name und E-Mail des Meldenden (außer bei sexueller Ausbeutung Minderjähriger).</li><li>Erklärung in gutem Glauben.</li></ul>
         <h2>5. Bestätigung</h2>
@@ -3183,8 +3210,8 @@ Datum: ___________________________________________________
     <section id="page-datenschutz" class="page">
       <div class="container legal-page">
         <h1>Datenschutzerklärung</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Datenschutzerklärung ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich. In der Beta-Phase werden ausschließlich technisch notwendige Daten verarbeitet.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Datenschutzerklärung ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich. In der Beta-Phase werden nur Daten verarbeitet, die für die bereitgestellten Plattformfunktionen, Sicherheit und Rechtsbefolgung erforderlich sind.</p>
         <p>Information gemäß Art. 13, 14 DSGVO über Art, Umfang und Zweck der Verarbeitung personenbezogener Daten auf der Plattform <strong>eventbörse.de</strong>.</p>
 
         <h2>1. Verantwortlicher und Datenschutzkontakt</h2>
@@ -3219,7 +3246,10 @@ Datum: ___________________________________________________
         <h2>10. Messaging, Bewertungen und Profile</h2>
         <p>Internes Messaging mit Dienstleistern; nach Buchung Bewertung möglich. Bewertungen werden öffentlich auf dem Profil des bewerteten Dienstleisters angezeigt; nur nach tatsächlich erfolgter und durchgeführter Buchung (Authentizität nach § 5b UWG). Inhalte des internen Messagings werden nicht öffentlich angezeigt.</p>
 
-        <h2>11. Drittlandtransfer</h2>
+        <h2>11. Inhaltsmeldungen und Moderation</h2>
+        <p>Bei einer Inhaltsmeldung verarbeiten wir die betroffene Inserat-ID und URL, Meldegrund, Begründung, Erklärung nach bestem Wissen sowie grundsätzlich Name und E-Mail-Adresse der meldenden Person. Bei Meldungen zur mutmaßlichen sexuellen Ausbeutung Minderjähriger sind Name und E-Mail nicht erforderlich. Zur Missbrauchsabwehr wird aus der IP-Adresse ein nicht rückrechenbarer Rate-Limit-Schlüssel gebildet, der nach spätestens einer Stunde verfällt; die IP-Adresse wird nicht im Meldedatensatz gespeichert. Zweck ist die Entgegennahme, Prüfung, Dokumentation und Beantwortung von Meldungen nach Art. 16 DSA sowie die Abwehr von Rechtsverstößen. Rechtsgrundlagen sind Art. 6 Abs. 1 lit. c DSGVO in Verbindung mit dem DSA und Art. 6 Abs. 1 lit. f DSGVO. Berechtigtes Interesse ist der sichere, rechtskonforme Plattformbetrieb. Beschwerde- und Moderationsvorgänge werden grundsätzlich drei Jahre gespeichert; zwingende Aufbewahrungs- oder Rechtsverteidigungsinteressen können eine längere Speicherung erfordern.</p>
+
+        <h2>12. Drittlandtransfer</h2>
         <table class="legal-table">
           <thead><tr><th>Dienst</th><th>Sitz</th><th>Absicherung</th></tr></thead>
           <tbody>
@@ -3231,23 +3261,23 @@ Datum: ___________________________________________________
           </tbody>
         </table>
 
-        <h2>12. Empfänger und Auftragsverarbeiter</h2>
+        <h2>13. Empfänger und Auftragsverarbeiter</h2>
         <ul><li>IONOS SE — Hosting (DE).</li><li>Stripe Payments Europe Ltd. — Zahlungsdienstleister.</li><li>GitHub Inc. — Source-Code-Verwaltung; keine personenbezogenen Endkundendaten in Repositories.</li></ul>
 
-        <h2>13. Speicher- und Löschfristen</h2>
+        <h2>14. Speicher- und Löschfristen</h2>
         <ul><li>Vertragsdaten: max. 6 Jahre (§ 257 HGB) bzw. 10 Jahre (§ 147 AO).</li><li>Bewertungen: dauerhaft, solange das bewertete Profil besteht.</li><li>Server-Logs: max. 14 Tage.</li><li>Beschwerde- und Moderations-Tickets: 3 Jahre.</li></ul>
 
-        <h2>14. Ihre Rechte als betroffene Person</h2>
+        <h2>15. Ihre Rechte als betroffene Person</h2>
         <ul><li>Auskunft (Art. 15 DSGVO)</li><li>Berichtigung (Art. 16 DSGVO)</li><li>Löschung (Art. 17 DSGVO)</li><li>Einschränkung (Art. 18 DSGVO)</li><li>Datenübertragbarkeit (Art. 20 DSGVO)</li><li>Widerspruch (Art. 21 DSGVO)</li><li>Widerruf einer Einwilligung (Art. 7 Abs. 3 DSGVO)</li><li>Beschwerde bei einer Aufsichtsbehörde (Art. 77 DSGVO): <strong>LDI NRW</strong>, Kavalleriestr. 2-4, 40213 Düsseldorf.</li></ul>
         <p>Anfragen an <strong>datenschutz@eventbörse.de</strong>.</p>
 
-        <h2>15. Bereitstellungspflicht</h2>
+        <h2>16. Bereitstellungspflicht</h2>
         <p>Stammdaten zur Vertragserfüllung sind erforderlich; ohne diese keine Buchung. Andere Daten (Profilbild) sind freiwillig.</p>
 
-        <h2>16. Automatisierte Entscheidungsfindung und Profiling</h2>
+        <h2>17. Automatisierte Entscheidungsfindung und Profiling</h2>
         <p>Unser Ranking-/Empfehlungssystem sortiert nach Relevanz, Bewertung, Premium-Status, Verfügbarkeit, Antwortgeschwindigkeit. Eine vollautomatisierte Entscheidung mit rechtlicher Wirkung im Sinne des Art. 22 DSGVO findet nicht statt; jede Sperrung oder Maßnahme mit erheblichen Folgen unterliegt menschlicher Überprüfung.</p>
 
-        <h2>17. Änderungen dieser Erklärung</h2>
+        <h2>18. Änderungen dieser Erklärung</h2>
         <p>Aktualisierung bei wesentlichen Änderungen. Wesentliche Änderungen kündigen wir Nutzern per E-Mail oder beim nächsten Login an.</p>
       </div>
     </section>
@@ -3905,6 +3935,56 @@ Datum: ___________________________________________________
         <button type="submit" class="btn-primary btn-block">
           <span class="material-icons-round">send</span> Bewertung abschicken
         </button>
+      </form>
+    </div>
+  </div>
+
+  <!-- DSA Art. 16: report the exact listing, including a reasoned notice. -->
+  <div class="modal-overlay" id="contentReportModal" onclick="closeModalOnOverlay(event)">
+    <div class="modal modal-md">
+      <button class="modal-close" aria-label="Schließen" onclick="closeModal('contentReportModal')">
+        <span class="material-icons-round">close</span>
+      </button>
+      <div class="modal-header">
+        <span class="material-icons-round modal-icon">flag</span>
+        <h2>Inhalt melden</h2>
+        <p>Rechtswidrige, irreführende oder nicht gekennzeichnete KI-Inhalte direkt melden.</p>
+      </div>
+      <form class="modal-form" id="contentReportForm" onsubmit="submitListingReport(event)">
+        <div class="form-group">
+          <label for="contentReportTarget">Betroffener Inhalt</label>
+          <input type="text" id="contentReportTarget" readonly />
+        </div>
+        <div class="form-group">
+          <label for="contentReportReason">Meldegrund</label>
+          <select id="contentReportReason" required onchange="toggleReportContactRequirement()">
+            <option value="">Bitte auswählen</option>
+            <option value="ai_undeclared">Nicht gekennzeichneter KI-Inhalt</option>
+            <option value="misleading">Irreführende oder falsche Darstellung</option>
+            <option value="rights">Urheber-, Marken- oder Persönlichkeitsrecht</option>
+            <option value="illegal">Sonstiger mutmaßlich rechtswidriger Inhalt</option>
+            <option value="sexual_abuse_minors">Sexuelle Ausbeutung Minderjähriger</option>
+            <option value="other">Anderer Grund</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="contentReportExplanation">Warum ist der Inhalt rechtswidrig oder irreführend?</label>
+          <textarea id="contentReportExplanation" rows="5" minlength="20" maxlength="4000" required placeholder="Bitte möglichst konkret begründen, bei Rechtsverstößen wenn möglich mit betroffener Norm oder betroffenem Recht."></textarea>
+          <small class="form-hint">20–4.000 Zeichen. Die genaue Inserat-URL wird automatisch mitgesendet.</small>
+        </div>
+        <div class="form-row" id="contentReportContactFields">
+          <div class="form-group">
+            <label for="contentReportName">Name</label>
+            <input type="text" id="contentReportName" maxlength="200" autocomplete="name" required />
+          </div>
+          <div class="form-group">
+            <label for="contentReportEmail">E-Mail</label>
+            <input type="email" id="contentReportEmail" maxlength="200" autocomplete="email" required />
+          </div>
+        </div>
+        <p class="report-contact-exception" id="contentReportException" hidden>Bei Meldungen zur sexuellen Ausbeutung Minderjähriger sind Name und E-Mail gemäß Art. 16 Abs. 2 lit. c DSA nicht erforderlich.</p>
+        <label class="report-good-faith"><input type="checkbox" id="contentReportGoodFaith" required /> <span>Ich bin nach bestem Wissen überzeugt, dass meine Angaben richtig und vollständig sind.</span></label>
+        <button type="submit" class="btn-primary btn-block" id="contentReportSubmit"><span class="material-icons-round">send</span> Meldung absenden</button>
       </form>
     </div>
   </div>

--- a/app.js
+++ b/app.js
@@ -156,6 +156,65 @@ function _surfaceVisibleListings(arr) {
   );
   return adminWantsDemo ? rows : filterDemos(rows);
 }
+
+// AI transparency is stored separately for copy and media so a human photo
+// is never falsely watermarked merely because the description used AI.
+// "undeclared" is reserved for migrated legacy records and is not shown as
+// proof of human authorship.
+function _aiDisclosureValue(item, kind) {
+  var key = kind === 'media' ? 'aiMediaDisclosure' : 'aiTextDisclosure';
+  var nested = item && item.aiDisclosure && item.aiDisclosure[kind];
+  var raw = item && (item[key] != null ? item[key] : nested);
+  raw = String(raw || 'undeclared').toLowerCase();
+  return ['none', 'assisted', 'generated', 'undeclared'].indexOf(raw) !== -1 ? raw : 'undeclared';
+}
+
+function _aiDisclosureAttrs(item) {
+  return ' data-ai-text="' + _aiDisclosureValue(item, 'text') + '"' +
+    ' data-ai-media="' + _aiDisclosureValue(item, 'media') + '"';
+}
+
+function _aiDisclosureLabels(item) {
+  var labels = [];
+  var textStatus = _aiDisclosureValue(item, 'text');
+  var mediaStatus = _aiDisclosureValue(item, 'media');
+  if (mediaStatus === 'generated') labels.push({ kind: 'media', label: 'KI-generiertes Bild', short: 'KI-generiert' });
+  if (mediaStatus === 'assisted') labels.push({ kind: 'media', label: 'KI-bearbeitetes Bild', short: 'KI-bearbeitet' });
+  if (textStatus === 'generated') labels.push({ kind: 'text', label: 'KI-generierter Text', short: 'KI-Text' });
+  if (textStatus === 'assisted') labels.push({ kind: 'text', label: 'KI-unterstützter Text', short: 'KI-Text bearbeitet' });
+  if (mediaStatus === 'undeclared') labels.push({ kind: 'media', label: 'KI-Status der Medien noch nicht deklariert', short: 'Medien: KI-Status offen', legacy: true });
+  if (textStatus === 'undeclared') labels.push({ kind: 'text', label: 'KI-Status des Textes noch nicht deklariert', short: 'Text: KI-Status offen', legacy: true });
+  return labels;
+}
+
+function _aiDisclosureLabelsHtml(item, extraClass) {
+  var labels = _aiDisclosureLabels(item);
+  if (!labels.length) return '';
+  return '<span class="ai-disclosure-stack' + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="KI-Transparenz">' +
+    labels.map(function(info) {
+      return '<span class="ai-content-label ai-content-label-' + info.kind + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
+        (info.legacy ? 'Altbestand: noch nicht nachdeklariert' : 'Von der einstellenden Person deklariert') + '">' +
+        '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + _escHtml(info.short) + '</span>';
+    }).join('') + '</span>';
+}
+
+function _aiMediaWatermarkHtml(item, extraClass) {
+  var mediaStatus = _aiDisclosureValue(item, 'media');
+  if (mediaStatus === 'none') return '';
+  var label = mediaStatus === 'generated' ? 'KI-GENERIERT' : (mediaStatus === 'assisted' ? 'KI-BEARBEITET' : 'KI-STATUS OFFEN');
+  var aria = mediaStatus === 'generated' ? 'KI-generiertes Bild' : (mediaStatus === 'assisted' ? 'KI-bearbeitetes Bild' : 'KI-Status der Medien noch nicht deklariert');
+  return '<span class="ai-media-watermark' + (mediaStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' + label + '</span>';
+}
+
+function _aiTextDisclosureHtml(item, extraClass) {
+  var textStatus = _aiDisclosureValue(item, 'text');
+  if (textStatus === 'none') return '';
+  var label = textStatus === 'generated' ? 'KI-Text' : (textStatus === 'assisted' ? 'KI-Text bearbeitet' : 'Text-KI offen');
+  var aria = textStatus === 'generated' ? 'KI-generierter Text' : (textStatus === 'assisted' ? 'KI-unterstützter Text' : 'KI-Status des Textes noch nicht deklariert');
+  return '<span class="ai-text-watermark' + (textStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' +
+    '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + label + '</span>';
+}
+
 function _safeRun(label, fn) {
   try {
     if (typeof fn === 'function') fn();
@@ -413,7 +472,6 @@ window._fitExploreImg = function(img) {
     img.classList.add('explore-item-img-contain');
   }
 };
-
 // ========== DEMO DATA ==========
 const LISTINGS = [
   {
@@ -1382,6 +1440,7 @@ function navigateTo(page, data, skipHistory) {
       if (!window._isEditNavigation) {
         window._editingListingId = null;
         document.getElementById('createListingForm').reset();
+        try { _setAiDisclosureForm('', ''); } catch (e) {}
         document.getElementById('uploadPreview').innerHTML = '';
         document.querySelectorAll('#createFeatureTags .feature-tag').forEach(function(t) { t.classList.remove('selected'); });
         document.querySelectorAll('#createFeatureTags .feature-tag-custom-item').forEach(function(t) { t.remove(); });
@@ -1554,7 +1613,7 @@ function renderListingCard(listing) {
   var imgs = Array.isArray(listing.images) && listing.images.length ? listing.images : [listing.image];
   var galleryId = 'gridGallery_' + listing.id;
   return `
-    <div class="listing-card" data-listing-id="${listing.id}">
+    <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
         <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bilder: ${_escHtml(listing.title)}">
           ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
@@ -1565,6 +1624,8 @@ function renderListingCard(listing) {
         </button>
         ${listing.badge ? '<span class="listing-badge">' + _escHtml(listing.badge) + '</span>' : ''}
         ${_boardStatusBadgeHtml(listing.id, 'bsb-on-card')}
+        ${_aiMediaWatermarkHtml(listing)}
+        ${_aiTextDisclosureHtml(listing)}
       </div>
       <div class="listing-card-body">
         <div class="listing-card-top">
@@ -1626,8 +1687,9 @@ function renderHeroMarquees() {
   }
 
   function cardHTML(l) {
-    return '<a class="hero-marquee-card" href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
+    return '<a class="hero-marquee-card"' + _aiDisclosureAttrs(l) + ' href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
       '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="eager"' + window.EB_IMG_ERR_ATTR + ' />' +
+      _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
       '<div class="hero-marquee-card-info">' +
         '<h4>' + _escHtml(l.title) + '</h4>' +
         '<span>' + _escHtml(l.priceLabel) + ' · ★ ' + (l.rating || 0) + '</span>' +
@@ -1784,11 +1846,11 @@ function renderExploreGrid(filter) {
   let items = [];
   filterDemos(LISTINGS).forEach(l => {
     // Main image
-    items.push({ image: l.image, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel });
+    items.push({ image: l.image, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel, aiTextDisclosure: l.aiTextDisclosure, aiMediaDisclosure: l.aiMediaDisclosure });
     // Additional images
     if (l.images) {
       l.images.slice(1).forEach(img => {
-        items.push({ image: img, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel });
+        items.push({ image: img, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel, aiTextDisclosure: l.aiTextDisclosure, aiMediaDisclosure: l.aiMediaDisclosure });
       });
     }
   });
@@ -1797,8 +1859,9 @@ function renderExploreGrid(filter) {
   }
   grid.innerHTML = items.map((it, i) => {
     const sizeClass = (i % 7 === 0) ? 'explore-item-large' : '';
-    return `<a href="#" class="explore-item ${sizeClass}" onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
+    return `<a href="#" class="explore-item ${sizeClass}"${_aiDisclosureAttrs(it)} onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
       <img src="${_escHtml(it.image)}" alt="${_escHtml(it.title)}" loading="lazy" onload="_fitExploreImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
+      ${_aiMediaWatermarkHtml(it)}${_aiTextDisclosureHtml(it)}
       <div class="explore-item-overlay">
         <span class="explore-item-title">${_escHtml(it.title)}</span>
         <span class="explore-item-price">${_escHtml(it.price)}</span>
@@ -1870,7 +1933,7 @@ function renderFeed(tab) {
     const isFav = favorites.has(l.id);
     const desc = l.description || l.title;
     const tags = l.features ? l.features.slice(0, 3) : [];
-    return `<div class="feed-card">
+    return `<div class="feed-card"${_aiDisclosureAttrs(l)}>
       <div class="feed-card-header">
         <img class="feed-card-avatar" src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
         <div class="feed-card-meta">
@@ -1879,7 +1942,7 @@ function renderFeed(tab) {
         </div>
         <span class="feed-card-category">${_escHtml(categoryLabel)}</span>
       </div>
-      <img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
+      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}</div>
       <div class="feed-card-body">
         <div class="feed-card-title" onclick="navigateTo('detail',${l.id})">${_escHtml(l.title)}</div>
         <div class="feed-card-desc">${_escHtml(_stripHtml(desc))}</div>
@@ -2277,7 +2340,6 @@ function haversineKm(lat1, lng1, lat2, lng2) {
   const a = Math.sin(dLat/2)**2 + Math.cos(lat1*Math.PI/180)*Math.cos(lat2*Math.PI/180)*Math.sin(dLng/2)**2;
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 }
-
 /* ══════════════════════════════════════════════════════════════════════
    EB INTELLIGENCE — Geschmacks-Gedächtnis & Satz-Vervollständigung
    ----------------------------------------------------------------------
@@ -4171,13 +4233,14 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
         ? `<span class="alt-distance-badge"><span class="material-icons-round">near_me</span> ~${l._distKm} km</span>`
         : '';
       return `
-        <div class="listing-card" onclick="navigateTo('detail', ${l.id})">
+        <div class="listing-card"${_aiDisclosureAttrs(l)} onclick="navigateTo('detail', ${l.id})">
           <div class="listing-card-img">
             <img src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" loading="lazy" />
             <button class="listing-fav" aria-label="Zu Favoriten hinzufügen" aria-pressed="false" onclick="event.stopPropagation(); toggleFavorite(${l.id}, this)">
               <span class="material-icons-round">favorite_border</span>
             </button>
             ${l.badge ? `<span class="listing-badge">${_escHtml(l.badge)}</span>` : ''}
+            ${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}
           </div>
           <div class="listing-card-body">
             <div class="listing-card-top">
@@ -4241,7 +4304,6 @@ function setView(view) {
     grid.style.gridTemplateColumns = '';
   }
 }
-
 // ========== DETAIL PAGE ==========
 function loadDetail(listingId) {
   const listing = LISTINGS.find(l => l.id === listingId);
@@ -4265,7 +4327,8 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />${_aiMediaWatermarkHtml(listing)}`;
+    heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 
   // Swipeable gallery carousel
@@ -4277,7 +4340,7 @@ function loadDetail(listingId) {
       var delBtn = _detailCanModerate && img !== window.EB_IMG_FALLBACK
         ? '<button type="button" class="detail-gallery-admin-del" title="Bild als Admin löschen" aria-label="Bild als Admin löschen" onclick="adminDeleteListingImage(' + i + ', event)"><span class="material-icons-round">delete</span> Löschen</button>'
         : '';
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + delBtn + '</div>';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + _aiMediaWatermarkHtml(listing) + delBtn + '</div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" aria-label="Vorheriges Bild" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -4286,6 +4349,8 @@ function loadDetail(listingId) {
     imgs.map(function(_, i) { return '<button class="detail-gallery-dot' + (i === 0 ? ' active' : '') + '" onclick="detailGalleryGoTo(' + i + ')" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') +
     '</div>' +
     '<div class="detail-gallery-counter" id="detailGalleryCounter">1 / ' + imgs.length + '</div>' : '');
+  gallery.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
+  gallery.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   _initDetailGallerySwipe();
   // Detect wide banners for hero + gallery
   detectWideBannerImg(heroImg.querySelector('img'));
@@ -4306,6 +4371,17 @@ function loadDetail(listingId) {
   document.getElementById('detailRating').textContent = listing.rating || '0';
   document.getElementById('detailReviewCount').textContent = '(' + (listing.reviews || 0) + ' Bewertungen)';
   document.getElementById('detailLocation').textContent = listing.region;
+  var aiDisclosure = document.getElementById('detailAiDisclosure');
+  if (aiDisclosure) {
+    var aiLabels = _aiDisclosureLabelsHtml(listing, 'ai-disclosure-detail');
+    var hasOpenStatus = _aiDisclosureValue(listing, 'text') === 'undeclared' || _aiDisclosureValue(listing, 'media') === 'undeclared';
+    var aiNote = hasOpenStatus
+      ? 'Altbestand: Die ausdrückliche Nachdeklaration steht noch aus.'
+      : 'Vom Anbieter bei Veröffentlichung deklariert.';
+    aiDisclosure.innerHTML = aiLabels ? aiLabels + '<small>' + aiNote + '</small>' : '';
+    aiDisclosure.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
+    aiDisclosure.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
+  }
   document.getElementById('detailProviderImg').src = _resolveAvatar(listing.providerImg, listing.providerName);
   document.getElementById('detailProviderName').textContent = listing.providerName;
   document.getElementById('detailProviderTag').textContent = `Superhost · Seit ${listing.providerSince} auf Eventbörse`;
@@ -4313,6 +4389,8 @@ function loadDetail(listingId) {
   // Show edit button only for own listings
   var editBtn = document.getElementById('detailEditBtn');
   if (editBtn) editBtn.style.display = (currentUser && listing.providerId === currentUser.id) ? '' : 'none';
+  var reportBtn = document.getElementById('detailReportBtn');
+  if (reportBtn) reportBtn.style.display = listing._fromDb ? '' : 'none';
 
   // Board-Status-Chip: zeigt, ob dieses Inserat schon im Planungsboard steckt
   // (Im Plan / Kontaktiert / Angebot / Gebucht) — Verknüpfung Detail ↔ Board.
@@ -4373,6 +4451,70 @@ function loadDetail(listingId) {
   // Negotiation price
   document.getElementById('negOriginalPrice').value = listing.priceLabel;
   renderDetailCollaborationSuggestions(listing.providerId);
+}
+
+var _contentReportListing = null;
+
+function openListingReport(listingArg) {
+  var listing = listingArg && listingArg.id ? listingArg : currentListing;
+  if (!listing || !listing._fromDb || !listing._dbId) {
+    showToast('Dieses Demo-Inserat ist nicht öffentlich meldbar.', 'info');
+    return;
+  }
+  _contentReportListing = listing;
+  var form = document.getElementById('contentReportForm');
+  if (form) form.reset();
+  var target = document.getElementById('contentReportTarget');
+  if (target) target.value = listing.title + ' · /detail/' + listing.id;
+  var name = document.getElementById('contentReportName');
+  var email = document.getElementById('contentReportEmail');
+  if (name && currentUser) name.value = currentUser.name || '';
+  if (email && currentUser) email.value = currentUser.email || '';
+  toggleReportContactRequirement();
+  openModal('contentReportModal');
+}
+
+function toggleReportContactRequirement() {
+  var reason = (document.getElementById('contentReportReason') || {}).value || '';
+  var optional = reason === 'sexual_abuse_minors';
+  var name = document.getElementById('contentReportName');
+  var email = document.getElementById('contentReportEmail');
+  var note = document.getElementById('contentReportException');
+  if (name) name.required = !optional;
+  if (email) email.required = !optional;
+  if (note) note.hidden = !optional;
+}
+
+async function submitListingReport(event) {
+  event.preventDefault();
+  var listing = _contentReportListing;
+  if (!listing || !listing._dbId) return;
+  var btn = document.getElementById('contentReportSubmit');
+  _setBtnLoading(btn, true);
+  try {
+    var response = await fetch(_apiUrl('listings/' + listing._dbId + '/report'), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: _apiHeaders(),
+      body: JSON.stringify({
+        reason: (document.getElementById('contentReportReason') || {}).value || '',
+        explanation: (document.getElementById('contentReportExplanation') || {}).value || '',
+        reporterName: (document.getElementById('contentReportName') || {}).value || '',
+        reporterEmail: (document.getElementById('contentReportEmail') || {}).value || '',
+        goodFaith: !!(document.getElementById('contentReportGoodFaith') || {}).checked
+      })
+    });
+    var data = {};
+    try { data = await response.json(); } catch (e) {}
+    if (!response.ok) throw new Error(data.message || 'Meldung konnte nicht gesendet werden.');
+    closeModal('contentReportModal');
+    _contentReportListing = null;
+    showToast('Meldung erhalten · Vorgang ' + (data.caseId || ''), 'verified_user');
+  } catch (err) {
+    showToast(err.message || 'Meldung konnte nicht gesendet werden.', 'error');
+  } finally {
+    _setBtnLoading(btn, false);
+  }
 }
 
 // ========== PROVIDER PROFILE ==========
@@ -6303,7 +6445,7 @@ function _feedRadarPopupHtml(gruppe) {
       + '<span class="material-icons-round">' + (hit.art === 'event' ? 'celebration' : 'storefront') + '</span>'
       + '<span><strong>' + _escHtml(title) + '</strong><small>'
       + _escHtml(hit.ort || '') + ' · ' + _escHtml(radarEntfernung(hit.km))
-      + (hit.genau ? '' : ' · ca.') + '</small></span>'
+      + (hit.genau ? '' : ' · ca.') + '</small>' + _aiDisclosureLabelsHtml(d, 'ai-disclosure-radar-popup') + '</span>'
       + '<span class="material-icons-round">arrow_forward</span></button>';
   }).join('');
   return '<div class="feed-radar-popup"><div class="feed-radar-popup-head">'
@@ -6511,9 +6653,9 @@ function _drawFeedRadar() {
       var d = hit.daten || {};
       var title = d.title || d.name || 'Event';
       var image = (d.images && d.images[0]) || d.image || window.EB_IMG_FALLBACK;
-      return '<article class="feed-radar-result" data-radar-index="' + index + '">' +
+      return '<article class="feed-radar-result" data-radar-index="' + index + '"' + _aiDisclosureAttrs(d) + '>' +
         '<button type="button" class="feed-radar-result-map" onclick="feedRadarFocus(' + index + ')" aria-label="' + _escHtml(title) + ' auf der Karte zeigen">' +
-        '<img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
+        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '>' + _aiMediaWatermarkHtml(d) + _aiTextDisclosureHtml(d) + '</span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
         '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong><small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
         '<button type="button" class="feed-radar-result-open" onclick="feedRadarOpen(' + index + ')" aria-label="' + _escHtml(title) + ' öffnen"><span class="material-icons-round">arrow_forward</span></button></article>';
     }).join('') + '</div>';
@@ -9088,6 +9230,82 @@ const CATEGORY_LABELS = {
   moderation: 'Moderation'
 };
 
+function _selectedAiDisclosure(kind) {
+  var name = kind === 'media' ? 'createAiMediaDisclosure' : 'createAiTextDisclosure';
+  var selected = document.querySelector('input[name="' + name + '"]:checked');
+  return selected ? selected.value : '';
+}
+
+function _setAiDisclosureForm(textStatus, mediaStatus) {
+  ['text', 'media'].forEach(function(kind) {
+    var status = kind === 'media' ? mediaStatus : textStatus;
+    var name = kind === 'media' ? 'createAiMediaDisclosure' : 'createAiTextDisclosure';
+    document.querySelectorAll('input[name="' + name + '"]').forEach(function(input) {
+      input.checked = ['none', 'assisted', 'generated'].indexOf(status) !== -1 && input.value === status;
+    });
+  });
+  _aiDisclosureFormChanged();
+}
+
+function _aiDisclosureFormChanged() {
+  var section = document.getElementById('aiDisclosureSection');
+  if (section) section.classList.remove('has-error');
+  _updateListingPreviewAiLabels();
+  _updateListingLivePreview();
+}
+
+function _updateListingPreviewAiLabels() {
+  var mediaStatus = _selectedAiDisclosure('media');
+  document.querySelectorAll('#uploadPreview .upload-preview-item').forEach(function(item) {
+    var old = item.querySelector('.ai-media-watermark');
+    if (old) old.remove();
+    var html = _aiMediaWatermarkHtml({ aiMediaDisclosure: mediaStatus }, 'ai-media-watermark-preview');
+    if (html) item.insertAdjacentHTML('beforeend', html);
+  });
+}
+
+// Burn the declaration into every newly uploaded AI image. The UI overlay is
+// still rendered separately because it must remain visible on all surfaces;
+// this pixel watermark additionally survives opening or sharing the file.
+function _aiWatermarkBlob(blob, mediaStatus) {
+  if (!blob || (mediaStatus !== 'assisted' && mediaStatus !== 'generated')) return Promise.resolve(blob);
+  return new Promise(function(resolve) {
+    var url = URL.createObjectURL(blob);
+    var img = new Image();
+    img.onload = function() {
+      try {
+        var canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth || img.width;
+        canvas.height = img.naturalHeight || img.height;
+        var ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        var label = mediaStatus === 'generated' ? 'KI-GENERIERT · EVENTBÖRSE' : 'KI-BEARBEITET · EVENTBÖRSE';
+        var fontSize = Math.max(20, Math.round(canvas.width * 0.027));
+        var padX = Math.round(fontSize * 0.65);
+        var padY = Math.round(fontSize * 0.42);
+        ctx.font = '700 ' + fontSize + 'px Arial, sans-serif';
+        var textWidth = ctx.measureText(label).width;
+        var boxW = textWidth + padX * 2;
+        var boxH = fontSize + padY * 2;
+        var x = Math.max(12, canvas.width - boxW - Math.round(fontSize * 0.6));
+        var y = Math.max(12, canvas.height - boxH - Math.round(fontSize * 0.6));
+        ctx.fillStyle = 'rgba(12, 15, 24, 0.84)';
+        ctx.fillRect(x, y, boxW, boxH);
+        ctx.fillStyle = '#ffffff';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(label, x + padX, y + boxH / 2);
+        canvas.toBlob(function(marked) { resolve(marked || blob); }, 'image/jpeg', 0.92);
+      } catch (e) {
+        resolve(blob);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    };
+    img.onerror = function() { URL.revokeObjectURL(url); resolve(blob); };
+    img.src = url;
+  });
+}
+
 async function submitListing(e) {
   if (e && e.preventDefault) e.preventDefault();
 
@@ -9141,12 +9359,24 @@ async function submitListing(e) {
   const priceMaxRaw = parseInt((document.getElementById('createPriceMax')||{}).value) || 0;
   const priceMax = (priceMaxRaw > 0 && priceMaxRaw > price) ? priceMaxRaw : 0;
   const priceModel = requiredEl('createPriceModel', 'Preismodell').value;
+  const aiTextDisclosure = _selectedAiDisclosure('text');
+  const aiMediaDisclosure = _selectedAiDisclosure('media');
 
   // Basic validation
   if (!title)       { _releaseGuard(); showToast('Bitte gib einen Titel ein', 'warning'); nextStep(1); return; }
   if (!category)    { _releaseGuard(); showToast('Bitte wähle eine Kategorie', 'warning'); nextStep(1); return; }
   if (!description) { _releaseGuard(); showToast('Bitte gib eine Beschreibung ein', 'warning'); nextStep(1); return; }
   if (!price)       { _releaseGuard(); showToast(isSearch ? 'Bitte gib dein Budget ein' : 'Bitte gib einen Preis ein', 'warning'); nextStep(1); return; }
+  if (!aiTextDisclosure || !aiMediaDisclosure) {
+    _releaseGuard();
+    var aiSection = document.getElementById('aiDisclosureSection');
+    if (aiSection) {
+      aiSection.classList.add('has-error');
+      aiSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    showToast('Bitte die KI-Nutzung für Text und Medien ausdrücklich angeben.', 'warning');
+    return;
+  }
   const region = document.getElementById('createRegionValue').value.trim()
     || document.getElementById('createRegion').value.trim() || 'Deutschland';
   const dateFrom = document.getElementById('createDateFrom').value;
@@ -9210,15 +9440,20 @@ async function submitListing(e) {
   // Upload images: cropped blobs first, then data URLs, keep existing URLs
   var uploadPromises = imgEntries.map(function(entry) {
     if (entry.blob) {
-      var file = new File([entry.blob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
-      return uploadFile(file).then(function(r) { return r.url; });
+      return _aiWatermarkBlob(entry.blob, aiMediaDisclosure).then(function(markedBlob) {
+        var file = new File([markedBlob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
+        return uploadFile(file).then(function(r) { return r.url; });
+      });
     }
     if (entry.src.startsWith('data:')) {
       var arr = entry.src.split(','), mime = arr[0].match(/:(.*?);/)[1];
       var bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
       while (n--) u8arr[n] = bstr.charCodeAt(n);
-      var file = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
-      return uploadFile(file).then(function(r) { return r.url; });
+      var sourceFile = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
+      return _aiWatermarkBlob(sourceFile, aiMediaDisclosure).then(function(markedBlob) {
+        var file = new File([markedBlob], 'listing-' + Date.now() + '.jpg', { type: 'image/jpeg' });
+        return uploadFile(file).then(function(r) { return r.url; });
+      });
     }
     return Promise.resolve(entry.src);
   });
@@ -9234,6 +9469,8 @@ async function submitListing(e) {
     var payload = {
       title: title,
       listingType: listingType,
+      aiTextDisclosure: aiTextDisclosure,
+      aiMediaDisclosure: aiMediaDisclosure,
       category: category,
       categoryLabel: CATEGORY_LABELS[category] || category,
       description: '<p>' + description.replace(/\n/g, '</p><p>') + '</p>',
@@ -9312,6 +9549,7 @@ async function submitListing(e) {
 
       // Reset the form
       document.getElementById('createListingForm').reset();
+      try { _setAiDisclosureForm('', ''); } catch (e) {}
       document.getElementById('uploadPreview').innerHTML = '';
       document.querySelectorAll('#createFeatureTags .feature-tag').forEach(function(t) { t.classList.remove('selected'); });
       document.querySelectorAll('#createFeatureTags .feature-tag-custom-item').forEach(function(t) { t.remove(); });
@@ -9661,6 +9899,12 @@ function _updateListingLivePreview() {
     return;
   }
   container.style.display = '';
+  var previewDisclosure = {
+    aiTextDisclosure: _selectedAiDisclosure('text') || 'undeclared',
+    aiMediaDisclosure: _selectedAiDisclosure('media') || 'undeclared'
+  };
+  container.setAttribute('data-ai-text', _aiDisclosureValue(previewDisclosure, 'text'));
+  container.setAttribute('data-ai-media', _aiDisclosureValue(previewDisclosure, 'media'));
 
   // Build slides
   track.innerHTML = '';
@@ -9671,6 +9915,8 @@ function _updateListingLivePreview() {
     slideImg.src = img.src;
     slideImg.alt = 'Vorschau';
     slide.appendChild(slideImg);
+    var watermark = _aiMediaWatermarkHtml(previewDisclosure, 'ai-media-watermark-live');
+    if (watermark) slide.insertAdjacentHTML('beforeend', watermark);
     track.appendChild(slide);
   });
 
@@ -10226,7 +10472,6 @@ function initDragScroll() {
     document.querySelectorAll(sel).forEach(_makeDraggable);
   });
 }
-
 // ========== DARK MODE ==========
 function initDarkMode() {
   var isDark = localStorage.getItem('eb_dark_mode') !== '0';
@@ -10869,6 +11114,8 @@ function renderMyListings() {
               title: l.title,
               category: l.category,
               categoryLabel: l.categoryLabel || l.category,
+              aiTextDisclosure: l.aiTextDisclosure,
+              aiMediaDisclosure: l.aiMediaDisclosure,
               image: (l.images && l.images[0]) || '',
               images: l.images || [],
               location: l.location,
@@ -10911,8 +11158,9 @@ function renderMyListings() {
           // DB events from API
           if (evt._fromDb) {
             return '<div class="my-listing-card">' +
-              '<div class="my-listing-img">' +
+              '<div class="my-listing-img"' + _aiDisclosureAttrs(evt) + '>' +
                 '<img src="' + _escHtml(evt.image) + '" alt="' + _escHtml(evt.title) + '" />' +
+                _aiMediaWatermarkHtml(evt) + _aiTextDisclosureHtml(evt) +
                 '<span class="status-badge status-active">Aktiv</span>' +
               '</div>' +
               '<div class="my-listing-info">' +
@@ -10992,8 +11240,9 @@ function renderMyListings() {
           var rating = l.rating || 0;
           var reviewCount = l.reviewCount || 0;
           return '<div class="my-listing-card">' +
-            '<div class="my-listing-img">' +
+            '<div class="my-listing-img"' + _aiDisclosureAttrs(l) + '>' +
               '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" />' +
+              _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
               '<span class="status-badge status-active">Aktiv</span>' +
             '</div>' +
             '<div class="my-listing-info">' +
@@ -11053,6 +11302,8 @@ function renderMyListings() {
               title: l.title,
               category: l.category,
               categoryLabel: l.categoryLabel || l.category,
+              aiTextDisclosure: l.aiTextDisclosure,
+              aiMediaDisclosure: l.aiMediaDisclosure,
               image: (l.images && l.images[0]) || '',
               images: l.images || [],
               location: l.location,
@@ -11114,6 +11365,9 @@ function editListing(listingId) {
 
   // Typ (Biete/Suche) aus dem Inserat übernehmen
   try { _clSetType(listing.listingType === 'search' ? 'search' : 'offer'); } catch (e) {}
+  // Legacy records remain unselected and require an explicit declaration on
+  // the next save; do not silently turn "undeclared" into "without AI".
+  try { _setAiDisclosureForm(listing.aiTextDisclosure, listing.aiMediaDisclosure); } catch (e) {}
   // Verfügbarkeitskalender mit bestehenden Block-Tagen vorbefüllen
   try { _clAvailPrefill(listing); } catch (e) {}
 
@@ -11736,7 +11990,6 @@ function adminChangeRole(userId, role) {
     loadAdminUsers();
   }).catch(function(e) { showToast(e.message || 'Rollenwechsel fehlgeschlagen', 'error'); });
 }
-
 // ========== REVIEW SYSTEM ==========
 var selectedRating = 0;
 // Store user reviews per listing (listingId → array of reviews)
@@ -22193,14 +22446,15 @@ function _buildListingPickerCardsHtml(baseList, isSearchListingFn, showSearchLis
     var img = l.image || l.providerImg || '';
     var price = l.priceLabel || (l.price ? ('ab ' + l.price + ' €') : '');
     return '<button type="button" class="eb-lpick-card" data-id="' + l.id +
-      '" data-name="' + _escHtml(l.providerName || l.title || '') + '"' +
+      '"' + _aiDisclosureAttrs(l) +
+      ' data-name="' + _escHtml(l.providerName || l.title || '') + '"' +
       ' data-category="' + _escHtml(l.categoryLabel || l.category || '') + '"' +
       ' data-price="' + (l.price || '') + '"' +
       ' data-avatar="' + _escHtml(img) + '"' +
       ' data-image="' + _escHtml(l.image || img) + '"' +
       ' data-title="' + _escHtml(l.title || '') + '"' +
       ' onclick="_selectListingCard(this)">' +
-      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')"></span>' +
+      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')">' + _aiMediaWatermarkHtml(l, 'ai-media-watermark-picker') + _aiTextDisclosureHtml(l, 'ai-text-watermark-picker') + '</span>' +
       '<span class="eb-lpick-body">' +
         '<span class="eb-lpick-title">' + _escHtml(l.title || '') + '</span>' +
         '<span class="eb-lpick-meta">' +
@@ -22508,6 +22762,12 @@ function ignoreUser(authorName) {
 
 function reportPost(postId) {
   closePostMenu();
+  if (String(postId).indexOf('listing-') === 0) {
+    var listingId = parseInt(String(postId).slice(8), 10);
+    var listing = (typeof LISTINGS !== 'undefined' ? LISTINGS : []).find(function(item) { return item.id === listingId; });
+    if (listing && typeof openListingReport === 'function') openListingReport(listing);
+    return;
+  }
   // Simple reason selection sheet
   var overlay = document.createElement('div');
   overlay.className = 'post-options-overlay';
@@ -23115,7 +23375,7 @@ function renderSocialPostCard(post) {
 function renderListingFeedCard(l) {
   var avatar = l.providerImg || l.providerAvatar || ebAvatar(l.providerName || 'user', l.providerName);
   var isFav = favorites.has(l.id);
-  return '<div class="feed-post-card" data-post-id="listing-' + l.id + '">' +
+  return '<div class="feed-post-card" data-post-id="listing-' + l.id + '"' + _aiDisclosureAttrs(l) + '>' +
     '<div class="feed-post-header">' +
       '<img class="feed-post-avatar" src="' + _escHtml(avatar) + '" alt="' + _escHtml(l.providerName) + '" onerror="this.onerror=null;this.src=ebAvatar(this.alt||\'user\',this.alt)" onclick="navigateTo(\'provider\',' + (l.providerId || l.id) + ')" />' +
       '<div class="feed-post-author">' +
@@ -23124,7 +23384,7 @@ function renderListingFeedCard(l) {
       '</div>' +
       '<button class="feed-more-btn" onclick="openPostMenu(event,\'listing-' + l.id + '\',\'' + (l.providerName || '').replace(/'/g, '') + '\')" aria-label="Optionen"><span class="material-icons-round">more_horiz</span></button>' +
     '</div>' +
-    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>' +
+    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />' + _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) + '</div>' +
     '<div class="feed-post-content">' + _escHtml(l.title) + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
     '<div class="feed-action-bar">' +
       '<div class="feed-actions">' +
@@ -26261,7 +26521,7 @@ function _drawBusinessMediaPreview(seedExtra) {
   ctx.fillStyle=style==='minimal'?'#18181b':'#fff';ctx.font='700 '+Math.round(c.width/20)+'px Inter, sans-serif';ctx.textAlign='left';
   var words=prompt.trim().split(/\s+/), lines=[],line=''; words.forEach(function(w){ if((line+' '+w).length>28){lines.push(line);line=w;}else line+=(line?' ':'')+w;});if(line)lines.push(line);
   lines.slice(0,3).forEach(function(l,i){ctx.fillText(l,70,c.height-170+(i-lines.length+1)*62);});
-  ctx.font='600 20px Inter, sans-serif';ctx.fillText('EVENTBÖRSE · EINZIGARTIGER ACCOUNT-ENTWURF',72,c.height-62);
+  ctx.font='600 20px Inter, sans-serif';ctx.fillText('DIGITAL ERSTELLT · EVENTBÖRSE · KEIN KI-FOTOMODELL',72,c.height-62);
 }
 function createAccountMedia() {
   var c=document.getElementById('mediaStudioCanvas'); if(!c) return;
@@ -26271,7 +26531,7 @@ function createAccountMedia() {
     var file=new File([blob],'eventboerse-motiv-'+Date.now()+'.png',{type:'image/png'});
     uploadFile(file).then(function(data){
       var result=document.getElementById('mediaStudioResult');
-      if(result) result.innerHTML='<span><span class="material-icons-round">verified_user</span> Account #' + _escHtml(String(data.ownerId||currentUser.id)) + ' zugeordnet</span><button class="btn-outline btn-sm" onclick="useMediaInPortfolio(\'' + _escHtml(data.url) + '\')">Ins Portfolio</button><button class="btn-outline btn-sm" onclick="useMediaAsProfilePhoto(\'' + _escHtml(data.url) + '\')">Als Profilbild</button>';
+      if(result) result.innerHTML='<span><span class="material-icons-round">verified_user</span> Digital erstellt · kein KI-Fotomodell · Account #' + _escHtml(String(data.ownerId||currentUser.id)) + '</span><button class="btn-outline btn-sm" onclick="useMediaInPortfolio(\'' + _escHtml(data.url) + '\')">Ins Portfolio</button><button class="btn-outline btn-sm" onclick="useMediaAsProfilePhoto(\'' + _escHtml(data.url) + '\')">Als Profilbild</button>';
       showToast('Motiv sicher in deinem Account gespeichert.','verified_user');
     }).catch(function(err){ showToast(err.message||'Upload fehlgeschlagen.','error'); });
   },'image/png',0.92);

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-13T11:03:41.114Z",
+  "erzeugt": "2026-08-14T12:39:44.024Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/functions.php
+++ b/functions.php
@@ -3160,13 +3160,12 @@ add_filter( 'rest_post_dispatch', function( $response ) {
 /**
  * Schema-Stand, gegen den `eb_db_version` in der Datenbank geprueft wird.
  *
- * 2.5 statt 2.4, obwohl fachlich nichts dazukommt: bis hierher wurde die
- * Version unbedingt hochgesetzt, auch wenn ein ALTER scheiterte. Eine
- * Datenbank koennte also '2.4' melden und die Spalten trotzdem nicht haben.
- * Die Erhoehung erzwingt genau einen geprueften Durchlauf ueberall.
+ * 2.6: getrennte, persistente KI-Erklaerungen fuer Text und Medien sowie ein
+ * revisionsfaehiger Inhalt-Meldeeingang. Bestandsinhalte bleiben bewusst
+ * "undeclared"; die Migration erfindet keine menschliche Urheberschaft.
  */
 if ( ! defined( 'EB_DB_VERSION' ) ) {
-    define( 'EB_DB_VERSION', '2.5' );
+    define( 'EB_DB_VERSION', '2.6' );
 }
 
 function eb_create_tables() {
@@ -3180,6 +3179,8 @@ function eb_create_tables() {
         category varchar(100) NOT NULL DEFAULT '',
         category_label varchar(100) NOT NULL DEFAULT '',
         listing_type varchar(20) NOT NULL DEFAULT 'offer',
+        ai_text_disclosure varchar(20) NOT NULL DEFAULT 'undeclared',
+        ai_media_disclosure varchar(20) NOT NULL DEFAULT 'undeclared',
         description longtext,
         price int(10) unsigned NOT NULL DEFAULT 0,
         price_model varchar(50) NOT NULL DEFAULT '',
@@ -3291,6 +3292,24 @@ function eb_create_tables() {
         KEY idx_status (status)
     ) $charset;";
 
+    $sql_content_reports = "CREATE TABLE {$wpdb->prefix}eb_content_reports (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        content_type varchar(30) NOT NULL DEFAULT 'listing',
+        content_id bigint(20) unsigned NOT NULL,
+        content_url text NOT NULL,
+        reason varchar(50) NOT NULL DEFAULT '',
+        explanation text NOT NULL,
+        reporter_name varchar(200) NOT NULL DEFAULT '',
+        reporter_email varchar(200) NOT NULL DEFAULT '',
+        good_faith tinyint(1) NOT NULL DEFAULT 0,
+        status varchar(20) NOT NULL DEFAULT 'received',
+        created_at datetime DEFAULT '0000-00-00 00:00:00',
+        PRIMARY KEY  (id),
+        KEY idx_content (content_type, content_id),
+        KEY idx_status (status),
+        KEY idx_created (created_at)
+    ) $charset;";
+
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
     dbDelta( $sql_listings );
     dbDelta( $sql_reviews );
@@ -3298,6 +3317,7 @@ function eb_create_tables() {
     dbDelta( $sql_messages );
     dbDelta( $sql_favorites );
     dbDelta( $sql_registrations );
+    dbDelta( $sql_content_reports );
 }
 add_action( 'after_switch_theme', 'eb_create_tables' );
 // Also run on init once (version check)
@@ -3338,6 +3358,17 @@ function eb_maybe_create_tables() {
             // Bestands-Gesuche anhand der bisherigen Titel-Heuristik markieren
             $wpdb->query( "UPDATE {$wpdb->prefix}eb_listings SET listing_type = 'search' WHERE title REGEXP 'gesucht' OR title REGEXP '^[[:space:]]*[Ss]uche[[:space:]]'" );
         }
+        // 2.6: Art.-50-Kennzeichnung getrennt nach Text und Medien. Der
+        // Default "undeclared" ist absichtlich kein "none": Bei alten
+        // Inseraten wissen wir nicht, wie sie entstanden sind.
+        $ai_text_col = $wpdb->get_var( "SHOW COLUMNS FROM {$wpdb->prefix}eb_listings LIKE 'ai_text_disclosure'" );
+        if ( ! $ai_text_col ) {
+            $wpdb->query( "ALTER TABLE {$wpdb->prefix}eb_listings ADD COLUMN ai_text_disclosure varchar(20) NOT NULL DEFAULT 'undeclared' AFTER listing_type" );
+        }
+        $ai_media_col = $wpdb->get_var( "SHOW COLUMNS FROM {$wpdb->prefix}eb_listings LIKE 'ai_media_disclosure'" );
+        if ( ! $ai_media_col ) {
+            $wpdb->query( "ALTER TABLE {$wpdb->prefix}eb_listings ADD COLUMN ai_media_disclosure varchar(20) NOT NULL DEFAULT 'undeclared' AFTER ai_text_disclosure" );
+        }
         // 2.4: Koordinaten und Stadtteil fuer den Umkreis-Radar.
         //
         // Ohne diese Migration bliebe das Adressfeld in der Maske wirkungslos:
@@ -3372,7 +3403,7 @@ function eb_maybe_create_tables() {
         // Migration auch dann als erledigt, wenn ein ALTER scheiterte — und
         // lief nie wieder an. Die Datenbank waere kaputt und die Anzeige
         // gruen; genau die Kombination, die man am spaetesten bemerkt.
-        $soll = array( 'blocked_dates', 'listing_type', 'stadtteil', 'lat', 'lng' );
+        $soll = array( 'blocked_dates', 'listing_type', 'ai_text_disclosure', 'ai_media_disclosure', 'stadtteil', 'lat', 'lng' );
         $ist  = $wpdb->get_col( "SHOW COLUMNS FROM {$wpdb->prefix}eb_listings" );
         $fehlt = array_values( array_diff( $soll, is_array( $ist ) ? $ist : array() ) );
         if ( ! $wpdb->get_var( "SHOW COLUMNS FROM {$wpdb->prefix}eb_messages LIKE 'updated_at'" ) ) {
@@ -3380,6 +3411,14 @@ function eb_maybe_create_tables() {
         }
         if ( ! $geo_idx && ! $wpdb->get_var( "SHOW INDEX FROM {$wpdb->prefix}eb_listings WHERE Key_name = 'idx_geo'" ) ) {
             $fehlt[] = 'idx_geo';
+        }
+        $reports_table = $wpdb->prefix . 'eb_content_reports';
+        // Der Tabellenname besteht ausschliesslich aus dem von WordPress
+        // kontrollierten Prefix und unserem festen Suffix; kein Nutzwert.
+        // Ohne prepare() bleibt die Migrationspruefung auch in der isolierten
+        // Installations-/Recovery-Umgebung lauffaehig.
+        if ( $wpdb->get_var( "SHOW TABLES LIKE '{$reports_table}'" ) !== $reports_table ) {
+            $fehlt[] = 'eb_content_reports';
         }
 
         if ( empty( $fehlt ) ) {
@@ -3437,6 +3476,15 @@ function eb_register_extra_routes() {
             'callback'            => 'eb_listings_delete',
             'permission_callback' => 'is_user_logged_in',
         ),
+    ) );
+
+    // DSA Art. 16: leicht zugaenglicher elektronischer Meldeweg direkt am
+    // konkreten Inserat. Oeffentlich, weil auch Dritte ohne Konto melden
+    // duerfen; Validierung und Rate-Limit liegen im Handler.
+    register_rest_route( 'eventboerse/v1', '/listings/(?P<id>\d+)/report', array(
+        'methods'             => 'POST',
+        'callback'            => 'eb_listing_report_create',
+        'permission_callback' => '__return_true',
     ) );
 
     register_rest_route( 'eventboerse/v1', '/my-listings', array(
@@ -4025,6 +4073,11 @@ function eb_admin_seed_test_listing() {
             'title'          => $title,
             'category'       => 'location',
             'category_label' => 'Location',
+            // Plattformgeschriebener Demo-Text + unveraendertes Stockfoto;
+            // deshalb hier bewusst und nachvollziehbar "none" statt Legacy-
+            // Default "undeclared".
+            'ai_text_disclosure'  => 'none',
+            'ai_media_disclosure' => 'none',
             'description'    => $description,
             'price'          => 1,
             'price_model'    => 'pro_stunde',
@@ -4054,6 +4107,8 @@ function eb_admin_seed_test_listing() {
         'title'          => $title,
         'category'       => 'location',
         'category_label' => 'Location',
+        'ai_text_disclosure'  => 'none',
+        'ai_media_disclosure' => 'none',
         'description'    => $description,
         'price'          => 1,
         'price_model'    => 'pro_stunde',
@@ -4358,7 +4413,7 @@ function eb_admin_smtp_set( WP_REST_Request $request ) {
 
 function eb_diagnostics() {
     global $wpdb;
-    $tables = array( 'eb_listings', 'eb_reviews', 'eb_conversations', 'eb_messages', 'eb_favorites', 'eb_registrations' );
+    $tables = array( 'eb_listings', 'eb_reviews', 'eb_conversations', 'eb_messages', 'eb_favorites', 'eb_registrations', 'eb_content_reports' );
     // „Ist die Migration durch?" soll man sehen, nicht erschliessen muessen:
     // Sollstand, Iststand, was fehlt, und ob der Geo-Index wirklich steht.
     $fehlt = get_option( 'eb_db_migration_fehlt', array() );
@@ -4679,6 +4734,11 @@ function eb_format_listing( $row ) {
         'category'      => $row['category'],
         'categoryLabel' => $row['category_label'],
         'listingType'   => ( isset( $row['listing_type'] ) && $row['listing_type'] === 'search' ) ? 'search' : 'offer',
+        // Maschinenlesbare Kennzeichnung plus sichtbare UI-Wasserzeichen im
+        // Frontend. "undeclared" kennzeichnet nur migrierte Altinhalte und
+        // wird niemals als menschliche Erstellung ausgegeben.
+        'aiTextDisclosure'  => isset( $row['ai_text_disclosure'] ) ? $row['ai_text_disclosure'] : 'undeclared',
+        'aiMediaDisclosure' => isset( $row['ai_media_disclosure'] ) ? $row['ai_media_disclosure'] : 'undeclared',
         'location'      => $row['location'],
         'region'        => $row['region'],
         'stadtteil'     => isset( $row['stadtteil'] ) ? $row['stadtteil'] : '',
@@ -4792,6 +4852,27 @@ function eb_geo_pruefen( $roh ) {
     return array( round( $lat, 4 ), round( $lng, 4 ) );
 }
 
+/**
+ * Explizite KI-Erklaerung fuer einen Inhaltsbereich validieren.
+ *
+ * "undeclared" ist ausschliesslich der Migrationszustand alter Datensaetze
+ * und darf vom Client nicht neu gesetzt werden. So kann niemand eine
+ * verpflichtende Auswahl umgehen oder Altinhalte faelschlich freisprechen.
+ *
+ * @return string|WP_Error
+ */
+function eb_ai_disclosure_pruefen( $roh, $feldname ) {
+    $wert = sanitize_key( (string) $roh );
+    if ( ! in_array( $wert, array( 'none', 'assisted', 'generated' ), true ) ) {
+        return new WP_Error(
+            'ai_disclosure_required',
+            sprintf( 'Bitte die KI-Nutzung für %s ausdrücklich angeben.', $feldname ),
+            array( 'status' => 400 )
+        );
+    }
+    return $wert;
+}
+
 function eb_listings_create( WP_REST_Request $request ) {
     global $wpdb;
     $uid    = get_current_user_id();
@@ -4805,6 +4886,10 @@ function eb_listings_create( WP_REST_Request $request ) {
     $category       = sanitize_text_field( $params['category'] ?? '' );
     $category_label = sanitize_text_field( $params['categoryLabel'] ?? $category );
     $listing_type   = ( ( $params['listingType'] ?? '' ) === 'search' ) ? 'search' : 'offer';
+    $ai_text        = eb_ai_disclosure_pruefen( $params['aiTextDisclosure'] ?? '', 'Text und Angaben' );
+    $ai_media       = eb_ai_disclosure_pruefen( $params['aiMediaDisclosure'] ?? '', 'Bilder und Medien' );
+    if ( is_wp_error( $ai_text ) ) return $ai_text;
+    if ( is_wp_error( $ai_media ) ) return $ai_media;
     $description    = wp_kses_post( $params['description'] ?? '' );
     $price          = absint( $params['price'] ?? 0 );
     $price_model    = sanitize_text_field( $params['priceModel'] ?? '' );
@@ -4846,6 +4931,8 @@ function eb_listings_create( WP_REST_Request $request ) {
         'category'       => $category,
         'category_label' => $category_label,
         'listing_type'   => $listing_type,
+        'ai_text_disclosure'  => $ai_text,
+        'ai_media_disclosure' => $ai_media,
         'description'    => $description,
         'price'          => $price,
         'price_model'    => $price_model,
@@ -4925,6 +5012,15 @@ function eb_listings_update( WP_REST_Request $request ) {
     if ( isset( $params['listingType'] ) ) {
         $update['listing_type'] = ( $params['listingType'] === 'search' ) ? 'search' : 'offer';
     }
+    // Auch direkte API-Aenderungen muessen nachdeklarieren. Waeren die Felder
+    // hier optional, koennte ein alter oder absichtlich manipulierter Client
+    // den Pflichtschritt der Oberflaeche umgehen und "undeclared" behalten.
+    $ai_text = eb_ai_disclosure_pruefen( $params['aiTextDisclosure'] ?? '', 'Text und Angaben' );
+    $ai_media = eb_ai_disclosure_pruefen( $params['aiMediaDisclosure'] ?? '', 'Bilder und Medien' );
+    if ( is_wp_error( $ai_text ) ) return $ai_text;
+    if ( is_wp_error( $ai_media ) ) return $ai_media;
+    $update['ai_text_disclosure'] = $ai_text;
+    $update['ai_media_disclosure'] = $ai_media;
     // Koordinaten aendern oder loeschen.
     //
     // Ohne diesen Block waeren sie beim Anlegen setzbar und danach fuer immer
@@ -4965,9 +5061,13 @@ function eb_listings_update( WP_REST_Request $request ) {
     if ( isset( $params['instantBook'] ) ) {
         $update['instant_book'] = ! empty( $params['instantBook'] ) ? 1 : 0;
     }
+    $update['updated_at'] = current_time( 'mysql' );
 
     if ( ! empty( $update ) ) {
-        $wpdb->update( $wpdb->prefix . 'eb_listings', $update, array( 'id' => $id ) );
+        $updated = $wpdb->update( $wpdb->prefix . 'eb_listings', $update, array( 'id' => $id ) );
+        if ( $updated === false ) {
+            return new WP_REST_Response( array( 'message' => 'Änderungen konnten nicht gespeichert werden.' ), 500 );
+        }
     }
 
     $row = $wpdb->get_row( $wpdb->prepare(
@@ -5000,6 +5100,143 @@ function eb_listings_delete( WP_REST_Request $request ) {
 
     return new WP_REST_Response( array( 'deleted' => true ), 200 );
 }
+
+/**
+ * DSA-Art.-16-Meldung zu einem konkreten Inserat annehmen.
+ *
+ * Die Meldung wird zuerst dauerhaft gespeichert und erst danach per E-Mail
+ * signalisiert. Ein Mail-Ausfall darf keinen bereits bestaetigten Eingang
+ * vernichten. IP-Adressen werden nicht gespeichert; sie dienen nur dem
+ * kurzlebigen Rate-Limit-Bucket.
+ */
+function eb_listing_report_create( WP_REST_Request $request ) {
+    global $wpdb;
+
+    // Genug Spielraum fuer mehrere betroffene Inhalte, aber Schutz gegen
+    // automatisierten Missbrauch. Der Bucket enthaelt nur einen IP-Hash und
+    // verfällt nach einer Stunde.
+    $rl = eventboerse_check_rate_limit( 'content_report', 20, HOUR_IN_SECONDS );
+    if ( is_wp_error( $rl ) ) return $rl;
+
+    $listing_id = absint( $request['id'] );
+    $listing = $wpdb->get_row( $wpdb->prepare(
+        "SELECT id, title, ai_text_disclosure, ai_media_disclosure FROM {$wpdb->prefix}eb_listings WHERE id = %d",
+        $listing_id
+    ), ARRAY_A );
+    if ( ! $listing ) {
+        return new WP_REST_Response( array( 'message' => 'Inserat nicht gefunden.' ), 404 );
+    }
+
+    $params = $request->get_json_params();
+    $reason = sanitize_key( $params['reason'] ?? '' );
+    $reasons = array(
+        'ai_undeclared'          => 'Nicht gekennzeichneter KI-Inhalt',
+        'misleading'             => 'Irreführende oder falsche Darstellung',
+        'rights'                 => 'Urheber-, Marken- oder Persönlichkeitsrecht',
+        'illegal'                => 'Sonstiger mutmaßlich rechtswidriger Inhalt',
+        'sexual_abuse_minors'    => 'Sexuelle Ausbeutung Minderjähriger',
+        'other'                  => 'Anderer Grund',
+    );
+    if ( ! isset( $reasons[ $reason ] ) ) {
+        return new WP_REST_Response( array( 'message' => 'Bitte einen Meldegrund auswählen.' ), 400 );
+    }
+
+    $explanation = sanitize_textarea_field( $params['explanation'] ?? '' );
+    if ( strlen( trim( $explanation ) ) < 20 || strlen( $explanation ) > 4000 ) {
+        return new WP_REST_Response( array( 'message' => 'Bitte die Rechtswidrigkeit in 20 bis 4.000 Zeichen begründen.' ), 400 );
+    }
+    if ( empty( $params['goodFaith'] ) ) {
+        return new WP_REST_Response( array( 'message' => 'Die Erklärung nach bestem Wissen ist erforderlich.' ), 400 );
+    }
+
+    $reporter_name  = sanitize_text_field( $params['reporterName'] ?? '' );
+    $reporter_email = eb_normalize_email( (string) ( $params['reporterEmail'] ?? '' ) );
+    // Art. 16 Abs. 2 lit. c DSA: Bei mutmaßlicher sexueller Ausbeutung
+    // Minderjähriger darf die Meldung ohne Name/E-Mail erfolgen.
+    if ( $reason !== 'sexual_abuse_minors' ) {
+        if ( $reporter_name === '' || ! is_email( $reporter_email ) ) {
+            return new WP_REST_Response( array( 'message' => 'Name und gültige E-Mail-Adresse sind für diese Meldung erforderlich.' ), 400 );
+        }
+    }
+
+    $content_url = home_url( '/detail/' . ( $listing_id + 10000 ) );
+    $now = current_time( 'mysql' );
+    $ok = $wpdb->insert( $wpdb->prefix . 'eb_content_reports', array(
+        'content_type'   => 'listing',
+        'content_id'     => $listing_id,
+        'content_url'    => $content_url,
+        'reason'         => $reason,
+        'explanation'    => $explanation,
+        'reporter_name'  => $reporter_name,
+        'reporter_email' => $reporter_email,
+        'good_faith'     => 1,
+        'status'         => 'received',
+        'created_at'     => $now,
+    ) );
+    if ( ! $ok || ! $wpdb->insert_id ) {
+        return new WP_REST_Response( array( 'message' => 'Meldung konnte nicht gespeichert werden.' ), 500 );
+    }
+
+    $report_id = (int) $wpdb->insert_id;
+    $case_id = 'EB-' . wp_date( 'Ymd' ) . '-' . str_pad( (string) $report_id, 6, '0', STR_PAD_LEFT );
+    $headers = array( 'Content-Type: text/html; charset=UTF-8' );
+    $body = '<h2>Neue DSA-Inhaltsmeldung ' . esc_html( $case_id ) . '</h2>'
+        . '<p><strong>Inserat:</strong> ' . esc_html( $listing['title'] ) . ' (#' . $listing_id . ')</p>'
+        . '<p><strong>URL:</strong> <a href="' . esc_url( $content_url ) . '">' . esc_html( $content_url ) . '</a></p>'
+        . '<p><strong>Grund:</strong> ' . esc_html( $reasons[ $reason ] ) . '</p>'
+        . '<p><strong>Begründung:</strong><br>' . nl2br( esc_html( $explanation ) ) . '</p>'
+        . '<p><strong>KI-Status:</strong> Text ' . esc_html( $listing['ai_text_disclosure'] )
+        . ' · Medien ' . esc_html( $listing['ai_media_disclosure'] ) . '</p>'
+        . '<p><strong>Meldende Person:</strong> ' . esc_html( $reporter_name ?: 'nicht angegeben' )
+        . ' · ' . esc_html( $reporter_email ?: 'nicht angegeben' ) . '</p>';
+    // Interne Zustellung ueber das bereits ueberwachte Betreiberpostfach.
+    // Damit geht keine Datenbankmeldung verloren, falls der oeffentliche
+    // dsa-meldung-Alias noch nicht im IONOS-Postfach eingerichtet ist.
+    $mail_sent = wp_mail(
+        eb_ops_notify_address(),
+        'DSA-Meldung ' . $case_id . ': ' . $reasons[ $reason ],
+        $body,
+        $headers
+    );
+
+    if ( $reporter_email && is_email( $reporter_email ) ) {
+        wp_mail(
+            $reporter_email,
+            'Eingangsbestätigung ' . $case_id,
+            '<p>Wir haben deine Meldung zum Inserat <strong>' . esc_html( $listing['title'] ) . '</strong> erhalten.</p>'
+            . '<p>Vorgangsnummer: <strong>' . esc_html( $case_id ) . '</strong></p>'
+            . '<p>Wir prüfen die Meldung sorgfältig und informieren dich über die Entscheidung.</p>',
+            $headers
+        );
+    }
+
+    return new WP_REST_Response( array(
+        'received' => true,
+        'caseId'   => $case_id,
+        'mailSent' => (bool) $mail_sent,
+    ), 201 );
+}
+
+/**
+ * Meldedaten nach der veroeffentlichten Regelfrist entfernen.
+ * Ein ausdruecklicher legal_hold bleibt fuer laufende Verfahren bestehen.
+ */
+function eb_content_reports_cleanup() {
+    global $wpdb;
+    $cutoff = wp_date( 'Y-m-d H:i:s', time() - ( 3 * YEAR_IN_SECONDS ) );
+    $wpdb->query( $wpdb->prepare(
+        "DELETE FROM {$wpdb->prefix}eb_content_reports WHERE created_at < %s AND status <> 'legal_hold'",
+        $cutoff
+    ) );
+}
+add_action( 'eb_content_reports_cleanup', 'eb_content_reports_cleanup' );
+
+function eb_content_reports_schedule_cleanup() {
+    if ( ! wp_next_scheduled( 'eb_content_reports_cleanup' ) ) {
+        wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'eb_content_reports_cleanup' );
+    }
+}
+add_action( 'init', 'eb_content_reports_schedule_cleanup' );
 
 /** My listings */
 function eb_my_listings() {

--- a/includes/security/rate-limit.php
+++ b/includes/security/rate-limit.php
@@ -13,7 +13,9 @@
  * Audit-Issue: #13 (P0.4 — Fehlende Rate-Limiting auf Auth-Endpoints).
  *
  * Implementierung: WordPress-Transients als Sliding-Window-Counter.
- * Key besteht aus aktion + IP-Hash, sodass mehrere Endpoints unabhaengige Buckets haben.
+ * Key besteht aus Aktion + serverseitig geschuetztem IP-HMAC, sodass mehrere
+ * Endpoints unabhaengige Buckets haben und die IP nicht aus einem einfachen
+ * Hash-Woerterbuch zurueckgewonnen werden kann.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -54,7 +56,7 @@ function eventboerse_get_client_ip() {
 function eventboerse_check_rate_limit( $action, $limit = 5, $window_secs = 900, $identifier_override = null ) {
     $ip       = eventboerse_get_client_ip();
     $ident    = $identifier_override !== null ? (string) $identifier_override : $ip;
-    $bucket   = 'eb_rl_' . md5( $action . '|' . $ident );
+    $bucket   = 'eb_rl_' . hash_hmac( 'sha256', $action . '|' . $ident, wp_salt( 'auth' ) );
 
     $entry = get_transient( $bucket );
     $now   = time();
@@ -92,6 +94,6 @@ function eventboerse_check_rate_limit( $action, $limit = 5, $window_secs = 900, 
  */
 function eventboerse_reset_rate_limit( $action, $identifier_override = null ) {
     $ident  = $identifier_override !== null ? (string) $identifier_override : eventboerse_get_client_ip();
-    $bucket = 'eb_rl_' . md5( $action . '|' . $ident );
+    $bucket = 'eb_rl_' . hash_hmac( 'sha256', $action . '|' . $ident, wp_salt( 'auth' ) );
     delete_transient( $bucket );
 }

--- a/index.html
+++ b/index.html
@@ -1393,6 +1393,7 @@
               <span id="detailLocation">Berlin, Deutschland</span>
             </span>
           </div>
+          <div id="detailAiDisclosure" class="detail-ai-disclosure" aria-live="polite"></div>
         </div>
         <div class="detail-gallery" id="detailGallery">
           <!-- Images loaded by JS -->
@@ -1405,6 +1406,7 @@
           </div>
           <button id="detailEditBtn" class="btn-primary btn-sm" style="display:none" onclick="editListing(currentListing?.id)"><span class="material-icons-round">edit</span> Bearbeiten</button>
           <button class="btn-outline" onclick="navigateTo('provider', currentListing?.providerId)">Profil ansehen</button>
+          <button id="detailReportBtn" class="btn-outline btn-sm" onclick="openListingReport()"><span class="material-icons-round">flag</span> Inhalt melden</button>
         </div>
         <div id="detailCollaborationSuggestions" class="detail-collaboration-suggestions" aria-live="polite"></div>
         <div class="detail-layout">
@@ -2409,6 +2411,28 @@
           <div class="form-section" id="step3">
             <h2><span class="fs-num">3</span> Fotos &amp; Galerie</h2>
             <p class="step-intro" id="clPhotosIntro">Inserate mit hochwertigen Fotos werden bis zu <strong>3&times; h&auml;ufiger</strong> angefragt. Lade mind. 3 Bilder hoch.</p>
+            <section class="ai-declaration" id="aiDisclosureSection" aria-labelledby="aiDisclosureHeading">
+              <div class="ai-declaration-head">
+                <span class="material-icons-round" aria-hidden="true">verified_user</span>
+                <div>
+                  <h3 id="aiDisclosureHeading">KI-Transparenz <span>Pflichtangabe</span></h3>
+                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Bei KI-Medien setzt Eventbörse zusätzlich ein sichtbares Wasserzeichen.</p>
+                </div>
+              </div>
+              <fieldset class="ai-declaration-group">
+                <legend>Text und Angaben</legend>
+                <label><input type="radio" name="createAiTextDisclosure" value="none" required onchange="_aiDisclosureFormChanged()"><span><strong>Ohne generative KI</strong><small>Text und Angaben selbst erstellt.</small></span></label>
+                <label><input type="radio" name="createAiTextDisclosure" value="assisted" onchange="_aiDisclosureFormChanged()"><span><strong>Mit KI unterstützt</strong><small>KI hat wesentliche Formulierungen bearbeitet.</small></span></label>
+                <label><input type="radio" name="createAiTextDisclosure" value="generated" onchange="_aiDisclosureFormChanged()"><span><strong>KI-generiert</strong><small>Text wurde ganz oder überwiegend mit KI erzeugt.</small></span></label>
+              </fieldset>
+              <fieldset class="ai-declaration-group">
+                <legend>Bilder und Medien</legend>
+                <label><input type="radio" name="createAiMediaDisclosure" value="none" required onchange="_aiDisclosureFormChanged()"><span><strong>Ohne generative KI</strong><small>Keine wesentliche KI-Erzeugung oder -Manipulation.</small></span></label>
+                <label><input type="radio" name="createAiMediaDisclosure" value="assisted" onchange="_aiDisclosureFormChanged()"><span><strong>KI-bearbeitet</strong><small>Medien wurden wesentlich mit KI verändert.</small></span></label>
+                <label><input type="radio" name="createAiMediaDisclosure" value="generated" onchange="_aiDisclosureFormChanged()"><span><strong>KI-generiert</strong><small>Medien wurden ganz oder überwiegend mit KI erzeugt.</small></span></label>
+              </fieldset>
+              <p class="ai-declaration-legal">Normale Farb-, Größen- oder Zuschnittkorrekturen gelten nicht als generative KI. Falsche Angaben können zur Entfernung führen. Details: <a href="#" onclick="navigateTo('upload');return false;">Upload-Richtlinie</a>.</p>
+            </section>
             <div class="upload-zone" id="uploadZone" onclick="document.getElementById('fileInput').click()">
               <span class="material-icons-round">cloud_upload</span>
               <h3>Bilder hochladen</h3>
@@ -2777,13 +2801,13 @@ Datum: ___________________________________________________
     <section id="page-community" class="page">
       <div class="container legal-page">
         <h1>Nutzungs- und Community-Richtlinien</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinien sind als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und werden mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinien sind als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und werden mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <p>Diese Richtlinien gelten verbindlich für alle Nutzer und erfüllen die AGB-Pflichtinhalte gemäß <strong>Art. 14 DSA</strong> (VO (EU) 2022/2065).</p>
         <h2>1. Grundsätze</h2>
         <ul><li>Respektvoller, sachlicher und professioneller Umgang.</li><li>Wahrhaftige Profil- und Leistungsangaben.</li><li>Keine Diskriminierung.</li><li>Beachtung des deutschen und europäischen Rechts.</li></ul>
         <h2>2. Verbotene Inhalte und Verhaltensweisen</h2>
-        <ul><li>Beleidigung, Verleumdung, Hassrede, Volksverhetzung.</li><li>Sexuell explizite oder pornografische Inhalte; Inhalte zum Nachteil Minderjähriger.</li><li>Verstoß gegen Urheber-, Marken-, Persönlichkeits- oder Datenschutzrechte.</li><li>Manipulation des Bewertungs- oder Rankingsystems (Fake-Bewertungen, Sockenpuppen).</li><li>Spam, Phishing, Malware, Identitätsdiebstahl.</li><li>Umgehung der Plattformfunktionen.</li><li>Scraping/Bots ohne Erlaubnis.</li></ul>
+        <ul><li>Beleidigung, Verleumdung, Hassrede, Volksverhetzung.</li><li>Sexuell explizite oder pornografische Inhalte; Inhalte zum Nachteil Minderjähriger.</li><li>Verstoß gegen Urheber-, Marken-, Persönlichkeits- oder Datenschutzrechte.</li><li>Manipulation des Bewertungs- oder Rankingsystems (Fake-Bewertungen, Sockenpuppen).</li><li>Nicht oder falsch deklarierte KI-generierte bzw. wesentlich KI-bearbeitete Texte, Bilder, Audio- oder Videoinhalte.</li><li>Spam, Phishing, Malware, Identitätsdiebstahl.</li><li>Umgehung der Plattformfunktionen.</li><li>Scraping/Bots ohne Erlaubnis.</li></ul>
         <h2>3. Profil- und Account-Regeln</h2>
         <p>Nur ein Account pro Person bzw. rechtlich eigenständigem Träger. Profilangaben müssen wahrhaftig, aktuell und vollständig sein. Demo-/Test-Profile (Beta-Betrieb) sind als solche zu kennzeichnen.</p>
         <h2>4. Kommunikationsregeln</h2>
@@ -2838,21 +2862,24 @@ Datum: ___________________________________________________
     <section id="page-upload" class="page">
       <div class="container legal-page">
         <h1>Upload- und Inhaltsrichtlinie / UGC-Lizenz</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Was sind Inhalte?</h2>
         <p>Profilbilder, Profilbeschreibungen, Logos, Texte, Bilder, Videos (z.&nbsp;B. Portfolio-Fotos, Eventfotos in Bewertungen), Audio (z.&nbsp;B. DJ-Mixe), sonstige hochgeladene Dateien.</p>
         <h2>2. Pflichten des Hochladenden</h2>
         <ul><li>Du verfügst über alle erforderlichen Rechte (Urheberrechte, Nutzungsrechte, Persönlichkeitsrechte, Markenrechte).</li><li>Einwilligung aller abgebildeten Personen (Art. 6, 9 DSGVO; KUG).</li><li>Bei Minderjährigen Einwilligung der Erziehungsberechtigten; im Zweifel keine Veröffentlichung.</li><li>Beachtung der Community-Richtlinien.</li></ul>
-        <h2>3. Lizenzeinräumung an die Plattform</h2>
+        <h2>3. KI-generierte und KI-bearbeitete Inhalte</h2>
+        <p>Beim Veröffentlichen ist getrennt für Text und Medien anzugeben, ob generative KI nicht genutzt, wesentlich unterstützend eingesetzt oder der Inhalt ganz bzw. überwiegend KI-generiert wurde. Normale Farb-, Größen- und Zuschnittkorrekturen zählen nicht als generative KI-Nutzung.</p>
+        <ul><li>KI-generierte und wesentlich KI-bearbeitete Medien erhalten auf Eventbörse ein dauerhaft sichtbares Wasserzeichen; neue lokale Bild-Uploads werden zusätzlich in den Bildpixeln gekennzeichnet.</li><li>Die Erklärung wird maschinenlesbar am Inserat und in der Schnittstelle gespeichert. Die Kennzeichnung muss beim Teilen oder Exportieren erhalten bleiben.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
+        <h2>4. Lizenzeinräumung an die Plattform</h2>
         <p>Mit dem Upload räumst du der Eventbörse UG (haftungsbeschränkt) ein einfaches, weltweites, zeitlich auf die Dauer der Profil-/Inhaltsverfügbarkeit auf der Plattform begrenztes, unentgeltliches und übertragbares Nutzungsrecht ein, deine Inhalte auf der Plattform öffentlich zugänglich zu machen, zu speichern, zu skalieren, zu transcodieren, in Vorschauen darzustellen und in Profilen, Suchergebnissen, Kommunikation und Bewertungen anzuzeigen. Eine Übertragung von Urheberrechten findet nicht statt; alle Rechte verbleiben beim Hochladenden.</p>
-        <h2>4. Recht zur Entfernung und Sperrung</h2>
+        <h2>5. Recht zur Entfernung und Sperrung</h2>
         <p>Inhalte können bei begründetem Verdacht eines Rechtsverstoßes oder Eingang einer Beschwerde nach DSA Art. 16 entfernt oder gesperrt werden; jeweils mit Statement of Reasons. Beschwerde nach DSA Art. 20 möglich.</p>
-        <h2>5. Verantwortung für Inhalte</h2>
-        <p>Die Plattform haftet als Diensteanbieter für fremde Inhalte erst ab Kenntnis (§§ 7–10 DDG). Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
-        <h2>6. Datenformate und Größenlimits</h2>
+        <h2>6. Verantwortung für Inhalte</h2>
+        <p>Der Hochladende bleibt für die Rechtmäßigkeit und Richtigkeit seiner Inhalte verantwortlich. Für fremde gespeicherte Inhalte gelten die Voraussetzungen des Art. 6 DSA; erhält die Plattform hinreichende Kenntnis von rechtswidrigen Inhalten, prüft sie die Meldung und sperrt oder entfernt rechtswidrige Inhalte zügig. Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
+        <h2>7. Datenformate und Größenlimits</h2>
         <ul><li>Bilder: JPG, PNG, WEBP — max. 10 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
-        <h2>7. Speicherort und Datenschutz</h2>
+        <h2>8. Speicherort und Datenschutz</h2>
         <p>Speicherung auf den IONOS-Servern in Deutschland. Verarbeitung gemäß Datenschutzerklärung. Bei Löschung des Accounts werden Inhalte gemäß Löschkonzept entfernt.</p>
       </div>
     </section>
@@ -2861,14 +2888,14 @@ Datum: ___________________________________________________
     <section id="page-dsa" class="page">
       <div class="container legal-page">
         <h1>DSA — Notice-and-Action-Verfahren</h1>
-        <p class="legal-date">Art. 16, 17, 22 VO (EU) 2022/2065 · Stand: 04. Mai 2026</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Dieses Verfahren ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Art. 16, 17, 22 VO (EU) 2022/2065 · Stand: 14. August 2026</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Dieses Verfahren ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Wer kann melden?</h2>
         <p>Jede natürliche oder juristische Person; Trusted Flagger (Art. 22 DSA); Behörden im Rahmen ihrer Zuständigkeit.</p>
         <h2>2. Was kann gemeldet werden?</h2>
         <p>Profile, Inhalte, Bewertungen, Nachrichten, Bilder, Videos. Mutmaßlich rechtswidrige Inhalte: Beleidigung, Verleumdung, Hassrede, Volksverhetzung, Urheber-/Marken-/Persönlichkeitsrechtsverletzung, Betrug, Phishing, Malware, jugendgefährdende Inhalte, Verstoß gegen JuSchG/JMStV, Schwarzarbeit, unzulässige Werbung.</p>
         <h2>3. Wie melden?</h2>
-        <ul><li>In-Product-Meldebutton „Inhalt melden" auf jedem Profil/Bewertung/Nachricht.</li><li>E-Mail an <strong>dsa-meldung@eventbörse.de</strong>.</li><li>Postalisch: Eventbörse UG (haftungsbeschränkt) i.&nbsp;G., Nonnenberger Str. 95a, 53639 Königswinter.</li></ul>
+        <ul><li>In-Product-Meldebutton „Inhalt melden" direkt an jedem Inserat; die genaue URL und Inserat-ID werden automatisch übernommen.</li><li>E-Mail an <strong>dsa-meldung@eventbörse.de</strong> für andere Inhalte oder ergänzende Unterlagen.</li><li>Postalisch: Eventbörse UG (haftungsbeschränkt) i.&nbsp;G., Nonnenberger Str. 95a, 53639 Königswinter.</li></ul>
         <h2>4. Pflichtangaben (Art. 16 Abs. 2 DSA)</h2>
         <ul><li>Begründung der Rechtswidrigkeit (Norm).</li><li>Eindeutige URL/Bezeichnung des Inhalts (Profil-, Bewertungs-, Nachrichten-ID).</li><li>Name und E-Mail des Meldenden (außer bei sexueller Ausbeutung Minderjähriger).</li><li>Erklärung in gutem Glauben.</li></ul>
         <h2>5. Bestätigung</h2>
@@ -3244,8 +3271,8 @@ Datum: ___________________________________________________
     <section id="page-datenschutz" class="page">
       <div class="container legal-page">
         <h1>Datenschutzerklärung</h1>
-        <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Datenschutzerklärung ist als Versionsentwurf 1.0 (Stand 04.05.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich. In der Beta-Phase werden ausschließlich technisch notwendige Daten verarbeitet.</p>
+        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Datenschutzerklärung ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich. In der Beta-Phase werden nur Daten verarbeitet, die für die bereitgestellten Plattformfunktionen, Sicherheit und Rechtsbefolgung erforderlich sind.</p>
         <p>Information gemäß Art. 13, 14 DSGVO über Art, Umfang und Zweck der Verarbeitung personenbezogener Daten auf der Plattform <strong>eventbörse.de</strong>.</p>
 
         <h2>1. Verantwortlicher und Datenschutzkontakt</h2>
@@ -3280,7 +3307,10 @@ Datum: ___________________________________________________
         <h2>10. Messaging, Bewertungen und Profile</h2>
         <p>Internes Messaging mit Dienstleistern; nach Buchung Bewertung möglich. Bewertungen werden öffentlich auf dem Profil des bewerteten Dienstleisters angezeigt; nur nach tatsächlich erfolgter und durchgeführter Buchung (Authentizität nach § 5b UWG). Inhalte des internen Messagings werden nicht öffentlich angezeigt.</p>
 
-        <h2>11. Drittlandtransfer</h2>
+        <h2>11. Inhaltsmeldungen und Moderation</h2>
+        <p>Bei einer Inhaltsmeldung verarbeiten wir die betroffene Inserat-ID und URL, Meldegrund, Begründung, Erklärung nach bestem Wissen sowie grundsätzlich Name und E-Mail-Adresse der meldenden Person. Bei Meldungen zur mutmaßlichen sexuellen Ausbeutung Minderjähriger sind Name und E-Mail nicht erforderlich. Zur Missbrauchsabwehr wird aus der IP-Adresse ein nicht rückrechenbarer Rate-Limit-Schlüssel gebildet, der nach spätestens einer Stunde verfällt; die IP-Adresse wird nicht im Meldedatensatz gespeichert. Zweck ist die Entgegennahme, Prüfung, Dokumentation und Beantwortung von Meldungen nach Art. 16 DSA sowie die Abwehr von Rechtsverstößen. Rechtsgrundlagen sind Art. 6 Abs. 1 lit. c DSGVO in Verbindung mit dem DSA und Art. 6 Abs. 1 lit. f DSGVO. Berechtigtes Interesse ist der sichere, rechtskonforme Plattformbetrieb. Beschwerde- und Moderationsvorgänge werden grundsätzlich drei Jahre gespeichert; zwingende Aufbewahrungs- oder Rechtsverteidigungsinteressen können eine längere Speicherung erfordern.</p>
+
+        <h2>12. Drittlandtransfer</h2>
         <table class="legal-table">
           <thead><tr><th>Dienst</th><th>Sitz</th><th>Absicherung</th></tr></thead>
           <tbody>
@@ -3292,23 +3322,23 @@ Datum: ___________________________________________________
           </tbody>
         </table>
 
-        <h2>12. Empfänger und Auftragsverarbeiter</h2>
+        <h2>13. Empfänger und Auftragsverarbeiter</h2>
         <ul><li>IONOS SE — Hosting (DE).</li><li>Stripe Payments Europe Ltd. — Zahlungsdienstleister.</li><li>GitHub Inc. — Source-Code-Verwaltung; keine personenbezogenen Endkundendaten in Repositories.</li></ul>
 
-        <h2>13. Speicher- und Löschfristen</h2>
+        <h2>14. Speicher- und Löschfristen</h2>
         <ul><li>Vertragsdaten: max. 6 Jahre (§ 257 HGB) bzw. 10 Jahre (§ 147 AO).</li><li>Bewertungen: dauerhaft, solange das bewertete Profil besteht.</li><li>Server-Logs: max. 14 Tage.</li><li>Beschwerde- und Moderations-Tickets: 3 Jahre.</li></ul>
 
-        <h2>14. Ihre Rechte als betroffene Person</h2>
+        <h2>15. Ihre Rechte als betroffene Person</h2>
         <ul><li>Auskunft (Art. 15 DSGVO)</li><li>Berichtigung (Art. 16 DSGVO)</li><li>Löschung (Art. 17 DSGVO)</li><li>Einschränkung (Art. 18 DSGVO)</li><li>Datenübertragbarkeit (Art. 20 DSGVO)</li><li>Widerspruch (Art. 21 DSGVO)</li><li>Widerruf einer Einwilligung (Art. 7 Abs. 3 DSGVO)</li><li>Beschwerde bei einer Aufsichtsbehörde (Art. 77 DSGVO): <strong>LDI NRW</strong>, Kavalleriestr. 2-4, 40213 Düsseldorf.</li></ul>
         <p>Anfragen an <strong>datenschutz@eventbörse.de</strong>.</p>
 
-        <h2>15. Bereitstellungspflicht</h2>
+        <h2>16. Bereitstellungspflicht</h2>
         <p>Stammdaten zur Vertragserfüllung sind erforderlich; ohne diese keine Buchung. Andere Daten (Profilbild) sind freiwillig.</p>
 
-        <h2>16. Automatisierte Entscheidungsfindung und Profiling</h2>
+        <h2>17. Automatisierte Entscheidungsfindung und Profiling</h2>
         <p>Unser Ranking-/Empfehlungssystem sortiert nach Relevanz, Bewertung, Premium-Status, Verfügbarkeit, Antwortgeschwindigkeit. Eine vollautomatisierte Entscheidung mit rechtlicher Wirkung im Sinne des Art. 22 DSGVO findet nicht statt; jede Sperrung oder Maßnahme mit erheblichen Folgen unterliegt menschlicher Überprüfung.</p>
 
-        <h2>17. Änderungen dieser Erklärung</h2>
+        <h2>18. Änderungen dieser Erklärung</h2>
         <p>Aktualisierung bei wesentlichen Änderungen. Wesentliche Änderungen kündigen wir Nutzern per E-Mail oder beim nächsten Login an.</p>
       </div>
     </section>
@@ -3966,6 +3996,56 @@ Datum: ___________________________________________________
         <button type="submit" class="btn-primary btn-block">
           <span class="material-icons-round">send</span> Bewertung abschicken
         </button>
+      </form>
+    </div>
+  </div>
+
+  <!-- DSA Art. 16: report the exact listing, including a reasoned notice. -->
+  <div class="modal-overlay" id="contentReportModal" onclick="closeModalOnOverlay(event)">
+    <div class="modal modal-md">
+      <button class="modal-close" aria-label="Schließen" onclick="closeModal('contentReportModal')">
+        <span class="material-icons-round">close</span>
+      </button>
+      <div class="modal-header">
+        <span class="material-icons-round modal-icon">flag</span>
+        <h2>Inhalt melden</h2>
+        <p>Rechtswidrige, irreführende oder nicht gekennzeichnete KI-Inhalte direkt melden.</p>
+      </div>
+      <form class="modal-form" id="contentReportForm" onsubmit="submitListingReport(event)">
+        <div class="form-group">
+          <label for="contentReportTarget">Betroffener Inhalt</label>
+          <input type="text" id="contentReportTarget" readonly />
+        </div>
+        <div class="form-group">
+          <label for="contentReportReason">Meldegrund</label>
+          <select id="contentReportReason" required onchange="toggleReportContactRequirement()">
+            <option value="">Bitte auswählen</option>
+            <option value="ai_undeclared">Nicht gekennzeichneter KI-Inhalt</option>
+            <option value="misleading">Irreführende oder falsche Darstellung</option>
+            <option value="rights">Urheber-, Marken- oder Persönlichkeitsrecht</option>
+            <option value="illegal">Sonstiger mutmaßlich rechtswidriger Inhalt</option>
+            <option value="sexual_abuse_minors">Sexuelle Ausbeutung Minderjähriger</option>
+            <option value="other">Anderer Grund</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="contentReportExplanation">Warum ist der Inhalt rechtswidrig oder irreführend?</label>
+          <textarea id="contentReportExplanation" rows="5" minlength="20" maxlength="4000" required placeholder="Bitte möglichst konkret begründen, bei Rechtsverstößen wenn möglich mit betroffener Norm oder betroffenem Recht."></textarea>
+          <small class="form-hint">20–4.000 Zeichen. Die genaue Inserat-URL wird automatisch mitgesendet.</small>
+        </div>
+        <div class="form-row" id="contentReportContactFields">
+          <div class="form-group">
+            <label for="contentReportName">Name</label>
+            <input type="text" id="contentReportName" maxlength="200" autocomplete="name" required />
+          </div>
+          <div class="form-group">
+            <label for="contentReportEmail">E-Mail</label>
+            <input type="email" id="contentReportEmail" maxlength="200" autocomplete="email" required />
+          </div>
+        </div>
+        <p class="report-contact-exception" id="contentReportException" hidden>Bei Meldungen zur sexuellen Ausbeutung Minderjähriger sind Name und E-Mail gemäß Art. 16 Abs. 2 lit. c DSA nicht erforderlich.</p>
+        <label class="report-good-faith"><input type="checkbox" id="contentReportGoodFaith" required /> <span>Ich bin nach bestem Wissen überzeugt, dass meine Angaben richtig und vollständig sind.</span></label>
+        <button type="submit" class="btn-primary btn-block" id="contentReportSubmit"><span class="material-icons-round">send</span> Meldung absenden</button>
       </form>
     </div>
   </div>

--- a/js/modules/board/42-guide-social-feed.js
+++ b/js/modules/board/42-guide-social-feed.js
@@ -483,14 +483,15 @@ function _buildListingPickerCardsHtml(baseList, isSearchListingFn, showSearchLis
     var img = l.image || l.providerImg || '';
     var price = l.priceLabel || (l.price ? ('ab ' + l.price + ' €') : '');
     return '<button type="button" class="eb-lpick-card" data-id="' + l.id +
-      '" data-name="' + _escHtml(l.providerName || l.title || '') + '"' +
+      '"' + _aiDisclosureAttrs(l) +
+      ' data-name="' + _escHtml(l.providerName || l.title || '') + '"' +
       ' data-category="' + _escHtml(l.categoryLabel || l.category || '') + '"' +
       ' data-price="' + (l.price || '') + '"' +
       ' data-avatar="' + _escHtml(img) + '"' +
       ' data-image="' + _escHtml(l.image || img) + '"' +
       ' data-title="' + _escHtml(l.title || '') + '"' +
       ' onclick="_selectListingCard(this)">' +
-      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')"></span>' +
+      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')">' + _aiMediaWatermarkHtml(l, 'ai-media-watermark-picker') + _aiTextDisclosureHtml(l, 'ai-text-watermark-picker') + '</span>' +
       '<span class="eb-lpick-body">' +
         '<span class="eb-lpick-title">' + _escHtml(l.title || '') + '</span>' +
         '<span class="eb-lpick-meta">' +
@@ -798,6 +799,12 @@ function ignoreUser(authorName) {
 
 function reportPost(postId) {
   closePostMenu();
+  if (String(postId).indexOf('listing-') === 0) {
+    var listingId = parseInt(String(postId).slice(8), 10);
+    var listing = (typeof LISTINGS !== 'undefined' ? LISTINGS : []).find(function(item) { return item.id === listingId; });
+    if (listing && typeof openListingReport === 'function') openListingReport(listing);
+    return;
+  }
   // Simple reason selection sheet
   var overlay = document.createElement('div');
   overlay.className = 'post-options-overlay';
@@ -1405,7 +1412,7 @@ function renderSocialPostCard(post) {
 function renderListingFeedCard(l) {
   var avatar = l.providerImg || l.providerAvatar || ebAvatar(l.providerName || 'user', l.providerName);
   var isFav = favorites.has(l.id);
-  return '<div class="feed-post-card" data-post-id="listing-' + l.id + '">' +
+  return '<div class="feed-post-card" data-post-id="listing-' + l.id + '"' + _aiDisclosureAttrs(l) + '>' +
     '<div class="feed-post-header">' +
       '<img class="feed-post-avatar" src="' + _escHtml(avatar) + '" alt="' + _escHtml(l.providerName) + '" onerror="this.onerror=null;this.src=ebAvatar(this.alt||\'user\',this.alt)" onclick="navigateTo(\'provider\',' + (l.providerId || l.id) + ')" />' +
       '<div class="feed-post-author">' +
@@ -1414,7 +1421,7 @@ function renderListingFeedCard(l) {
       '</div>' +
       '<button class="feed-more-btn" onclick="openPostMenu(event,\'listing-' + l.id + '\',\'' + (l.providerName || '').replace(/'/g, '') + '\')" aria-label="Optionen"><span class="material-icons-round">more_horiz</span></button>' +
     '</div>' +
-    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>' +
+    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />' + _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) + '</div>' +
     '<div class="feed-post-content">' + _escHtml(l.title) + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
     '<div class="feed-action-bar">' +
       '<div class="feed-actions">' +

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -156,6 +156,65 @@ function _surfaceVisibleListings(arr) {
   );
   return adminWantsDemo ? rows : filterDemos(rows);
 }
+
+// AI transparency is stored separately for copy and media so a human photo
+// is never falsely watermarked merely because the description used AI.
+// "undeclared" is reserved for migrated legacy records and is not shown as
+// proof of human authorship.
+function _aiDisclosureValue(item, kind) {
+  var key = kind === 'media' ? 'aiMediaDisclosure' : 'aiTextDisclosure';
+  var nested = item && item.aiDisclosure && item.aiDisclosure[kind];
+  var raw = item && (item[key] != null ? item[key] : nested);
+  raw = String(raw || 'undeclared').toLowerCase();
+  return ['none', 'assisted', 'generated', 'undeclared'].indexOf(raw) !== -1 ? raw : 'undeclared';
+}
+
+function _aiDisclosureAttrs(item) {
+  return ' data-ai-text="' + _aiDisclosureValue(item, 'text') + '"' +
+    ' data-ai-media="' + _aiDisclosureValue(item, 'media') + '"';
+}
+
+function _aiDisclosureLabels(item) {
+  var labels = [];
+  var textStatus = _aiDisclosureValue(item, 'text');
+  var mediaStatus = _aiDisclosureValue(item, 'media');
+  if (mediaStatus === 'generated') labels.push({ kind: 'media', label: 'KI-generiertes Bild', short: 'KI-generiert' });
+  if (mediaStatus === 'assisted') labels.push({ kind: 'media', label: 'KI-bearbeitetes Bild', short: 'KI-bearbeitet' });
+  if (textStatus === 'generated') labels.push({ kind: 'text', label: 'KI-generierter Text', short: 'KI-Text' });
+  if (textStatus === 'assisted') labels.push({ kind: 'text', label: 'KI-unterstützter Text', short: 'KI-Text bearbeitet' });
+  if (mediaStatus === 'undeclared') labels.push({ kind: 'media', label: 'KI-Status der Medien noch nicht deklariert', short: 'Medien: KI-Status offen', legacy: true });
+  if (textStatus === 'undeclared') labels.push({ kind: 'text', label: 'KI-Status des Textes noch nicht deklariert', short: 'Text: KI-Status offen', legacy: true });
+  return labels;
+}
+
+function _aiDisclosureLabelsHtml(item, extraClass) {
+  var labels = _aiDisclosureLabels(item);
+  if (!labels.length) return '';
+  return '<span class="ai-disclosure-stack' + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="KI-Transparenz">' +
+    labels.map(function(info) {
+      return '<span class="ai-content-label ai-content-label-' + info.kind + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
+        (info.legacy ? 'Altbestand: noch nicht nachdeklariert' : 'Von der einstellenden Person deklariert') + '">' +
+        '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + _escHtml(info.short) + '</span>';
+    }).join('') + '</span>';
+}
+
+function _aiMediaWatermarkHtml(item, extraClass) {
+  var mediaStatus = _aiDisclosureValue(item, 'media');
+  if (mediaStatus === 'none') return '';
+  var label = mediaStatus === 'generated' ? 'KI-GENERIERT' : (mediaStatus === 'assisted' ? 'KI-BEARBEITET' : 'KI-STATUS OFFEN');
+  var aria = mediaStatus === 'generated' ? 'KI-generiertes Bild' : (mediaStatus === 'assisted' ? 'KI-bearbeitetes Bild' : 'KI-Status der Medien noch nicht deklariert');
+  return '<span class="ai-media-watermark' + (mediaStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' + label + '</span>';
+}
+
+function _aiTextDisclosureHtml(item, extraClass) {
+  var textStatus = _aiDisclosureValue(item, 'text');
+  if (textStatus === 'none') return '';
+  var label = textStatus === 'generated' ? 'KI-Text' : (textStatus === 'assisted' ? 'KI-Text bearbeitet' : 'Text-KI offen');
+  var aria = textStatus === 'generated' ? 'KI-generierter Text' : (textStatus === 'assisted' ? 'KI-unterstützter Text' : 'KI-Status des Textes noch nicht deklariert');
+  return '<span class="ai-text-watermark' + (textStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' +
+    '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + label + '</span>';
+}
+
 function _safeRun(label, fn) {
   try {
     if (typeof fn === 'function') fn();
@@ -413,4 +472,3 @@ window._fitExploreImg = function(img) {
     img.classList.add('explore-item-img-contain');
   }
 };
-

--- a/js/modules/core/02-router-navigation.js
+++ b/js/modules/core/02-router-navigation.js
@@ -416,6 +416,7 @@ function navigateTo(page, data, skipHistory) {
       if (!window._isEditNavigation) {
         window._editingListingId = null;
         document.getElementById('createListingForm').reset();
+        try { _setAiDisclosureForm('', ''); } catch (e) {}
         document.getElementById('uploadPreview').innerHTML = '';
         document.querySelectorAll('#createFeatureTags .feature-tag').forEach(function(t) { t.classList.remove('selected'); });
         document.querySelectorAll('#createFeatureTags .feature-tag-custom-item').forEach(function(t) { t.remove(); });

--- a/js/modules/search/10-karten-home-feed.js
+++ b/js/modules/search/10-karten-home-feed.js
@@ -4,7 +4,7 @@ function renderListingCard(listing) {
   var imgs = Array.isArray(listing.images) && listing.images.length ? listing.images : [listing.image];
   var galleryId = 'gridGallery_' + listing.id;
   return `
-    <div class="listing-card" data-listing-id="${listing.id}">
+    <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
         <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bilder: ${_escHtml(listing.title)}">
           ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
@@ -15,6 +15,8 @@ function renderListingCard(listing) {
         </button>
         ${listing.badge ? '<span class="listing-badge">' + _escHtml(listing.badge) + '</span>' : ''}
         ${_boardStatusBadgeHtml(listing.id, 'bsb-on-card')}
+        ${_aiMediaWatermarkHtml(listing)}
+        ${_aiTextDisclosureHtml(listing)}
       </div>
       <div class="listing-card-body">
         <div class="listing-card-top">
@@ -76,8 +78,9 @@ function renderHeroMarquees() {
   }
 
   function cardHTML(l) {
-    return '<a class="hero-marquee-card" href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
+    return '<a class="hero-marquee-card"' + _aiDisclosureAttrs(l) + ' href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
       '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="eager"' + window.EB_IMG_ERR_ATTR + ' />' +
+      _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
       '<div class="hero-marquee-card-info">' +
         '<h4>' + _escHtml(l.title) + '</h4>' +
         '<span>' + _escHtml(l.priceLabel) + ' · ★ ' + (l.rating || 0) + '</span>' +
@@ -234,11 +237,11 @@ function renderExploreGrid(filter) {
   let items = [];
   filterDemos(LISTINGS).forEach(l => {
     // Main image
-    items.push({ image: l.image, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel });
+    items.push({ image: l.image, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel, aiTextDisclosure: l.aiTextDisclosure, aiMediaDisclosure: l.aiMediaDisclosure });
     // Additional images
     if (l.images) {
       l.images.slice(1).forEach(img => {
-        items.push({ image: img, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel });
+        items.push({ image: img, listingId: l.id, title: l.title, provider: l.providerName, price: l.priceLabel, aiTextDisclosure: l.aiTextDisclosure, aiMediaDisclosure: l.aiMediaDisclosure });
       });
     }
   });
@@ -247,8 +250,9 @@ function renderExploreGrid(filter) {
   }
   grid.innerHTML = items.map((it, i) => {
     const sizeClass = (i % 7 === 0) ? 'explore-item-large' : '';
-    return `<a href="#" class="explore-item ${sizeClass}" onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
+    return `<a href="#" class="explore-item ${sizeClass}"${_aiDisclosureAttrs(it)} onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
       <img src="${_escHtml(it.image)}" alt="${_escHtml(it.title)}" loading="lazy" onload="_fitExploreImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
+      ${_aiMediaWatermarkHtml(it)}${_aiTextDisclosureHtml(it)}
       <div class="explore-item-overlay">
         <span class="explore-item-title">${_escHtml(it.title)}</span>
         <span class="explore-item-price">${_escHtml(it.price)}</span>
@@ -320,7 +324,7 @@ function renderFeed(tab) {
     const isFav = favorites.has(l.id);
     const desc = l.description || l.title;
     const tags = l.features ? l.features.slice(0, 3) : [];
-    return `<div class="feed-card">
+    return `<div class="feed-card"${_aiDisclosureAttrs(l)}>
       <div class="feed-card-header">
         <img class="feed-card-avatar" src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
         <div class="feed-card-meta">
@@ -329,7 +333,7 @@ function renderFeed(tab) {
         </div>
         <span class="feed-card-category">${_escHtml(categoryLabel)}</span>
       </div>
-      <img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
+      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}</div>
       <div class="feed-card-body">
         <div class="feed-card-title" onclick="navigateTo('detail',${l.id})">${_escHtml(l.title)}</div>
         <div class="feed-card-desc">${_escHtml(_stripHtml(desc))}</div>
@@ -727,4 +731,3 @@ function haversineKm(lat1, lng1, lat2, lng2) {
   const a = Math.sin(dLat/2)**2 + Math.cos(lat1*Math.PI/180)*Math.cos(lat2*Math.PI/180)*Math.sin(dLng/2)**2;
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
 }
-

--- a/js/modules/search/11-suche-ki.js
+++ b/js/modules/search/11-suche-ki.js
@@ -1891,13 +1891,14 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
         ? `<span class="alt-distance-badge"><span class="material-icons-round">near_me</span> ~${l._distKm} km</span>`
         : '';
       return `
-        <div class="listing-card" onclick="navigateTo('detail', ${l.id})">
+        <div class="listing-card"${_aiDisclosureAttrs(l)} onclick="navigateTo('detail', ${l.id})">
           <div class="listing-card-img">
             <img src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" loading="lazy" />
             <button class="listing-fav" aria-label="Zu Favoriten hinzufügen" aria-pressed="false" onclick="event.stopPropagation(); toggleFavorite(${l.id}, this)">
               <span class="material-icons-round">favorite_border</span>
             </button>
             ${l.badge ? `<span class="listing-badge">${_escHtml(l.badge)}</span>` : ''}
+            ${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}
           </div>
           <div class="listing-card-body">
             <div class="listing-card-top">
@@ -1961,4 +1962,3 @@ function setView(view) {
     grid.style.gridTemplateColumns = '';
   }
 }
-

--- a/js/modules/search/12-detail-provider.js
+++ b/js/modules/search/12-detail-provider.js
@@ -21,7 +21,8 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />${_aiMediaWatermarkHtml(listing)}`;
+    heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 
   // Swipeable gallery carousel
@@ -33,7 +34,7 @@ function loadDetail(listingId) {
       var delBtn = _detailCanModerate && img !== window.EB_IMG_FALLBACK
         ? '<button type="button" class="detail-gallery-admin-del" title="Bild als Admin löschen" aria-label="Bild als Admin löschen" onclick="adminDeleteListingImage(' + i + ', event)"><span class="material-icons-round">delete</span> Löschen</button>'
         : '';
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + delBtn + '</div>';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + _aiMediaWatermarkHtml(listing) + delBtn + '</div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" aria-label="Vorheriges Bild" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -42,6 +43,8 @@ function loadDetail(listingId) {
     imgs.map(function(_, i) { return '<button class="detail-gallery-dot' + (i === 0 ? ' active' : '') + '" onclick="detailGalleryGoTo(' + i + ')" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') +
     '</div>' +
     '<div class="detail-gallery-counter" id="detailGalleryCounter">1 / ' + imgs.length + '</div>' : '');
+  gallery.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
+  gallery.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   _initDetailGallerySwipe();
   // Detect wide banners for hero + gallery
   detectWideBannerImg(heroImg.querySelector('img'));
@@ -62,6 +65,17 @@ function loadDetail(listingId) {
   document.getElementById('detailRating').textContent = listing.rating || '0';
   document.getElementById('detailReviewCount').textContent = '(' + (listing.reviews || 0) + ' Bewertungen)';
   document.getElementById('detailLocation').textContent = listing.region;
+  var aiDisclosure = document.getElementById('detailAiDisclosure');
+  if (aiDisclosure) {
+    var aiLabels = _aiDisclosureLabelsHtml(listing, 'ai-disclosure-detail');
+    var hasOpenStatus = _aiDisclosureValue(listing, 'text') === 'undeclared' || _aiDisclosureValue(listing, 'media') === 'undeclared';
+    var aiNote = hasOpenStatus
+      ? 'Altbestand: Die ausdrückliche Nachdeklaration steht noch aus.'
+      : 'Vom Anbieter bei Veröffentlichung deklariert.';
+    aiDisclosure.innerHTML = aiLabels ? aiLabels + '<small>' + aiNote + '</small>' : '';
+    aiDisclosure.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
+    aiDisclosure.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
+  }
   document.getElementById('detailProviderImg').src = _resolveAvatar(listing.providerImg, listing.providerName);
   document.getElementById('detailProviderName').textContent = listing.providerName;
   document.getElementById('detailProviderTag').textContent = `Superhost · Seit ${listing.providerSince} auf Eventbörse`;
@@ -69,6 +83,8 @@ function loadDetail(listingId) {
   // Show edit button only for own listings
   var editBtn = document.getElementById('detailEditBtn');
   if (editBtn) editBtn.style.display = (currentUser && listing.providerId === currentUser.id) ? '' : 'none';
+  var reportBtn = document.getElementById('detailReportBtn');
+  if (reportBtn) reportBtn.style.display = listing._fromDb ? '' : 'none';
 
   // Board-Status-Chip: zeigt, ob dieses Inserat schon im Planungsboard steckt
   // (Im Plan / Kontaktiert / Angebot / Gebucht) — Verknüpfung Detail ↔ Board.
@@ -129,6 +145,70 @@ function loadDetail(listingId) {
   // Negotiation price
   document.getElementById('negOriginalPrice').value = listing.priceLabel;
   renderDetailCollaborationSuggestions(listing.providerId);
+}
+
+var _contentReportListing = null;
+
+function openListingReport(listingArg) {
+  var listing = listingArg && listingArg.id ? listingArg : currentListing;
+  if (!listing || !listing._fromDb || !listing._dbId) {
+    showToast('Dieses Demo-Inserat ist nicht öffentlich meldbar.', 'info');
+    return;
+  }
+  _contentReportListing = listing;
+  var form = document.getElementById('contentReportForm');
+  if (form) form.reset();
+  var target = document.getElementById('contentReportTarget');
+  if (target) target.value = listing.title + ' · /detail/' + listing.id;
+  var name = document.getElementById('contentReportName');
+  var email = document.getElementById('contentReportEmail');
+  if (name && currentUser) name.value = currentUser.name || '';
+  if (email && currentUser) email.value = currentUser.email || '';
+  toggleReportContactRequirement();
+  openModal('contentReportModal');
+}
+
+function toggleReportContactRequirement() {
+  var reason = (document.getElementById('contentReportReason') || {}).value || '';
+  var optional = reason === 'sexual_abuse_minors';
+  var name = document.getElementById('contentReportName');
+  var email = document.getElementById('contentReportEmail');
+  var note = document.getElementById('contentReportException');
+  if (name) name.required = !optional;
+  if (email) email.required = !optional;
+  if (note) note.hidden = !optional;
+}
+
+async function submitListingReport(event) {
+  event.preventDefault();
+  var listing = _contentReportListing;
+  if (!listing || !listing._dbId) return;
+  var btn = document.getElementById('contentReportSubmit');
+  _setBtnLoading(btn, true);
+  try {
+    var response = await fetch(_apiUrl('listings/' + listing._dbId + '/report'), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: _apiHeaders(),
+      body: JSON.stringify({
+        reason: (document.getElementById('contentReportReason') || {}).value || '',
+        explanation: (document.getElementById('contentReportExplanation') || {}).value || '',
+        reporterName: (document.getElementById('contentReportName') || {}).value || '',
+        reporterEmail: (document.getElementById('contentReportEmail') || {}).value || '',
+        goodFaith: !!(document.getElementById('contentReportGoodFaith') || {}).checked
+      })
+    });
+    var data = {};
+    try { data = await response.json(); } catch (e) {}
+    if (!response.ok) throw new Error(data.message || 'Meldung konnte nicht gesendet werden.');
+    closeModal('contentReportModal');
+    _contentReportListing = null;
+    showToast('Meldung erhalten · Vorgang ' + (data.caseId || ''), 'verified_user');
+  } catch (err) {
+    showToast(err.message || 'Meldung konnte nicht gesendet werden.', 'error');
+  } finally {
+    _setBtnLoading(btn, false);
+  }
 }
 
 // ========== PROVIDER PROFILE ==========

--- a/js/modules/search/13-event-radar.js
+++ b/js/modules/search/13-event-radar.js
@@ -572,7 +572,7 @@ function _feedRadarPopupHtml(gruppe) {
       + '<span class="material-icons-round">' + (hit.art === 'event' ? 'celebration' : 'storefront') + '</span>'
       + '<span><strong>' + _escHtml(title) + '</strong><small>'
       + _escHtml(hit.ort || '') + ' · ' + _escHtml(radarEntfernung(hit.km))
-      + (hit.genau ? '' : ' · ca.') + '</small></span>'
+      + (hit.genau ? '' : ' · ca.') + '</small>' + _aiDisclosureLabelsHtml(d, 'ai-disclosure-radar-popup') + '</span>'
       + '<span class="material-icons-round">arrow_forward</span></button>';
   }).join('');
   return '<div class="feed-radar-popup"><div class="feed-radar-popup-head">'
@@ -780,9 +780,9 @@ function _drawFeedRadar() {
       var d = hit.daten || {};
       var title = d.title || d.name || 'Event';
       var image = (d.images && d.images[0]) || d.image || window.EB_IMG_FALLBACK;
-      return '<article class="feed-radar-result" data-radar-index="' + index + '">' +
+      return '<article class="feed-radar-result" data-radar-index="' + index + '"' + _aiDisclosureAttrs(d) + '>' +
         '<button type="button" class="feed-radar-result-map" onclick="feedRadarFocus(' + index + ')" aria-label="' + _escHtml(title) + ' auf der Karte zeigen">' +
-        '<img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
+        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '>' + _aiMediaWatermarkHtml(d) + _aiTextDisclosureHtml(d) + '</span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
         '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong><small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
         '<button type="button" class="feed-radar-result-open" onclick="feedRadarOpen(' + index + ')" aria-label="' + _escHtml(title) + ' öffnen"><span class="material-icons-round">arrow_forward</span></button></article>';
     }).join('') + '</div>';

--- a/js/modules/ui/22-inserat-settings-uploads.js
+++ b/js/modules/ui/22-inserat-settings-uploads.js
@@ -579,6 +579,82 @@ const CATEGORY_LABELS = {
   moderation: 'Moderation'
 };
 
+function _selectedAiDisclosure(kind) {
+  var name = kind === 'media' ? 'createAiMediaDisclosure' : 'createAiTextDisclosure';
+  var selected = document.querySelector('input[name="' + name + '"]:checked');
+  return selected ? selected.value : '';
+}
+
+function _setAiDisclosureForm(textStatus, mediaStatus) {
+  ['text', 'media'].forEach(function(kind) {
+    var status = kind === 'media' ? mediaStatus : textStatus;
+    var name = kind === 'media' ? 'createAiMediaDisclosure' : 'createAiTextDisclosure';
+    document.querySelectorAll('input[name="' + name + '"]').forEach(function(input) {
+      input.checked = ['none', 'assisted', 'generated'].indexOf(status) !== -1 && input.value === status;
+    });
+  });
+  _aiDisclosureFormChanged();
+}
+
+function _aiDisclosureFormChanged() {
+  var section = document.getElementById('aiDisclosureSection');
+  if (section) section.classList.remove('has-error');
+  _updateListingPreviewAiLabels();
+  _updateListingLivePreview();
+}
+
+function _updateListingPreviewAiLabels() {
+  var mediaStatus = _selectedAiDisclosure('media');
+  document.querySelectorAll('#uploadPreview .upload-preview-item').forEach(function(item) {
+    var old = item.querySelector('.ai-media-watermark');
+    if (old) old.remove();
+    var html = _aiMediaWatermarkHtml({ aiMediaDisclosure: mediaStatus }, 'ai-media-watermark-preview');
+    if (html) item.insertAdjacentHTML('beforeend', html);
+  });
+}
+
+// Burn the declaration into every newly uploaded AI image. The UI overlay is
+// still rendered separately because it must remain visible on all surfaces;
+// this pixel watermark additionally survives opening or sharing the file.
+function _aiWatermarkBlob(blob, mediaStatus) {
+  if (!blob || (mediaStatus !== 'assisted' && mediaStatus !== 'generated')) return Promise.resolve(blob);
+  return new Promise(function(resolve) {
+    var url = URL.createObjectURL(blob);
+    var img = new Image();
+    img.onload = function() {
+      try {
+        var canvas = document.createElement('canvas');
+        canvas.width = img.naturalWidth || img.width;
+        canvas.height = img.naturalHeight || img.height;
+        var ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        var label = mediaStatus === 'generated' ? 'KI-GENERIERT · EVENTBÖRSE' : 'KI-BEARBEITET · EVENTBÖRSE';
+        var fontSize = Math.max(20, Math.round(canvas.width * 0.027));
+        var padX = Math.round(fontSize * 0.65);
+        var padY = Math.round(fontSize * 0.42);
+        ctx.font = '700 ' + fontSize + 'px Arial, sans-serif';
+        var textWidth = ctx.measureText(label).width;
+        var boxW = textWidth + padX * 2;
+        var boxH = fontSize + padY * 2;
+        var x = Math.max(12, canvas.width - boxW - Math.round(fontSize * 0.6));
+        var y = Math.max(12, canvas.height - boxH - Math.round(fontSize * 0.6));
+        ctx.fillStyle = 'rgba(12, 15, 24, 0.84)';
+        ctx.fillRect(x, y, boxW, boxH);
+        ctx.fillStyle = '#ffffff';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(label, x + padX, y + boxH / 2);
+        canvas.toBlob(function(marked) { resolve(marked || blob); }, 'image/jpeg', 0.92);
+      } catch (e) {
+        resolve(blob);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    };
+    img.onerror = function() { URL.revokeObjectURL(url); resolve(blob); };
+    img.src = url;
+  });
+}
+
 async function submitListing(e) {
   if (e && e.preventDefault) e.preventDefault();
 
@@ -632,12 +708,24 @@ async function submitListing(e) {
   const priceMaxRaw = parseInt((document.getElementById('createPriceMax')||{}).value) || 0;
   const priceMax = (priceMaxRaw > 0 && priceMaxRaw > price) ? priceMaxRaw : 0;
   const priceModel = requiredEl('createPriceModel', 'Preismodell').value;
+  const aiTextDisclosure = _selectedAiDisclosure('text');
+  const aiMediaDisclosure = _selectedAiDisclosure('media');
 
   // Basic validation
   if (!title)       { _releaseGuard(); showToast('Bitte gib einen Titel ein', 'warning'); nextStep(1); return; }
   if (!category)    { _releaseGuard(); showToast('Bitte wähle eine Kategorie', 'warning'); nextStep(1); return; }
   if (!description) { _releaseGuard(); showToast('Bitte gib eine Beschreibung ein', 'warning'); nextStep(1); return; }
   if (!price)       { _releaseGuard(); showToast(isSearch ? 'Bitte gib dein Budget ein' : 'Bitte gib einen Preis ein', 'warning'); nextStep(1); return; }
+  if (!aiTextDisclosure || !aiMediaDisclosure) {
+    _releaseGuard();
+    var aiSection = document.getElementById('aiDisclosureSection');
+    if (aiSection) {
+      aiSection.classList.add('has-error');
+      aiSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    showToast('Bitte die KI-Nutzung für Text und Medien ausdrücklich angeben.', 'warning');
+    return;
+  }
   const region = document.getElementById('createRegionValue').value.trim()
     || document.getElementById('createRegion').value.trim() || 'Deutschland';
   const dateFrom = document.getElementById('createDateFrom').value;
@@ -701,15 +789,20 @@ async function submitListing(e) {
   // Upload images: cropped blobs first, then data URLs, keep existing URLs
   var uploadPromises = imgEntries.map(function(entry) {
     if (entry.blob) {
-      var file = new File([entry.blob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
-      return uploadFile(file).then(function(r) { return r.url; });
+      return _aiWatermarkBlob(entry.blob, aiMediaDisclosure).then(function(markedBlob) {
+        var file = new File([markedBlob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
+        return uploadFile(file).then(function(r) { return r.url; });
+      });
     }
     if (entry.src.startsWith('data:')) {
       var arr = entry.src.split(','), mime = arr[0].match(/:(.*?);/)[1];
       var bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
       while (n--) u8arr[n] = bstr.charCodeAt(n);
-      var file = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
-      return uploadFile(file).then(function(r) { return r.url; });
+      var sourceFile = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
+      return _aiWatermarkBlob(sourceFile, aiMediaDisclosure).then(function(markedBlob) {
+        var file = new File([markedBlob], 'listing-' + Date.now() + '.jpg', { type: 'image/jpeg' });
+        return uploadFile(file).then(function(r) { return r.url; });
+      });
     }
     return Promise.resolve(entry.src);
   });
@@ -725,6 +818,8 @@ async function submitListing(e) {
     var payload = {
       title: title,
       listingType: listingType,
+      aiTextDisclosure: aiTextDisclosure,
+      aiMediaDisclosure: aiMediaDisclosure,
       category: category,
       categoryLabel: CATEGORY_LABELS[category] || category,
       description: '<p>' + description.replace(/\n/g, '</p><p>') + '</p>',
@@ -803,6 +898,7 @@ async function submitListing(e) {
 
       // Reset the form
       document.getElementById('createListingForm').reset();
+      try { _setAiDisclosureForm('', ''); } catch (e) {}
       document.getElementById('uploadPreview').innerHTML = '';
       document.querySelectorAll('#createFeatureTags .feature-tag').forEach(function(t) { t.classList.remove('selected'); });
       document.querySelectorAll('#createFeatureTags .feature-tag-custom-item').forEach(function(t) { t.remove(); });
@@ -1152,6 +1248,12 @@ function _updateListingLivePreview() {
     return;
   }
   container.style.display = '';
+  var previewDisclosure = {
+    aiTextDisclosure: _selectedAiDisclosure('text') || 'undeclared',
+    aiMediaDisclosure: _selectedAiDisclosure('media') || 'undeclared'
+  };
+  container.setAttribute('data-ai-text', _aiDisclosureValue(previewDisclosure, 'text'));
+  container.setAttribute('data-ai-media', _aiDisclosureValue(previewDisclosure, 'media'));
 
   // Build slides
   track.innerHTML = '';
@@ -1162,6 +1264,8 @@ function _updateListingLivePreview() {
     slideImg.src = img.src;
     slideImg.alt = 'Vorschau';
     slide.appendChild(slideImg);
+    var watermark = _aiMediaWatermarkHtml(previewDisclosure, 'ai-media-watermark-live');
+    if (watermark) slide.insertAdjacentHTML('beforeend', watermark);
     track.appendChild(slide);
   });
 
@@ -1717,4 +1821,3 @@ function initDragScroll() {
     document.querySelectorAll(sel).forEach(_makeDraggable);
   });
 }
-

--- a/js/modules/ui/24-favoriten-inserate-admin.js
+++ b/js/modules/ui/24-favoriten-inserate-admin.js
@@ -47,6 +47,8 @@ function renderMyListings() {
               title: l.title,
               category: l.category,
               categoryLabel: l.categoryLabel || l.category,
+              aiTextDisclosure: l.aiTextDisclosure,
+              aiMediaDisclosure: l.aiMediaDisclosure,
               image: (l.images && l.images[0]) || '',
               images: l.images || [],
               location: l.location,
@@ -89,8 +91,9 @@ function renderMyListings() {
           // DB events from API
           if (evt._fromDb) {
             return '<div class="my-listing-card">' +
-              '<div class="my-listing-img">' +
+              '<div class="my-listing-img"' + _aiDisclosureAttrs(evt) + '>' +
                 '<img src="' + _escHtml(evt.image) + '" alt="' + _escHtml(evt.title) + '" />' +
+                _aiMediaWatermarkHtml(evt) + _aiTextDisclosureHtml(evt) +
                 '<span class="status-badge status-active">Aktiv</span>' +
               '</div>' +
               '<div class="my-listing-info">' +
@@ -170,8 +173,9 @@ function renderMyListings() {
           var rating = l.rating || 0;
           var reviewCount = l.reviewCount || 0;
           return '<div class="my-listing-card">' +
-            '<div class="my-listing-img">' +
+            '<div class="my-listing-img"' + _aiDisclosureAttrs(l) + '>' +
               '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" />' +
+              _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
               '<span class="status-badge status-active">Aktiv</span>' +
             '</div>' +
             '<div class="my-listing-info">' +
@@ -231,6 +235,8 @@ function renderMyListings() {
               title: l.title,
               category: l.category,
               categoryLabel: l.categoryLabel || l.category,
+              aiTextDisclosure: l.aiTextDisclosure,
+              aiMediaDisclosure: l.aiMediaDisclosure,
               image: (l.images && l.images[0]) || '',
               images: l.images || [],
               location: l.location,
@@ -292,6 +298,9 @@ function editListing(listingId) {
 
   // Typ (Biete/Suche) aus dem Inserat übernehmen
   try { _clSetType(listing.listingType === 'search' ? 'search' : 'offer'); } catch (e) {}
+  // Legacy records remain unselected and require an explicit declaration on
+  // the next save; do not silently turn "undeclared" into "without AI".
+  try { _setAiDisclosureForm(listing.aiTextDisclosure, listing.aiMediaDisclosure); } catch (e) {}
   // Verfügbarkeitskalender mit bestehenden Block-Tagen vorbefüllen
   try { _clAvailPrefill(listing); } catch (e) {}
 
@@ -914,4 +923,3 @@ function adminChangeRole(userId, role) {
     loadAdminUsers();
   }).catch(function(e) { showToast(e.message || 'Rollenwechsel fehlgeschlagen', 'error'); });
 }
-

--- a/js/modules/ui/52-release-vision.js
+++ b/js/modules/ui/52-release-vision.js
@@ -213,7 +213,7 @@ function _drawBusinessMediaPreview(seedExtra) {
   ctx.fillStyle=style==='minimal'?'#18181b':'#fff';ctx.font='700 '+Math.round(c.width/20)+'px Inter, sans-serif';ctx.textAlign='left';
   var words=prompt.trim().split(/\s+/), lines=[],line=''; words.forEach(function(w){ if((line+' '+w).length>28){lines.push(line);line=w;}else line+=(line?' ':'')+w;});if(line)lines.push(line);
   lines.slice(0,3).forEach(function(l,i){ctx.fillText(l,70,c.height-170+(i-lines.length+1)*62);});
-  ctx.font='600 20px Inter, sans-serif';ctx.fillText('EVENTBÖRSE · EINZIGARTIGER ACCOUNT-ENTWURF',72,c.height-62);
+  ctx.font='600 20px Inter, sans-serif';ctx.fillText('DIGITAL ERSTELLT · EVENTBÖRSE · KEIN KI-FOTOMODELL',72,c.height-62);
 }
 function createAccountMedia() {
   var c=document.getElementById('mediaStudioCanvas'); if(!c) return;
@@ -223,7 +223,7 @@ function createAccountMedia() {
     var file=new File([blob],'eventboerse-motiv-'+Date.now()+'.png',{type:'image/png'});
     uploadFile(file).then(function(data){
       var result=document.getElementById('mediaStudioResult');
-      if(result) result.innerHTML='<span><span class="material-icons-round">verified_user</span> Account #' + _escHtml(String(data.ownerId||currentUser.id)) + ' zugeordnet</span><button class="btn-outline btn-sm" onclick="useMediaInPortfolio(\'' + _escHtml(data.url) + '\')">Ins Portfolio</button><button class="btn-outline btn-sm" onclick="useMediaAsProfilePhoto(\'' + _escHtml(data.url) + '\')">Als Profilbild</button>';
+      if(result) result.innerHTML='<span><span class="material-icons-round">verified_user</span> Digital erstellt · kein KI-Fotomodell · Account #' + _escHtml(String(data.ownerId||currentUser.id)) + '</span><button class="btn-outline btn-sm" onclick="useMediaInPortfolio(\'' + _escHtml(data.url) + '\')">Ins Portfolio</button><button class="btn-outline btn-sm" onclick="useMediaAsProfilePhoto(\'' + _escHtml(data.url) + '\')">Als Profilbild</button>';
       showToast('Motiv sicher in deinem Account gespeichert.','verified_user');
     }).catch(function(err){ showToast(err.message||'Upload fehlgeschlagen.','error'); });
   },'image/png',0.92);

--- a/release-vision.css
+++ b/release-vision.css
@@ -86,3 +86,9 @@ body.dark-mode .feed-radar-map .leaflet-tile-pane,[data-theme="dark"] .feed-rada
 @media(max-width:700px){.feed-radar-map{height:390px}.feed-radar-map-top{top:10px;left:10px;right:10px}.feed-radar-map-top>span{padding:7px 9px;font-size:.66rem}.feed-radar-legend{left:10px;right:58px;bottom:11px}.feed-radar-result{grid-template-columns:minmax(0,1fr) 40px}.feed-radar-result-map{grid-template-columns:84px minmax(0,1fr);gap:10px}.feed-radar-result-map>img{width:84px;height:84px}.feed-radar-result-title{font-size:.86rem}.feed-radar-map .leaflet-control-attribution{max-width:180px;white-space:normal;line-height:1.1}}
 @media(max-width:420px){.feed-radar-map{height:350px}.feed-radar-map-radius{display:none!important}.feed-radar-legend{font-size:.6rem}.feed-radar-result{grid-template-columns:minmax(0,1fr) 38px}.feed-radar-result-map{grid-template-columns:72px minmax(0,1fr);padding:7px}.feed-radar-result-map>img{width:72px;height:78px}.feed-radar-result-map small{font-size:.66rem}}
 @media(prefers-reduced-motion:reduce){.feed-radar-live-dot.scannt{animation:none}.feed-radar-marker{transition:none}}
+
+/* AI labels need an image wrapper so the declaration stays attached to the
+   exact Radar thumbnail rather than floating over the distance copy. */
+.feed-radar-result-image{position:relative;display:block;width:104px;height:92px;overflow:hidden;border-radius:11px}.feed-radar-result-image>img{display:block;width:100%;height:100%;object-fit:cover}.feed-radar-result-image .ai-media-watermark,.feed-radar-result-image .ai-text-watermark{left:4px;max-width:calc(100% - 8px);padding:3px 4px;font-size:6px}.feed-radar-result-image .ai-media-watermark{bottom:4px}.feed-radar-result-image .ai-text-watermark{bottom:20px}
+@media(max-width:700px){.feed-radar-result-image{width:84px;height:84px}}
+@media(max-width:420px){.feed-radar-result-image{width:72px;height:78px}}

--- a/styles.css
+++ b/styles.css
@@ -7339,6 +7339,7 @@ span.flatpickr-weekday {
   flex: 0 0 100%;
   height: 100%;
   scroll-snap-align: start;
+  position: relative;
   background: var(--bg-alt);
 }
 .listing-live-preview-slide img {
@@ -16993,3 +16994,112 @@ body.dark-mode .radar-chip.aktiv { background: var(--primary); color: #fff; }
 .geo-status { font-size: .76rem; color: var(--text-light); margin: .45rem 0 0; min-height: 1.1rem; }
 .form-optional { font-weight: 400; color: var(--text-light); font-size: .8em; }
 body.dark-mode .geo-treffer-btn { background: var(--bg-alt); color: var(--text); }
+
+/* ===== AI TRANSPARENCY / ART. 50 AI ACT ===== */
+.ai-media-watermark,
+.ai-text-watermark {
+  position: absolute;
+  left: 10px;
+  z-index: 30;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: calc(100% - 20px);
+  padding: 5px 8px;
+  border: 1px solid rgba(255,255,255,.72);
+  border-radius: 7px;
+  color: #fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,.28);
+  font-size: 10px;
+  font-weight: 850;
+  line-height: 1;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.ai-media-watermark { bottom: 10px; background: rgba(12,15,24,.88); }
+.ai-text-watermark { bottom: 40px; background: rgba(70,24,114,.93); }
+.ai-watermark-open { border-style: dashed; background: rgba(55,65,81,.9); color: #f9fafb; }
+.ai-text-watermark .material-icons-round { font-size: 12px; }
+.hero-marquee-card { position: relative; }
+.hero-marquee-card .ai-media-watermark { top: 101px; bottom: auto; left: 8px; padding: 4px 6px; font-size: 8px; }
+.hero-marquee-card .ai-text-watermark { top: 74px; bottom: auto; left: 8px; padding: 4px 6px; font-size: 8px; }
+.explore-item .ai-media-watermark { top: 10px; bottom: auto; }
+.explore-item .ai-text-watermark { top: 40px; bottom: auto; }
+.detail-hero-img,
+.feed-card-media,
+.my-listing-img,
+.eb-lpick-thumb { position: relative; }
+.feed-card-media .feed-card-image { display: block; width: 100%; }
+.detail-hero-img .ai-media-watermark { bottom: 14px; }
+.ai-media-watermark-picker,
+.ai-text-watermark-picker { left: 3px; right: 3px; max-width: none; padding: 3px; font-size: 6px; overflow: hidden; }
+.ai-media-watermark-picker { bottom: 3px; }
+.ai-text-watermark-picker { bottom: 17px; }
+.ai-media-watermark-preview,
+.ai-media-watermark-live { bottom: 8px; }
+
+.ai-disclosure-stack {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ai-content-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 750;
+  line-height: 1.15;
+}
+.ai-content-label .material-icons-round { color: #6d28d9; font-size: 14px; }
+.ai-content-label-open { border-style: dashed; color: var(--text-light); }
+.ai-content-label-open .material-icons-round { color: #6b7280; }
+.detail-ai-disclosure { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.detail-ai-disclosure:empty { display: none; }
+.detail-ai-disclosure small { color: var(--text-light); font-size: 11px; }
+.ai-disclosure-radar-popup { margin-top: 4px; }
+.ai-disclosure-radar-popup .ai-content-label { padding: 3px 5px; font-size: 8px; }
+
+.ai-declaration {
+  display: grid;
+  gap: 15px;
+  margin: 18px 0 22px;
+  padding: 18px;
+  border: 1px solid rgba(109,40,217,.28);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(109,40,217,.055), rgba(255,56,92,.045));
+}
+.ai-declaration.has-error { border-color: #b42318; box-shadow: 0 0 0 3px rgba(180,35,24,.12); }
+.ai-declaration-head { display: flex; align-items: flex-start; gap: 11px; }
+.ai-declaration-head > .material-icons-round { color: #6d28d9; font-size: 27px; }
+.ai-declaration-head h3 { margin: 0 0 4px; font-size: 17px; }
+.ai-declaration-head h3 span { margin-left: 5px; color: #6d28d9; font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+.ai-declaration-head p { margin: 0; color: var(--text-light); font-size: 13px; line-height: 1.5; }
+.ai-declaration-group { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 8px; min-width: 0; padding: 0; border: 0; }
+.ai-declaration-group legend { grid-column: 1 / -1; margin-bottom: 2px; color: var(--text); font-size: 13px; font-weight: 800; }
+.ai-declaration-group label { display: flex; align-items: flex-start; gap: 8px; padding: 11px; border: 1px solid var(--border); border-radius: 11px; background: var(--bg); cursor: pointer; }
+.ai-declaration-group label:has(input:checked) { border-color: #6d28d9; box-shadow: 0 0 0 2px rgba(109,40,217,.13); }
+.ai-declaration-group input { margin-top: 3px; accent-color: #6d28d9; }
+.ai-declaration-group strong,
+.ai-declaration-group small { display: block; }
+.ai-declaration-group strong { color: var(--text); font-size: 12px; line-height: 1.3; }
+.ai-declaration-group small { margin-top: 3px; color: var(--text-light); font-size: 10px; line-height: 1.35; }
+.ai-declaration-legal { margin: 0; color: var(--text-light); font-size: 11px; line-height: 1.5; }
+.ai-declaration-legal a { color: var(--primary-text); font-weight: 700; }
+
+.report-good-faith { display: flex; align-items: flex-start; gap: 9px; margin: 4px 0 14px; color: var(--text); font-size: 13px; line-height: 1.45; }
+.report-good-faith input { margin-top: 3px; accent-color: var(--primary); }
+.report-contact-exception { margin: -3px 0 12px; padding: 9px 11px; border-radius: 9px; background: var(--bg-alt); color: var(--text-light); font-size: 11px; line-height: 1.45; }
+
+@media (max-width: 720px) {
+  .ai-declaration-group { grid-template-columns: 1fr; }
+  .ai-declaration { padding: 15px; }
+  .ai-media-watermark, .ai-text-watermark { font-size: 9px; }
+}

--- a/tests/e2e/ki-transparenz.spec.js
+++ b/tests/e2e/ki-transparenz.spec.js
@@ -1,0 +1,168 @@
+// KI-Transparenz: keine stillen Defaults, sichtbare Kennzeichnung auf jeder
+// Inseratflaeche und ein belastbarer Meldeweg fuer falsche Deklarationen.
+const { test, expect } = require('@playwright/test');
+const { openApp, expectNoPageErrors } = require('./helpers');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const FUNCTIONS = fs.readFileSync(path.join(ROOT, 'functions.php'), 'utf8');
+const SHELL = fs.readFileSync(path.join(ROOT, 'app-shell.html'), 'utf8');
+const BASIS = fs.readFileSync(path.join(ROOT, 'js/modules/core/00-basis.js'), 'utf8');
+const UPLOADS = fs.readFileSync(path.join(ROOT, 'js/modules/ui/22-inserat-settings-uploads.js'), 'utf8');
+const DETAIL = fs.readFileSync(path.join(ROOT, 'js/modules/search/12-detail-provider.js'), 'utf8');
+const VISION = fs.readFileSync(path.join(ROOT, 'js/modules/ui/52-release-vision.js'), 'utf8');
+const RATE_LIMIT = fs.readFileSync(path.join(ROOT, 'includes/security/rate-limit.php'), 'utf8');
+
+test.describe('Deklaration ist ausdruecklich und dauerhaft', () => {
+  test('Text und Medien brauchen getrennte Auswahl ohne Vorbelegung', () => {
+    expect(SHELL.match(/name="createAiTextDisclosure"/g) || []).toHaveLength(3);
+    expect(SHELL.match(/name="createAiMediaDisclosure"/g) || []).toHaveLength(3);
+    expect(SHELL).not.toMatch(/name="createAi(?:Text|Media)Disclosure"[^>]*\schecked(?:\s|>|=)/);
+    expect(UPLOADS).toMatch(/if \(!aiTextDisclosure \|\| !aiMediaDisclosure\)/);
+    expect(UPLOADS).toMatch(/aiTextDisclosure:\s*aiTextDisclosure/);
+    expect(UPLOADS).toMatch(/aiMediaDisclosure:\s*aiMediaDisclosure/);
+  });
+
+  test('Server akzeptiert keine fehlende oder erfundene Erklaerung', () => {
+    expect(FUNCTIONS).toMatch(/function eb_ai_disclosure_pruefen/);
+    expect(FUNCTIONS).toMatch(/array\( 'none', 'assisted', 'generated' \)/);
+    expect(FUNCTIONS).toMatch(/\$params\['aiTextDisclosure'\] \?\? ''/);
+    expect(FUNCTIONS).toMatch(/\$params\['aiMediaDisclosure'\] \?\? ''/);
+    expect(FUNCTIONS).not.toMatch(/array\( 'none', 'assisted', 'generated', 'undeclared' \)/);
+    const update = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_listings_update'), FUNCTIONS.indexOf('function eb_listings_delete'));
+    expect(update).toMatch(/\$params\['aiTextDisclosure'\] \?\? ''/);
+    expect(update).toMatch(/\$params\['aiMediaDisclosure'\] \?\? ''/);
+  });
+
+  test('Migration erfindet fuer Altinhalte keine menschliche Urheberschaft', () => {
+    expect(FUNCTIONS).toMatch(/define\( 'EB_DB_VERSION', '2\.6' \)/);
+    expect(FUNCTIONS).toMatch(/ai_text_disclosure varchar\(20\) NOT NULL DEFAULT 'undeclared'/);
+    expect(FUNCTIONS).toMatch(/ai_media_disclosure varchar\(20\) NOT NULL DEFAULT 'undeclared'/);
+    expect(BASIS).toContain('Medien: KI-Status offen');
+    expect(BASIS).toContain('Text: KI-Status offen');
+  });
+});
+
+test.describe('Kennzeichnung bleibt an jedem Inhalt', () => {
+  test('Helfer liefern sichtbare und maschinenlesbare Kennzeichnung', async ({ page }) => {
+    const errors = await openApp(page);
+    const result = await page.evaluate(() => {
+      const ai = { aiTextDisclosure: 'assisted', aiMediaDisclosure: 'generated' };
+      const human = { aiTextDisclosure: 'none', aiMediaDisclosure: 'none' };
+      const legacy = {};
+      return {
+        attrs: _aiDisclosureAttrs(ai),
+        media: _aiMediaWatermarkHtml(ai),
+        text: _aiTextDisclosureHtml(ai),
+        labels: _aiDisclosureLabelsHtml(ai),
+        humanMedia: _aiMediaWatermarkHtml(human),
+        humanText: _aiTextDisclosureHtml(human),
+        legacyMedia: _aiMediaWatermarkHtml(legacy),
+        legacyText: _aiTextDisclosureHtml(legacy),
+      };
+    });
+    expect(result.attrs).toContain('data-ai-text="assisted"');
+    expect(result.attrs).toContain('data-ai-media="generated"');
+    expect(result.media).toContain('KI-GENERIERT');
+    expect(result.text).toContain('KI-Text bearbeitet');
+    expect(result.labels).toContain('KI-generiert');
+    expect(result.humanMedia).toBe('');
+    expect(result.humanText).toBe('');
+    expect(result.legacyMedia).toContain('KI-STATUS OFFEN');
+    expect(result.legacyText).toContain('Text-KI offen');
+    expectNoPageErrors(errors, 'KI-Kennzeichnungshelfer');
+  });
+
+  test('Inseratkarte traegt Datenattribute und beide sichtbaren Hinweise', async ({ page }) => {
+    const errors = await openApp(page);
+    const html = await page.evaluate(() => renderListingCard({
+      id: 991,
+      title: 'Deklarierter Testinhalt',
+      image: window.EB_IMG_FALLBACK,
+      images: [window.EB_IMG_FALLBACK],
+      providerName: 'Transparenz-Test',
+      providerImg: window.EB_IMG_FALLBACK,
+      providerId: 1,
+      priceLabel: '100 €',
+      rating: 5,
+      reviews: 1,
+      region: 'Berlin',
+      aiTextDisclosure: 'generated',
+      aiMediaDisclosure: 'assisted',
+    }));
+    expect(html).toContain('data-ai-text="generated"');
+    expect(html).toContain('data-ai-media="assisted"');
+    expect(html).toContain('KI-BEARBEITET');
+    expect(html).toContain('KI-Text');
+    expectNoPageErrors(errors, 'KI-Inseratkarte');
+  });
+
+  test('neue KI-Bilder bekommen das Wasserzeichen in die Pixel', async ({ page }) => {
+    const errors = await openApp(page);
+    const marked = await page.evaluate(async () => {
+      const source = document.createElement('canvas');
+      source.width = 900;
+      source.height = 600;
+      const sourceCtx = source.getContext('2d');
+      sourceCtx.fillStyle = '#ffffff';
+      sourceCtx.fillRect(0, 0, source.width, source.height);
+      const original = await new Promise((resolve) => source.toBlob(resolve, 'image/png'));
+      const result = await _aiWatermarkBlob(original, 'generated');
+      const bitmap = await createImageBitmap(result);
+      const out = document.createElement('canvas');
+      out.width = bitmap.width;
+      out.height = bitmap.height;
+      const ctx = out.getContext('2d');
+      ctx.drawImage(bitmap, 0, 0);
+      const pixels = ctx.getImageData(0, Math.floor(out.height * .78), out.width, Math.ceil(out.height * .22)).data;
+      let dark = 0;
+      for (let i = 0; i < pixels.length; i += 4) {
+        if (pixels[i] < 100 && pixels[i + 1] < 100 && pixels[i + 2] < 100) dark++;
+      }
+      return { type: result.type, dark };
+    });
+    expect(marked.type).toBe('image/jpeg');
+    expect(marked.dark, 'eingebrannte dunkle Wasserzeichenflaeche fehlt').toBeGreaterThan(1000);
+    expectNoPageErrors(errors, 'Pixel-Wasserzeichen');
+  });
+});
+
+test.describe('Meldeweg und Rechtstexte', () => {
+  test('Meldung wird gespeichert, begrenzt und bestaetigt', () => {
+    expect(FUNCTIONS).toContain('eb_content_reports');
+    expect(FUNCTIONS).toMatch(/\/listings\/\(\?P<id>\\d\+\)\/report/);
+    expect(FUNCTIONS).toMatch(/eventboerse_check_rate_limit\( 'content_report', 20, HOUR_IN_SECONDS \)/);
+    expect(FUNCTIONS).toMatch(/'good_faith'\s*=>\s*1/);
+    expect(FUNCTIONS).toContain("'sexual_abuse_minors'");
+    expect(FUNCTIONS).toContain("'caseId'   => $case_id");
+    expect(RATE_LIMIT).toMatch(/hash_hmac\( 'sha256'.*wp_salt\( 'auth' \)/);
+    expect(RATE_LIMIT).not.toMatch(/\$bucket\s*=.*md5\(/);
+    expect(FUNCTIONS).toMatch(/function eb_content_reports_cleanup/);
+    expect(FUNCTIONS).toMatch(/3 \* YEAR_IN_SECONDS/);
+    expect(FUNCTIONS).toContain("status <> 'legal_hold'");
+    expect(FUNCTIONS.indexOf("$wpdb->insert( $wpdb->prefix . 'eb_content_reports'")).toBeLessThan(
+      FUNCTIONS.indexOf("$mail_sent = wp_mail(")
+    );
+  });
+
+  test('Meldeformular uebernimmt das konkrete Inserat und die Gutglaubenserklaerung', () => {
+    expect(SHELL).toContain('id="contentReportTarget" readonly');
+    expect(SHELL).toContain('value="ai_undeclared"');
+    expect(SHELL).toContain('id="contentReportGoodFaith" required');
+    expect(DETAIL).toContain("listing.title + ' · /detail/' + listing.id");
+    expect(DETAIL).toContain("'listings/' + listing._dbId + '/report'");
+  });
+
+  test('Richtlinien erklaeren Kennzeichnung, Grenzen und Meldedaten', () => {
+    expect(SHELL).toContain('Art. 50 VO (EU) 2024/1689');
+    expect(SHELL).toContain('Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig.');
+    expect(SHELL).toContain('Inhaltsmeldungen und Moderation');
+    expect(SHELL).toContain('Beschwerde- und Moderationsvorgänge werden grundsätzlich drei Jahre gespeichert');
+  });
+
+  test('regelbasierte Medienfunktion gibt sich nicht als KI-Modell aus', () => {
+    expect(VISION).toContain('KEIN KI-FOTOMODELL');
+    expect(VISION).toContain('Digital erstellt · kein KI-Fotomodell');
+  });
+});

--- a/tests/e2e/radar.spec.js
+++ b/tests/e2e/radar.spec.js
@@ -627,6 +627,8 @@ class FakeWpdb {
         if ( ! $this->wirkt ) { return false; }
         if ( strpos($sql, 'ADD COLUMN blocked_dates') !== false ) { $this->spalten[] = 'blocked_dates'; }
         if ( strpos($sql, 'ADD COLUMN listing_type') !== false ) { $this->spalten[] = 'listing_type'; }
+        if ( strpos($sql, 'ADD COLUMN ai_text_disclosure') !== false ) { $this->spalten[] = 'ai_text_disclosure'; }
+        if ( strpos($sql, 'ADD COLUMN ai_media_disclosure') !== false ) { $this->spalten[] = 'ai_media_disclosure'; }
         if ( strpos($sql, 'ADD COLUMN lat') !== false ) {
             $this->spalten = array_merge($this->spalten, array('stadtteil', 'lat', 'lng'));
         }
@@ -643,6 +645,12 @@ class FakeWpdb {
         }
         if ( strpos($sql, 'SHOW INDEX') !== false ) {
             return in_array('idx_geo', $this->indizes, true) ? 'wp_eb_listings' : null;
+        }
+        // eb_create_tables() ist in diesem isolierten Migrationstest ein
+        // Stub. Sein dbDelta-Ergebnis wird deshalb hier als vorhanden
+        // modelliert; die Tests dieser Suite variieren nur Spalten/Index.
+        if ( strpos($sql, "SHOW TABLES LIKE 'wp_eb_content_reports'") !== false ) {
+            return 'wp_eb_content_reports';
         }
         return null;
     }

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -7,7 +7,7 @@ tags: [layer/L0, domain/kern, share/internal, typ/messung]
 
 # ⚡ Impuls-Strom — der lebende Zustand
 
-> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-12**
+> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-14**
 > Nicht von Hand bearbeiten — jeder Lauf überschreibt die Datei.
 > Diese Notiz misst, was im Netz tatsächlich fließt. Die Ströme selbst
 > sind in [[00-Kern/Wissensstroeme]] beschrieben.
@@ -63,24 +63,24 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **26** |
-| Commits (30 Tage) | 107 |
-| Letzter Commit | `79cee61 · GitHub App statt Token — fuer Routine UND Autopilot` (2026-08-12) |
+| Commits (7 Tage) | **28** |
+| Commits (30 Tage) | 127 |
+| Letzter Commit | `3e530dc · Merge pull request #154 from Sabindro53/agent/fix-radar-popup-contrast` (2026-08-14) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
-34 app.js
-     29 tests/e2e/kern.spec.js
-     27 CLAUDE.md
-     26 styles.css
-     21 vault/30-Betrieb/Testing.md
+38 app.js
+  37 tests/e2e/kern.spec.js
+  33 CLAUDE.md
+  29 vault/50-Evolution/Roadmap/Current-Sprint.md
+  28 styles.css
 ```
 
 **Codegröße:**
-- `app.js` — 25.586 Zeilen
-- `styles.css` — 16.991 Zeilen
-- `functions.php` — 9.560 Zeilen
-- `app-shell.html` — 4.011 Zeilen
+- `app.js` — 26.599 Zeilen
+- `styles.css` — 17.105 Zeilen
+- `functions.php` — 10.198 Zeilen
+- `app-shell.html` — 4.122 Zeilen
 
 ## Verwandt
 - [[00-Kern/Wissensstroeme]] — die sechs Impulse

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -9,14 +9,14 @@ tags: [layer/L5, domain/evolution, share/internal]
 
 > Ziel: Die beste und funktionalste Eventplattform für jedermann
 
-## Stand heute (2026-08-11)
+## Stand heute (2026-08-14)
 
 Diese Zahlen gelten JETZT. Weiter unten stehen abgeschlossene Sprints mit den
 Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 279 Tests in 14 Suiten**, blockierendes Gate in `pr-check.yml`
+- **Playwright-Suite: 303 Tests in 17 Suiten**, blockierendes Gate in `pr-check.yml`
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift
 - **Lagebild-Lauf 4×/Tag** (02/08/14/20 UTC), 11 Rollen je Lauf, eigenes
@@ -34,6 +34,18 @@ einen alten Abschnitt gelesen und nicht diesen.
 
 ## Zuletzt ausgeliefert (August 2026)
 
+- [x] **KI-Transparenz fuer Inserate:** Beim Veröffentlichen sind Text und
+  Medien getrennt und ohne Vorbelegung als ohne generative KI, wesentlich
+  KI-unterstützt oder KI-generiert zu deklarieren. KI-Medien tragen auf allen
+  Inseratflächen ein sichtbares Wasserzeichen; neue lokale Uploads bekommen
+  die Kennzeichnung zusätzlich in die Bildpixel. API und Markup führen den
+  Status maschinenlesbar. Altinhalte werden nicht zu „menschlich" umgedeutet,
+  sondern bleiben sichtbar „KI-Status offen", bis der Anbieter nachdeklariert.
+  Direkt am Inserat nimmt ein begründeter DSA-Meldeweg falsche Kennzeichnung
+  und Irreführung entgegen, speichert vor E-Mail-Versand, vergibt eine
+  Vorgangsnummer und löscht Meldedaten nach drei Jahren (außer Legal Hold).
+  Community-, Upload-, DSA- und Datenschutzhinweise sind auf Stand 14.08.2026.
+  Absicherung: 10 neue KI-Transparenztests, Gesamtsuite 303/303 grün.
 - [x] **Die Belegschaft läuft wieder — und ihr Ausfall ist jetzt sichtbar.**
   Zwischen dem 07. und 11.08. sind **elf Läufe hintereinander fehlgeschlagen**
   (5× Tagesroutine, 6× Ensemble-Puls), ohne dass es jemand bemerkt hat. Vier


### PR DESCRIPTION
## Was sich ändert

- verpflichtende, getrennte KI-Deklaration für Text und Medien ohne Vorbelegung
- sichtbare Wasserzeichen auf allen Inseratflächen sowie eingebrannte Kennzeichnung bei neuen lokalen KI-Bild-Uploads
- maschinenlesbare Statusfelder in API und Markup; Altbestand bleibt ehrlich als „KI-Status offen“
- öffentlicher, begründeter DSA-Meldeweg mit Speicherung vor E-Mail, Vorgangsnummer, Rate-Limit und Löschfrist
- aktualisierte Community-, Upload-, DSA- und Datenschutzhinweise

## Warum

Bislang gab es weder eine persistente KI-Erklärung beim Veröffentlichen noch eine durchgängige sichtbare Kennzeichnung. Dadurch konnten KI-Inhalte wie normale Inhalte wirken und eine falsche menschliche Urheberschaft nahelegen. Der neue Ablauf macht die Herkunft am ersten Kontakt sichtbar, verhindert stille Defaults und schafft einen direkten Meldeweg für falsche Deklarationen oder Irreführung.

## Wirkung

Neue und bearbeitete Inserate lassen sich ohne ausdrückliche Angaben zu Text und Medien nicht speichern. KI-generierte bzw. wesentlich KI-bearbeitete Medien und Texte werden auf Karten, Feed, Suche, Radar, Board und Detailansicht gekennzeichnet. Bestandsinhalte werden nicht rückwirkend als „ohne KI“ behauptet.

## Prüfung

- 303/303 Playwright-Tests grün (17 Suiten)
- PHP-Syntaxprüfung grün
- Wissensbasis-, Quarantäne-, Demo-Feed-, Connector-, Modell-, Agent- und app.js-Drift-Gates grün
- CSS-Minifizierung, Design-Konfliktratsche, WCAG-AA- und Radar-Regressionen grün