### PR TITLE
Dezente KI-Kennzeichnung ohne Bild-Wasserzeichen

### DIFF
--- a/app-shell.html
+++ b/app-shell.html
@@ -2355,7 +2355,7 @@
                 <span class="material-icons-round" aria-hidden="true">verified_user</span>
                 <div>
                   <h3 id="aiDisclosureHeading">KI-Transparenz <span>Pflichtangabe</span></h3>
-                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Bei KI-Medien setzt Eventbörse zusätzlich ein sichtbares Wasserzeichen.</p>
+                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Eventbörse zeigt dazu einen kleinen Transparenzhinweis am Inserat.</p>
                 </div>
               </div>
               <fieldset class="ai-declaration-group">
@@ -2801,15 +2801,15 @@ Datum: ___________________________________________________
     <section id="page-upload" class="page">
       <div class="container legal-page">
         <h1>Upload- und Inhaltsrichtlinie / UGC-Lizenz</h1>
-        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 15. August 2026 · Versionsentwurf 1.2</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.2 (Stand 15.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Was sind Inhalte?</h2>
         <p>Profilbilder, Profilbeschreibungen, Logos, Texte, Bilder, Videos (z.&nbsp;B. Portfolio-Fotos, Eventfotos in Bewertungen), Audio (z.&nbsp;B. DJ-Mixe), sonstige hochgeladene Dateien.</p>
         <h2>2. Pflichten des Hochladenden</h2>
         <ul><li>Du verfügst über alle erforderlichen Rechte (Urheberrechte, Nutzungsrechte, Persönlichkeitsrechte, Markenrechte).</li><li>Einwilligung aller abgebildeten Personen (Art. 6, 9 DSGVO; KUG).</li><li>Bei Minderjährigen Einwilligung der Erziehungsberechtigten; im Zweifel keine Veröffentlichung.</li><li>Beachtung der Community-Richtlinien.</li></ul>
         <h2>3. KI-generierte und KI-bearbeitete Inhalte</h2>
         <p>Beim Veröffentlichen ist getrennt für Text und Medien anzugeben, ob generative KI nicht genutzt, wesentlich unterstützend eingesetzt oder der Inhalt ganz bzw. überwiegend KI-generiert wurde. Normale Farb-, Größen- und Zuschnittkorrekturen zählen nicht als generative KI-Nutzung.</p>
-        <ul><li>KI-generierte und wesentlich KI-bearbeitete Medien erhalten auf Eventbörse ein dauerhaft sichtbares Wasserzeichen; neue lokale Bild-Uploads werden zusätzlich in den Bildpixeln gekennzeichnet.</li><li>Die Erklärung wird maschinenlesbar am Inserat und in der Schnittstelle gespeichert. Die Kennzeichnung muss beim Teilen oder Exportieren erhalten bleiben.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
+        <ul><li>KI-generierte und wesentlich KI-bearbeitete Inserate erhalten auf Eventbörse einen kleinen, gut lesbaren Transparenzhinweis außerhalb der Bilder.</li><li>Die Erklärung wird zusätzlich maschinenlesbar am Inserat und in der Schnittstelle gespeichert.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
         <h2>4. Lizenzeinräumung an die Plattform</h2>
         <p>Mit dem Upload räumst du der Eventbörse UG (haftungsbeschränkt) ein einfaches, weltweites, zeitlich auf die Dauer der Profil-/Inhaltsverfügbarkeit auf der Plattform begrenztes, unentgeltliches und übertragbares Nutzungsrecht ein, deine Inhalte auf der Plattform öffentlich zugänglich zu machen, zu speichern, zu skalieren, zu transcodieren, in Vorschauen darzustellen und in Profilen, Suchergebnissen, Kommunikation und Bewertungen anzuzeigen. Eine Übertragung von Urheberrechten findet nicht statt; alle Rechte verbleiben beim Hochladenden.</p>
         <h2>5. Recht zur Entfernung und Sperrung</h2>

--- a/app.js
+++ b/app.js
@@ -158,7 +158,7 @@ function _surfaceVisibleListings(arr) {
 }
 
 // AI transparency is stored separately for copy and media so a human photo
-// is never falsely watermarked merely because the description used AI.
+// is never falsely classified merely because the description used AI.
 // "undeclared" is reserved for migrated legacy records and is not shown as
 // proof of human authorship.
 function _aiDisclosureValue(item, kind) {
@@ -175,16 +175,18 @@ function _aiDisclosureAttrs(item) {
 }
 
 function _aiDisclosureLabels(item) {
-  var labels = [];
   var textStatus = _aiDisclosureValue(item, 'text');
   var mediaStatus = _aiDisclosureValue(item, 'media');
-  if (mediaStatus === 'generated') labels.push({ kind: 'media', label: 'KI-generiertes Bild', short: 'KI-generiert' });
-  if (mediaStatus === 'assisted') labels.push({ kind: 'media', label: 'KI-bearbeitetes Bild', short: 'KI-bearbeitet' });
-  if (textStatus === 'generated') labels.push({ kind: 'text', label: 'KI-generierter Text', short: 'KI-Text' });
-  if (textStatus === 'assisted') labels.push({ kind: 'text', label: 'KI-unterstützter Text', short: 'KI-Text bearbeitet' });
-  if (mediaStatus === 'undeclared') labels.push({ kind: 'media', label: 'KI-Status der Medien noch nicht deklariert', short: 'Medien: KI-Status offen', legacy: true });
-  if (textStatus === 'undeclared') labels.push({ kind: 'text', label: 'KI-Status des Textes noch nicht deklariert', short: 'Text: KI-Status offen', legacy: true });
-  return labels;
+  if (textStatus === 'generated' || mediaStatus === 'generated') {
+    return [{ state: 'generated', label: 'KI-generierter Inhalt' }];
+  }
+  if (textStatus === 'assisted' || mediaStatus === 'assisted') {
+    return [{ state: 'assisted', label: 'KI-unterstützter Inhalt' }];
+  }
+  if (textStatus === 'undeclared' || mediaStatus === 'undeclared') {
+    return [{ state: 'open', label: 'KI-Status offen', legacy: true }];
+  }
+  return [];
 }
 
 function _aiDisclosureLabelsHtml(item, extraClass) {
@@ -192,27 +194,10 @@ function _aiDisclosureLabelsHtml(item, extraClass) {
   if (!labels.length) return '';
   return '<span class="ai-disclosure-stack' + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="KI-Transparenz">' +
     labels.map(function(info) {
-      return '<span class="ai-content-label ai-content-label-' + info.kind + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
+      return '<span class="ai-content-label ai-content-label-' + info.state + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
         (info.legacy ? 'Altbestand: noch nicht nachdeklariert' : 'Von der einstellenden Person deklariert') + '">' +
-        '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + _escHtml(info.short) + '</span>';
+        _escHtml(info.label) + '</span>';
     }).join('') + '</span>';
-}
-
-function _aiMediaWatermarkHtml(item, extraClass) {
-  var mediaStatus = _aiDisclosureValue(item, 'media');
-  if (mediaStatus === 'none') return '';
-  var label = mediaStatus === 'generated' ? 'KI-GENERIERT' : (mediaStatus === 'assisted' ? 'KI-BEARBEITET' : 'KI-STATUS OFFEN');
-  var aria = mediaStatus === 'generated' ? 'KI-generiertes Bild' : (mediaStatus === 'assisted' ? 'KI-bearbeitetes Bild' : 'KI-Status der Medien noch nicht deklariert');
-  return '<span class="ai-media-watermark' + (mediaStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' + label + '</span>';
-}
-
-function _aiTextDisclosureHtml(item, extraClass) {
-  var textStatus = _aiDisclosureValue(item, 'text');
-  if (textStatus === 'none') return '';
-  var label = textStatus === 'generated' ? 'KI-Text' : (textStatus === 'assisted' ? 'KI-Text bearbeitet' : 'Text-KI offen');
-  var aria = textStatus === 'generated' ? 'KI-generierter Text' : (textStatus === 'assisted' ? 'KI-unterstützter Text' : 'KI-Status des Textes noch nicht deklariert');
-  return '<span class="ai-text-watermark' + (textStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' +
-    '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + label + '</span>';
 }
 
 function _safeRun(label, fn) {
@@ -853,6 +838,13 @@ const LISTINGS = [
   }
 ];
 
+// Die redaktionellen Demo-Inserate wurden mit generativer KI erstellt. Die
+// Angabe sitzt als dezenter Text am Inserat; die Bilder selbst bleiben frei.
+LISTINGS.forEach(function(listing) {
+  listing.aiTextDisclosure = 'generated';
+  listing.aiMediaDisclosure = 'generated';
+});
+
 // Auto-Inject logical price ranges (priceMax) for demo listings + rebuild priceLabel as range.
 // Multiplikator pro Preismodell: realistische Spannen für DE-Eventmarkt.
 (function injectDemoPriceRanges(){
@@ -1021,7 +1013,6 @@ const DEMO_EVENTS = [
     ]
   }
 ];
-
 // ========== SPA PATH HELPERS ==========
 var _spaBase = (typeof eventboerseApi !== 'undefined' && eventboerseApi.siteUrl)
   ? new URL(eventboerseApi.siteUrl).pathname.replace(/\/+$/, '')
@@ -1624,8 +1615,6 @@ function renderListingCard(listing) {
         </button>
         ${listing.badge ? '<span class="listing-badge">' + _escHtml(listing.badge) + '</span>' : ''}
         ${_boardStatusBadgeHtml(listing.id, 'bsb-on-card')}
-        ${_aiMediaWatermarkHtml(listing)}
-        ${_aiTextDisclosureHtml(listing)}
       </div>
       <div class="listing-card-body">
         <div class="listing-card-top">
@@ -1634,6 +1623,7 @@ function renderListingCard(listing) {
             <span class="material-icons-round">star</span> ${listing.rating || 0}
           </span>
         </div>
+        ${_aiDisclosureLabelsHtml(listing, 'ai-disclosure-card')}
         <div class="listing-card-category">${_escHtml(listing.categoryLabel)}</div>
         <div class="listing-card-location">
           <span class="material-icons-round">location_on</span> ${_escHtml(listing.location)}
@@ -1689,10 +1679,10 @@ function renderHeroMarquees() {
   function cardHTML(l) {
     return '<a class="hero-marquee-card"' + _aiDisclosureAttrs(l) + ' href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
       '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="eager"' + window.EB_IMG_ERR_ATTR + ' />' +
-      _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
       '<div class="hero-marquee-card-info">' +
         '<h4>' + _escHtml(l.title) + '</h4>' +
         '<span>' + _escHtml(l.priceLabel) + ' · ★ ' + (l.rating || 0) + '</span>' +
+        _aiDisclosureLabelsHtml(l, 'ai-disclosure-marquee') +
       '</div></a>';
   }
 
@@ -1861,7 +1851,6 @@ function renderExploreGrid(filter) {
     const sizeClass = (i % 7 === 0) ? 'explore-item-large' : '';
     return `<a href="#" class="explore-item ${sizeClass}"${_aiDisclosureAttrs(it)} onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
       <img src="${_escHtml(it.image)}" alt="${_escHtml(it.title)}" loading="lazy" onload="_fitExploreImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
-      ${_aiMediaWatermarkHtml(it)}${_aiTextDisclosureHtml(it)}
       <div class="explore-item-overlay">
         <span class="explore-item-title">${_escHtml(it.title)}</span>
         <span class="explore-item-price">${_escHtml(it.price)}</span>
@@ -1942,9 +1931,10 @@ function renderFeed(tab) {
         </div>
         <span class="feed-card-category">${_escHtml(categoryLabel)}</span>
       </div>
-      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}</div>
+      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>
       <div class="feed-card-body">
         <div class="feed-card-title" onclick="navigateTo('detail',${l.id})">${_escHtml(l.title)}</div>
+        ${_aiDisclosureLabelsHtml(l, 'ai-disclosure-feed')}
         <div class="feed-card-desc">${_escHtml(_stripHtml(desc))}</div>
       </div>
       ${l.location ? '<div class="feed-card-location"><span class="material-icons-round">location_on</span> ' + _escHtml(l.location) + '</div>' : ''}
@@ -4240,7 +4230,6 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
               <span class="material-icons-round">favorite_border</span>
             </button>
             ${l.badge ? `<span class="listing-badge">${_escHtml(l.badge)}</span>` : ''}
-            ${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}
           </div>
           <div class="listing-card-body">
             <div class="listing-card-top">
@@ -4249,6 +4238,7 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
                 <span class="material-icons-round">star</span> ${l.rating}
               </span>
             </div>
+            ${_aiDisclosureLabelsHtml(l, 'ai-disclosure-card')}
             <div class="listing-card-category">${_escHtml(l.categoryLabel)}</div>
             <div class="listing-card-location">
               <span class="material-icons-round">location_on</span> ${_escHtml(l.location)} ${distBadge}
@@ -4327,7 +4317,7 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />${_aiMediaWatermarkHtml(listing)}`;
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
     heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 
@@ -4340,7 +4330,7 @@ function loadDetail(listingId) {
       var delBtn = _detailCanModerate && img !== window.EB_IMG_FALLBACK
         ? '<button type="button" class="detail-gallery-admin-del" title="Bild als Admin löschen" aria-label="Bild als Admin löschen" onclick="adminDeleteListingImage(' + i + ', event)"><span class="material-icons-round">delete</span> Löschen</button>'
         : '';
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + _aiMediaWatermarkHtml(listing) + delBtn + '</div>';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + delBtn + '</div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" aria-label="Vorheriges Bild" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -4377,8 +4367,8 @@ function loadDetail(listingId) {
     var hasOpenStatus = _aiDisclosureValue(listing, 'text') === 'undeclared' || _aiDisclosureValue(listing, 'media') === 'undeclared';
     var aiNote = hasOpenStatus
       ? 'Altbestand: Die ausdrückliche Nachdeklaration steht noch aus.'
-      : 'Vom Anbieter bei Veröffentlichung deklariert.';
-    aiDisclosure.innerHTML = aiLabels ? aiLabels + '<small>' + aiNote + '</small>' : '';
+      : '';
+    aiDisclosure.innerHTML = aiLabels ? aiLabels + (aiNote ? '<small>' + aiNote + '</small>' : '') : '';
     aiDisclosure.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
     aiDisclosure.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
@@ -6655,8 +6645,8 @@ function _drawFeedRadar() {
       var image = (d.images && d.images[0]) || d.image || window.EB_IMG_FALLBACK;
       return '<article class="feed-radar-result" data-radar-index="' + index + '"' + _aiDisclosureAttrs(d) + '>' +
         '<button type="button" class="feed-radar-result-map" onclick="feedRadarFocus(' + index + ')" aria-label="' + _escHtml(title) + ' auf der Karte zeigen">' +
-        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '>' + _aiMediaWatermarkHtml(d) + _aiTextDisclosureHtml(d) + '</span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
-        '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong><small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
+        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '></span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
+        '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong>' + _aiDisclosureLabelsHtml(d, 'ai-disclosure-radar-result') + '<small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
         '<button type="button" class="feed-radar-result-open" onclick="feedRadarOpen(' + index + ')" aria-label="' + _escHtml(title) + ' öffnen"><span class="material-icons-round">arrow_forward</span></button></article>';
     }).join('') + '</div>';
   _initFeedRadarMap(hits);
@@ -9250,60 +9240,7 @@ function _setAiDisclosureForm(textStatus, mediaStatus) {
 function _aiDisclosureFormChanged() {
   var section = document.getElementById('aiDisclosureSection');
   if (section) section.classList.remove('has-error');
-  _updateListingPreviewAiLabels();
   _updateListingLivePreview();
-}
-
-function _updateListingPreviewAiLabels() {
-  var mediaStatus = _selectedAiDisclosure('media');
-  document.querySelectorAll('#uploadPreview .upload-preview-item').forEach(function(item) {
-    var old = item.querySelector('.ai-media-watermark');
-    if (old) old.remove();
-    var html = _aiMediaWatermarkHtml({ aiMediaDisclosure: mediaStatus }, 'ai-media-watermark-preview');
-    if (html) item.insertAdjacentHTML('beforeend', html);
-  });
-}
-
-// Burn the declaration into every newly uploaded AI image. The UI overlay is
-// still rendered separately because it must remain visible on all surfaces;
-// this pixel watermark additionally survives opening or sharing the file.
-function _aiWatermarkBlob(blob, mediaStatus) {
-  if (!blob || (mediaStatus !== 'assisted' && mediaStatus !== 'generated')) return Promise.resolve(blob);
-  return new Promise(function(resolve) {
-    var url = URL.createObjectURL(blob);
-    var img = new Image();
-    img.onload = function() {
-      try {
-        var canvas = document.createElement('canvas');
-        canvas.width = img.naturalWidth || img.width;
-        canvas.height = img.naturalHeight || img.height;
-        var ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-        var label = mediaStatus === 'generated' ? 'KI-GENERIERT · EVENTBÖRSE' : 'KI-BEARBEITET · EVENTBÖRSE';
-        var fontSize = Math.max(20, Math.round(canvas.width * 0.027));
-        var padX = Math.round(fontSize * 0.65);
-        var padY = Math.round(fontSize * 0.42);
-        ctx.font = '700 ' + fontSize + 'px Arial, sans-serif';
-        var textWidth = ctx.measureText(label).width;
-        var boxW = textWidth + padX * 2;
-        var boxH = fontSize + padY * 2;
-        var x = Math.max(12, canvas.width - boxW - Math.round(fontSize * 0.6));
-        var y = Math.max(12, canvas.height - boxH - Math.round(fontSize * 0.6));
-        ctx.fillStyle = 'rgba(12, 15, 24, 0.84)';
-        ctx.fillRect(x, y, boxW, boxH);
-        ctx.fillStyle = '#ffffff';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(label, x + padX, y + boxH / 2);
-        canvas.toBlob(function(marked) { resolve(marked || blob); }, 'image/jpeg', 0.92);
-      } catch (e) {
-        resolve(blob);
-      } finally {
-        URL.revokeObjectURL(url);
-      }
-    };
-    img.onerror = function() { URL.revokeObjectURL(url); resolve(blob); };
-    img.src = url;
-  });
 }
 
 async function submitListing(e) {
@@ -9440,20 +9377,17 @@ async function submitListing(e) {
   // Upload images: cropped blobs first, then data URLs, keep existing URLs
   var uploadPromises = imgEntries.map(function(entry) {
     if (entry.blob) {
-      return _aiWatermarkBlob(entry.blob, aiMediaDisclosure).then(function(markedBlob) {
-        var file = new File([markedBlob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
-        return uploadFile(file).then(function(r) { return r.url; });
-      });
+      var blobType = entry.blob.type || 'image/jpeg';
+      var blobExt = (blobType.split('/')[1] || 'jpg').replace('jpeg', 'jpg');
+      var croppedFile = new File([entry.blob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.' + blobExt, { type: blobType });
+      return uploadFile(croppedFile).then(function(r) { return r.url; });
     }
     if (entry.src.startsWith('data:')) {
       var arr = entry.src.split(','), mime = arr[0].match(/:(.*?);/)[1];
       var bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
       while (n--) u8arr[n] = bstr.charCodeAt(n);
       var sourceFile = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
-      return _aiWatermarkBlob(sourceFile, aiMediaDisclosure).then(function(markedBlob) {
-        var file = new File([markedBlob], 'listing-' + Date.now() + '.jpg', { type: 'image/jpeg' });
-        return uploadFile(file).then(function(r) { return r.url; });
-      });
+      return uploadFile(sourceFile).then(function(r) { return r.url; });
     }
     return Promise.resolve(entry.src);
   });
@@ -9915,8 +9849,6 @@ function _updateListingLivePreview() {
     slideImg.src = img.src;
     slideImg.alt = 'Vorschau';
     slide.appendChild(slideImg);
-    var watermark = _aiMediaWatermarkHtml(previewDisclosure, 'ai-media-watermark-live');
-    if (watermark) slide.insertAdjacentHTML('beforeend', watermark);
     track.appendChild(slide);
   });
 
@@ -11160,11 +11092,11 @@ function renderMyListings() {
             return '<div class="my-listing-card">' +
               '<div class="my-listing-img"' + _aiDisclosureAttrs(evt) + '>' +
                 '<img src="' + _escHtml(evt.image) + '" alt="' + _escHtml(evt.title) + '" />' +
-                _aiMediaWatermarkHtml(evt) + _aiTextDisclosureHtml(evt) +
                 '<span class="status-badge status-active">Aktiv</span>' +
               '</div>' +
               '<div class="my-listing-info">' +
                 '<h3>' + _escHtml(evt.title) + '</h3>' +
+                _aiDisclosureLabelsHtml(evt, 'ai-disclosure-admin') +
                 '<p>' + _escHtml(evt.categoryLabel) + ' · ' + _escHtml(evt.location) + '</p>' +
                 '<p class="my-listing-price">' + _escHtml(evt.priceLabel) + '</p>' +
                 '<div class="my-listing-stats">' +
@@ -11242,11 +11174,11 @@ function renderMyListings() {
           return '<div class="my-listing-card">' +
             '<div class="my-listing-img"' + _aiDisclosureAttrs(l) + '>' +
               '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" />' +
-              _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
               '<span class="status-badge status-active">Aktiv</span>' +
             '</div>' +
             '<div class="my-listing-info">' +
               '<h3>' + _escHtml(l.title) + '</h3>' +
+              _aiDisclosureLabelsHtml(l, 'ai-disclosure-admin') +
               '<p>' + _escHtml(l.categoryLabel) + ' · ' + _escHtml(l.location) + '</p>' +
               '<p class="my-listing-price">' + _escHtml(l.priceLabel) + '</p>' +
               '<div class="my-listing-stats">' +
@@ -22454,9 +22386,10 @@ function _buildListingPickerCardsHtml(baseList, isSearchListingFn, showSearchLis
       ' data-image="' + _escHtml(l.image || img) + '"' +
       ' data-title="' + _escHtml(l.title || '') + '"' +
       ' onclick="_selectListingCard(this)">' +
-      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')">' + _aiMediaWatermarkHtml(l, 'ai-media-watermark-picker') + _aiTextDisclosureHtml(l, 'ai-text-watermark-picker') + '</span>' +
+      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')"></span>' +
       '<span class="eb-lpick-body">' +
         '<span class="eb-lpick-title">' + _escHtml(l.title || '') + '</span>' +
+        _aiDisclosureLabelsHtml(l, 'ai-disclosure-picker') +
         '<span class="eb-lpick-meta">' +
           '<span class="eb-lpick-cat">' + _escHtml(l.categoryLabel || l.category || '') + '</span>' +
           (price ? '<span class="eb-lpick-price">' + _escHtml(price) + '</span>' : '') +
@@ -23384,8 +23317,8 @@ function renderListingFeedCard(l) {
       '</div>' +
       '<button class="feed-more-btn" onclick="openPostMenu(event,\'listing-' + l.id + '\',\'' + (l.providerName || '').replace(/'/g, '') + '\')" aria-label="Optionen"><span class="material-icons-round">more_horiz</span></button>' +
     '</div>' +
-    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />' + _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) + '</div>' +
-    '<div class="feed-post-content">' + _escHtml(l.title) + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
+    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>' +
+    '<div class="feed-post-content">' + _escHtml(l.title) + _aiDisclosureLabelsHtml(l, 'ai-disclosure-social') + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
     '<div class="feed-action-bar">' +
       '<div class="feed-actions">' +
         '<button class="feed-action-btn' + (isFav ? ' liked' : '') + '" onclick="toggleFeedFav(this,' + l.id + ')">' +

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,11 +1,12 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-14T12:39:44.024Z",
+  "erzeugt": "2026-08-15T15:52:52.552Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",
   "auftraege": [],
-  "ausserhalb": [
+  "ausserhalb": [],
+  "verworfen": [
     {
       "herkunft": {
         "rolle": "mistral-ops",
@@ -15,10 +16,7 @@
         "zeit": "2026-08-12T12:44:59.524Z",
         "aufgabe": "Den ältesten roten oder unbekannten Betriebszustand benennen und eingrenzen."
       },
-      "dateien": [
-        "audit/latest.json"
-      ],
-      "grund": "nennt audit/latest.json — außerhalb des freigegebenen Rahmens"
+      "grund": "älter als 72 h — beschreibt einen anderen Code-Stand"
     },
     {
       "herkunft": {
@@ -29,12 +27,7 @@
         "zeit": "2026-08-12T11:23:21.145Z",
         "aufgabe": "Deploys, Tests und Monitor-Signale zu einem belastbaren Lagebild verdichten."
       },
-      "dateien": [
-        "audit/latest.json",
-        ".github/workflows/site-monitor.yml"
-      ],
-      "grund": "nennt audit/latest.json, .github/workflows/site-monitor.yml — außerhalb des freigegebenen Rahmens"
+      "grund": "älter als 72 h — beschreibt einen anderen Code-Stand"
     }
-  ],
-  "verworfen": []
+  ]
 }

--- a/functions.php
+++ b/functions.php
@@ -3161,11 +3161,12 @@ add_filter( 'rest_post_dispatch', function( $response ) {
  * Schema-Stand, gegen den `eb_db_version` in der Datenbank geprueft wird.
  *
  * 2.6: getrennte, persistente KI-Erklaerungen fuer Text und Medien sowie ein
- * revisionsfaehiger Inhalt-Meldeeingang. Bestandsinhalte bleiben bewusst
- * "undeclared"; die Migration erfindet keine menschliche Urheberschaft.
+ * revisionsfaehiger Inhalt-Meldeeingang.
+ * 2.7: vom Betreiber bestaetigte Nachdeklaration der sieben aktuellen
+ * Bestandsinserate; DJ Julian und Sandros Inserate sind menschlich erstellt.
  */
 if ( ! defined( 'EB_DB_VERSION' ) ) {
-    define( 'EB_DB_VERSION', '2.6' );
+    define( 'EB_DB_VERSION', '2.7' );
 }
 
 function eb_create_tables() {
@@ -3368,6 +3369,16 @@ function eb_maybe_create_tables() {
         $ai_media_col = $wpdb->get_var( "SHOW COLUMNS FROM {$wpdb->prefix}eb_listings LIKE 'ai_media_disclosure'" );
         if ( ! $ai_media_col ) {
             $wpdb->query( "ALTER TABLE {$wpdb->prefix}eb_listings ADD COLUMN ai_media_disclosure varchar(20) NOT NULL DEFAULT 'undeclared' AFTER ai_text_disclosure" );
+        }
+        // 2.7: Der Betreiber hat den konkreten Live-Bestand nachdeklariert.
+        // IDs 5 und 8 gehoeren Sandro, ID 7 ist DJ Julian. Alle uebrigen
+        // derzeitigen Inserate (9, 10, 12, 13) wurden mit KI erstellt.
+        if ( ! get_option( 'eb_ai_disclosure_backfill_27', false ) ) {
+            $human_update = $wpdb->query( "UPDATE {$wpdb->prefix}eb_listings SET ai_text_disclosure = 'none', ai_media_disclosure = 'none' WHERE id IN (5, 7, 8)" );
+            $ai_update    = $wpdb->query( "UPDATE {$wpdb->prefix}eb_listings SET ai_text_disclosure = 'generated', ai_media_disclosure = 'generated' WHERE id IN (9, 10, 12, 13)" );
+            if ( false !== $human_update && false !== $ai_update ) {
+                update_option( 'eb_ai_disclosure_backfill_27', 1 );
+            }
         }
         // 2.4: Koordinaten und Stadtteil fuer den Umkreis-Radar.
         //

--- a/index.html
+++ b/index.html
@@ -2416,7 +2416,7 @@
                 <span class="material-icons-round" aria-hidden="true">verified_user</span>
                 <div>
                   <h3 id="aiDisclosureHeading">KI-Transparenz <span>Pflichtangabe</span></h3>
-                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Bei KI-Medien setzt Eventbörse zusätzlich ein sichtbares Wasserzeichen.</p>
+                  <p>Gib getrennt an, ob generative KI für Text oder Medien genutzt wurde. Eventbörse zeigt dazu einen kleinen Transparenzhinweis am Inserat.</p>
                 </div>
               </div>
               <fieldset class="ai-declaration-group">
@@ -2862,15 +2862,15 @@ Datum: ___________________________________________________
     <section id="page-upload" class="page">
       <div class="container legal-page">
         <h1>Upload- und Inhaltsrichtlinie / UGC-Lizenz</h1>
-        <p class="legal-date">Stand: 14. August 2026 · Versionsentwurf 1.1</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.1 (Stand 14.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
+        <p class="legal-date">Stand: 15. August 2026 · Versionsentwurf 1.2</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Diese Richtlinie ist als Versionsentwurf 1.2 (Stand 15.08.2026) veröffentlicht und wird mit Eintragung der Eventbörse UG (haftungsbeschränkt) im Handelsregister verbindlich.</p>
         <h2>1. Was sind Inhalte?</h2>
         <p>Profilbilder, Profilbeschreibungen, Logos, Texte, Bilder, Videos (z.&nbsp;B. Portfolio-Fotos, Eventfotos in Bewertungen), Audio (z.&nbsp;B. DJ-Mixe), sonstige hochgeladene Dateien.</p>
         <h2>2. Pflichten des Hochladenden</h2>
         <ul><li>Du verfügst über alle erforderlichen Rechte (Urheberrechte, Nutzungsrechte, Persönlichkeitsrechte, Markenrechte).</li><li>Einwilligung aller abgebildeten Personen (Art. 6, 9 DSGVO; KUG).</li><li>Bei Minderjährigen Einwilligung der Erziehungsberechtigten; im Zweifel keine Veröffentlichung.</li><li>Beachtung der Community-Richtlinien.</li></ul>
         <h2>3. KI-generierte und KI-bearbeitete Inhalte</h2>
         <p>Beim Veröffentlichen ist getrennt für Text und Medien anzugeben, ob generative KI nicht genutzt, wesentlich unterstützend eingesetzt oder der Inhalt ganz bzw. überwiegend KI-generiert wurde. Normale Farb-, Größen- und Zuschnittkorrekturen zählen nicht als generative KI-Nutzung.</p>
-        <ul><li>KI-generierte und wesentlich KI-bearbeitete Medien erhalten auf Eventbörse ein dauerhaft sichtbares Wasserzeichen; neue lokale Bild-Uploads werden zusätzlich in den Bildpixeln gekennzeichnet.</li><li>Die Erklärung wird maschinenlesbar am Inserat und in der Schnittstelle gespeichert. Die Kennzeichnung muss beim Teilen oder Exportieren erhalten bleiben.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
+        <ul><li>KI-generierte und wesentlich KI-bearbeitete Inserate erhalten auf Eventbörse einen kleinen, gut lesbaren Transparenzhinweis außerhalb der Bilder.</li><li>Die Erklärung wird zusätzlich maschinenlesbar am Inserat und in der Schnittstelle gespeichert.</li><li>Deepfakes müssen klar als künstlich erzeugt oder manipuliert erkennbar sein. Das gilt grundsätzlich auch für KI-erzeugte oder manipulierte Texte, die die Öffentlichkeit über Angelegenheiten von öffentlichem Interesse informieren sollen, soweit keine gesetzliche Ausnahme greift (Art. 50 VO (EU) 2024/1689).</li><li>Eine KI-Kennzeichnung macht irreführende, rechtswidrige oder rechtsverletzende Inhalte nicht zulässig. Falsche Erklärungen können zur Entfernung, Verwarnung oder Sperre führen.</li></ul>
         <h2>4. Lizenzeinräumung an die Plattform</h2>
         <p>Mit dem Upload räumst du der Eventbörse UG (haftungsbeschränkt) ein einfaches, weltweites, zeitlich auf die Dauer der Profil-/Inhaltsverfügbarkeit auf der Plattform begrenztes, unentgeltliches und übertragbares Nutzungsrecht ein, deine Inhalte auf der Plattform öffentlich zugänglich zu machen, zu speichern, zu skalieren, zu transcodieren, in Vorschauen darzustellen und in Profilen, Suchergebnissen, Kommunikation und Bewertungen anzuzeigen. Eine Übertragung von Urheberrechten findet nicht statt; alle Rechte verbleiben beim Hochladenden.</p>
         <h2>5. Recht zur Entfernung und Sperrung</h2>

--- a/js/modules/board/42-guide-social-feed.js
+++ b/js/modules/board/42-guide-social-feed.js
@@ -491,9 +491,10 @@ function _buildListingPickerCardsHtml(baseList, isSearchListingFn, showSearchLis
       ' data-image="' + _escHtml(l.image || img) + '"' +
       ' data-title="' + _escHtml(l.title || '') + '"' +
       ' onclick="_selectListingCard(this)">' +
-      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')">' + _aiMediaWatermarkHtml(l, 'ai-media-watermark-picker') + _aiTextDisclosureHtml(l, 'ai-text-watermark-picker') + '</span>' +
+      '<span class="eb-lpick-thumb" style="background-image:url(\'' + _escHtml(img) + '\')"></span>' +
       '<span class="eb-lpick-body">' +
         '<span class="eb-lpick-title">' + _escHtml(l.title || '') + '</span>' +
+        _aiDisclosureLabelsHtml(l, 'ai-disclosure-picker') +
         '<span class="eb-lpick-meta">' +
           '<span class="eb-lpick-cat">' + _escHtml(l.categoryLabel || l.category || '') + '</span>' +
           (price ? '<span class="eb-lpick-price">' + _escHtml(price) + '</span>' : '') +
@@ -1421,8 +1422,8 @@ function renderListingFeedCard(l) {
       '</div>' +
       '<button class="feed-more-btn" onclick="openPostMenu(event,\'listing-' + l.id + '\',\'' + (l.providerName || '').replace(/'/g, '') + '\')" aria-label="Optionen"><span class="material-icons-round">more_horiz</span></button>' +
     '</div>' +
-    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />' + _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) + '</div>' +
-    '<div class="feed-post-content">' + _escHtml(l.title) + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
+    '<div class="feed-post-media" style="background-image:url(&quot;' + _escHtml(l.image) + '&quot;)"><img class="feed-post-image" src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="lazy" onclick="navigateTo(\'detail\',' + l.id + ')" onload="_fitFeedImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>' +
+    '<div class="feed-post-content">' + _escHtml(l.title) + _aiDisclosureLabelsHtml(l, 'ai-disclosure-social') + (l.location ? '<br><small style="color:var(--text-light)"><span class=\"material-icons-round\" style=\"font-size:12px;vertical-align:middle\">location_on</span>' + _escHtml(l.location) + '</small>' : '') + '</div>' +
     '<div class="feed-action-bar">' +
       '<div class="feed-actions">' +
         '<button class="feed-action-btn' + (isFav ? ' liked' : '') + '" onclick="toggleFeedFav(this,' + l.id + ')">' +

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -158,7 +158,7 @@ function _surfaceVisibleListings(arr) {
 }
 
 // AI transparency is stored separately for copy and media so a human photo
-// is never falsely watermarked merely because the description used AI.
+// is never falsely classified merely because the description used AI.
 // "undeclared" is reserved for migrated legacy records and is not shown as
 // proof of human authorship.
 function _aiDisclosureValue(item, kind) {
@@ -175,16 +175,18 @@ function _aiDisclosureAttrs(item) {
 }
 
 function _aiDisclosureLabels(item) {
-  var labels = [];
   var textStatus = _aiDisclosureValue(item, 'text');
   var mediaStatus = _aiDisclosureValue(item, 'media');
-  if (mediaStatus === 'generated') labels.push({ kind: 'media', label: 'KI-generiertes Bild', short: 'KI-generiert' });
-  if (mediaStatus === 'assisted') labels.push({ kind: 'media', label: 'KI-bearbeitetes Bild', short: 'KI-bearbeitet' });
-  if (textStatus === 'generated') labels.push({ kind: 'text', label: 'KI-generierter Text', short: 'KI-Text' });
-  if (textStatus === 'assisted') labels.push({ kind: 'text', label: 'KI-unterstützter Text', short: 'KI-Text bearbeitet' });
-  if (mediaStatus === 'undeclared') labels.push({ kind: 'media', label: 'KI-Status der Medien noch nicht deklariert', short: 'Medien: KI-Status offen', legacy: true });
-  if (textStatus === 'undeclared') labels.push({ kind: 'text', label: 'KI-Status des Textes noch nicht deklariert', short: 'Text: KI-Status offen', legacy: true });
-  return labels;
+  if (textStatus === 'generated' || mediaStatus === 'generated') {
+    return [{ state: 'generated', label: 'KI-generierter Inhalt' }];
+  }
+  if (textStatus === 'assisted' || mediaStatus === 'assisted') {
+    return [{ state: 'assisted', label: 'KI-unterstützter Inhalt' }];
+  }
+  if (textStatus === 'undeclared' || mediaStatus === 'undeclared') {
+    return [{ state: 'open', label: 'KI-Status offen', legacy: true }];
+  }
+  return [];
 }
 
 function _aiDisclosureLabelsHtml(item, extraClass) {
@@ -192,27 +194,10 @@ function _aiDisclosureLabelsHtml(item, extraClass) {
   if (!labels.length) return '';
   return '<span class="ai-disclosure-stack' + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="KI-Transparenz">' +
     labels.map(function(info) {
-      return '<span class="ai-content-label ai-content-label-' + info.kind + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
+      return '<span class="ai-content-label ai-content-label-' + info.state + (info.legacy ? ' ai-content-label-open' : '') + '" title="' +
         (info.legacy ? 'Altbestand: noch nicht nachdeklariert' : 'Von der einstellenden Person deklariert') + '">' +
-        '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + _escHtml(info.short) + '</span>';
+        _escHtml(info.label) + '</span>';
     }).join('') + '</span>';
-}
-
-function _aiMediaWatermarkHtml(item, extraClass) {
-  var mediaStatus = _aiDisclosureValue(item, 'media');
-  if (mediaStatus === 'none') return '';
-  var label = mediaStatus === 'generated' ? 'KI-GENERIERT' : (mediaStatus === 'assisted' ? 'KI-BEARBEITET' : 'KI-STATUS OFFEN');
-  var aria = mediaStatus === 'generated' ? 'KI-generiertes Bild' : (mediaStatus === 'assisted' ? 'KI-bearbeitetes Bild' : 'KI-Status der Medien noch nicht deklariert');
-  return '<span class="ai-media-watermark' + (mediaStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' + label + '</span>';
-}
-
-function _aiTextDisclosureHtml(item, extraClass) {
-  var textStatus = _aiDisclosureValue(item, 'text');
-  if (textStatus === 'none') return '';
-  var label = textStatus === 'generated' ? 'KI-Text' : (textStatus === 'assisted' ? 'KI-Text bearbeitet' : 'Text-KI offen');
-  var aria = textStatus === 'generated' ? 'KI-generierter Text' : (textStatus === 'assisted' ? 'KI-unterstützter Text' : 'KI-Status des Textes noch nicht deklariert');
-  return '<span class="ai-text-watermark' + (textStatus === 'undeclared' ? ' ai-watermark-open' : '') + (extraClass ? ' ' + _escHtml(extraClass) : '') + '" aria-label="' + aria + '">' +
-    '<span class="material-icons-round" aria-hidden="true">auto_awesome</span>' + label + '</span>';
 }
 
 function _safeRun(label, fn) {

--- a/js/modules/core/01-demo-daten.js
+++ b/js/modules/core/01-demo-daten.js
@@ -379,6 +379,13 @@ const LISTINGS = [
   }
 ];
 
+// Die redaktionellen Demo-Inserate wurden mit generativer KI erstellt. Die
+// Angabe sitzt als dezenter Text am Inserat; die Bilder selbst bleiben frei.
+LISTINGS.forEach(function(listing) {
+  listing.aiTextDisclosure = 'generated';
+  listing.aiMediaDisclosure = 'generated';
+});
+
 // Auto-Inject logical price ranges (priceMax) for demo listings + rebuild priceLabel as range.
 // Multiplikator pro Preismodell: realistische Spannen für DE-Eventmarkt.
 (function injectDemoPriceRanges(){
@@ -547,4 +554,3 @@ const DEMO_EVENTS = [
     ]
   }
 ];
-

--- a/js/modules/search/10-karten-home-feed.js
+++ b/js/modules/search/10-karten-home-feed.js
@@ -15,8 +15,6 @@ function renderListingCard(listing) {
         </button>
         ${listing.badge ? '<span class="listing-badge">' + _escHtml(listing.badge) + '</span>' : ''}
         ${_boardStatusBadgeHtml(listing.id, 'bsb-on-card')}
-        ${_aiMediaWatermarkHtml(listing)}
-        ${_aiTextDisclosureHtml(listing)}
       </div>
       <div class="listing-card-body">
         <div class="listing-card-top">
@@ -25,6 +23,7 @@ function renderListingCard(listing) {
             <span class="material-icons-round">star</span> ${listing.rating || 0}
           </span>
         </div>
+        ${_aiDisclosureLabelsHtml(listing, 'ai-disclosure-card')}
         <div class="listing-card-category">${_escHtml(listing.categoryLabel)}</div>
         <div class="listing-card-location">
           <span class="material-icons-round">location_on</span> ${_escHtml(listing.location)}
@@ -80,10 +79,10 @@ function renderHeroMarquees() {
   function cardHTML(l) {
     return '<a class="hero-marquee-card"' + _aiDisclosureAttrs(l) + ' href="#" onclick="navigateTo(\'detail\',' + l.id + ');return false;">' +
       '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" loading="eager"' + window.EB_IMG_ERR_ATTR + ' />' +
-      _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
       '<div class="hero-marquee-card-info">' +
         '<h4>' + _escHtml(l.title) + '</h4>' +
         '<span>' + _escHtml(l.priceLabel) + ' · ★ ' + (l.rating || 0) + '</span>' +
+        _aiDisclosureLabelsHtml(l, 'ai-disclosure-marquee') +
       '</div></a>';
   }
 
@@ -252,7 +251,6 @@ function renderExploreGrid(filter) {
     const sizeClass = (i % 7 === 0) ? 'explore-item-large' : '';
     return `<a href="#" class="explore-item ${sizeClass}"${_aiDisclosureAttrs(it)} onclick="navigateTo('detail',${it.listingId});return false;" style="background-image:url('${_escHtml(it.image)}')">
       <img src="${_escHtml(it.image)}" alt="${_escHtml(it.title)}" loading="lazy" onload="_fitExploreImg(this)" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />
-      ${_aiMediaWatermarkHtml(it)}${_aiTextDisclosureHtml(it)}
       <div class="explore-item-overlay">
         <span class="explore-item-title">${_escHtml(it.title)}</span>
         <span class="explore-item-price">${_escHtml(it.price)}</span>
@@ -333,9 +331,10 @@ function renderFeed(tab) {
         </div>
         <span class="feed-card-category">${_escHtml(categoryLabel)}</span>
       </div>
-      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" />${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}</div>
+      <div class="feed-card-media"><img class="feed-card-image" src="${_escHtml(l.image)}" alt="${_escHtml(l.title)}" onclick="navigateTo('detail',${l.id})" loading="lazy" onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK" /></div>
       <div class="feed-card-body">
         <div class="feed-card-title" onclick="navigateTo('detail',${l.id})">${_escHtml(l.title)}</div>
+        ${_aiDisclosureLabelsHtml(l, 'ai-disclosure-feed')}
         <div class="feed-card-desc">${_escHtml(_stripHtml(desc))}</div>
       </div>
       ${l.location ? '<div class="feed-card-location"><span class="material-icons-round">location_on</span> ' + _escHtml(l.location) + '</div>' : ''}

--- a/js/modules/search/11-suche-ki.js
+++ b/js/modules/search/11-suche-ki.js
@@ -1898,7 +1898,6 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
               <span class="material-icons-round">favorite_border</span>
             </button>
             ${l.badge ? `<span class="listing-badge">${_escHtml(l.badge)}</span>` : ''}
-            ${_aiMediaWatermarkHtml(l)}${_aiTextDisclosureHtml(l)}
           </div>
           <div class="listing-card-body">
             <div class="listing-card-top">
@@ -1907,6 +1906,7 @@ function showNoResultsWithAlternatives(search, category, eventType, location) {
                 <span class="material-icons-round">star</span> ${l.rating}
               </span>
             </div>
+            ${_aiDisclosureLabelsHtml(l, 'ai-disclosure-card')}
             <div class="listing-card-category">${_escHtml(l.categoryLabel)}</div>
             <div class="listing-card-location">
               <span class="material-icons-round">location_on</span> ${_escHtml(l.location)} ${distBadge}

--- a/js/modules/search/12-detail-provider.js
+++ b/js/modules/search/12-detail-provider.js
@@ -21,7 +21,7 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />${_aiMediaWatermarkHtml(listing)}`;
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
     heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 
@@ -34,7 +34,7 @@ function loadDetail(listingId) {
       var delBtn = _detailCanModerate && img !== window.EB_IMG_FALLBACK
         ? '<button type="button" class="detail-gallery-admin-del" title="Bild als Admin löschen" aria-label="Bild als Admin löschen" onclick="adminDeleteListingImage(' + i + ', event)"><span class="material-icons-round">delete</span> Löschen</button>'
         : '';
-      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + _aiMediaWatermarkHtml(listing) + delBtn + '</div>';
+      return '<div class="detail-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_ERR_ATTR + ' />' + delBtn + '</div>';
     }).join('') +
     '</div>' +
     (imgs.length > 1 ? '<button class="detail-gallery-arrow prev" aria-label="Vorheriges Bild" onclick="detailGalleryNav(-1)"><span class="material-icons-round">chevron_left</span></button>' +
@@ -71,8 +71,8 @@ function loadDetail(listingId) {
     var hasOpenStatus = _aiDisclosureValue(listing, 'text') === 'undeclared' || _aiDisclosureValue(listing, 'media') === 'undeclared';
     var aiNote = hasOpenStatus
       ? 'Altbestand: Die ausdrückliche Nachdeklaration steht noch aus.'
-      : 'Vom Anbieter bei Veröffentlichung deklariert.';
-    aiDisclosure.innerHTML = aiLabels ? aiLabels + '<small>' + aiNote + '</small>' : '';
+      : '';
+    aiDisclosure.innerHTML = aiLabels ? aiLabels + (aiNote ? '<small>' + aiNote + '</small>' : '') : '';
     aiDisclosure.setAttribute('data-ai-text', _aiDisclosureValue(listing, 'text'));
     aiDisclosure.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }

--- a/js/modules/search/13-event-radar.js
+++ b/js/modules/search/13-event-radar.js
@@ -782,8 +782,8 @@ function _drawFeedRadar() {
       var image = (d.images && d.images[0]) || d.image || window.EB_IMG_FALLBACK;
       return '<article class="feed-radar-result" data-radar-index="' + index + '"' + _aiDisclosureAttrs(d) + '>' +
         '<button type="button" class="feed-radar-result-map" onclick="feedRadarFocus(' + index + ')" aria-label="' + _escHtml(title) + ' auf der Karte zeigen">' +
-        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '>' + _aiMediaWatermarkHtml(d) + _aiTextDisclosureHtml(d) + '</span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
-        '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong><small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
+        '<span class="feed-radar-result-image"><img src="' + _escHtml(image) + '" alt="" loading="lazy"' + window.EB_IMG_ERR_ATTR + '></span><span><span class="radar-result-meta"><span>' + (hit.art === 'event' ? 'EVENT' : 'DIENSTLEISTER') + '</span><strong>' + _escHtml(radarEntfernung(hit.km)) + '</strong></span>' +
+        '<strong class="feed-radar-result-title">' + _escHtml(title) + '</strong>' + _aiDisclosureLabelsHtml(d, 'ai-disclosure-radar-result') + '<small><span class="material-icons-round">location_on</span>' + _escHtml(hit.ort || '') + (hit.genau ? '' : ' · ca.') + '</small></span></button>' +
         '<button type="button" class="feed-radar-result-open" onclick="feedRadarOpen(' + index + ')" aria-label="' + _escHtml(title) + ' öffnen"><span class="material-icons-round">arrow_forward</span></button></article>';
     }).join('') + '</div>';
   _initFeedRadarMap(hits);

--- a/js/modules/ui/22-inserat-settings-uploads.js
+++ b/js/modules/ui/22-inserat-settings-uploads.js
@@ -599,60 +599,7 @@ function _setAiDisclosureForm(textStatus, mediaStatus) {
 function _aiDisclosureFormChanged() {
   var section = document.getElementById('aiDisclosureSection');
   if (section) section.classList.remove('has-error');
-  _updateListingPreviewAiLabels();
   _updateListingLivePreview();
-}
-
-function _updateListingPreviewAiLabels() {
-  var mediaStatus = _selectedAiDisclosure('media');
-  document.querySelectorAll('#uploadPreview .upload-preview-item').forEach(function(item) {
-    var old = item.querySelector('.ai-media-watermark');
-    if (old) old.remove();
-    var html = _aiMediaWatermarkHtml({ aiMediaDisclosure: mediaStatus }, 'ai-media-watermark-preview');
-    if (html) item.insertAdjacentHTML('beforeend', html);
-  });
-}
-
-// Burn the declaration into every newly uploaded AI image. The UI overlay is
-// still rendered separately because it must remain visible on all surfaces;
-// this pixel watermark additionally survives opening or sharing the file.
-function _aiWatermarkBlob(blob, mediaStatus) {
-  if (!blob || (mediaStatus !== 'assisted' && mediaStatus !== 'generated')) return Promise.resolve(blob);
-  return new Promise(function(resolve) {
-    var url = URL.createObjectURL(blob);
-    var img = new Image();
-    img.onload = function() {
-      try {
-        var canvas = document.createElement('canvas');
-        canvas.width = img.naturalWidth || img.width;
-        canvas.height = img.naturalHeight || img.height;
-        var ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-        var label = mediaStatus === 'generated' ? 'KI-GENERIERT · EVENTBÖRSE' : 'KI-BEARBEITET · EVENTBÖRSE';
-        var fontSize = Math.max(20, Math.round(canvas.width * 0.027));
-        var padX = Math.round(fontSize * 0.65);
-        var padY = Math.round(fontSize * 0.42);
-        ctx.font = '700 ' + fontSize + 'px Arial, sans-serif';
-        var textWidth = ctx.measureText(label).width;
-        var boxW = textWidth + padX * 2;
-        var boxH = fontSize + padY * 2;
-        var x = Math.max(12, canvas.width - boxW - Math.round(fontSize * 0.6));
-        var y = Math.max(12, canvas.height - boxH - Math.round(fontSize * 0.6));
-        ctx.fillStyle = 'rgba(12, 15, 24, 0.84)';
-        ctx.fillRect(x, y, boxW, boxH);
-        ctx.fillStyle = '#ffffff';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(label, x + padX, y + boxH / 2);
-        canvas.toBlob(function(marked) { resolve(marked || blob); }, 'image/jpeg', 0.92);
-      } catch (e) {
-        resolve(blob);
-      } finally {
-        URL.revokeObjectURL(url);
-      }
-    };
-    img.onerror = function() { URL.revokeObjectURL(url); resolve(blob); };
-    img.src = url;
-  });
 }
 
 async function submitListing(e) {
@@ -789,20 +736,17 @@ async function submitListing(e) {
   // Upload images: cropped blobs first, then data URLs, keep existing URLs
   var uploadPromises = imgEntries.map(function(entry) {
     if (entry.blob) {
-      return _aiWatermarkBlob(entry.blob, aiMediaDisclosure).then(function(markedBlob) {
-        var file = new File([markedBlob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.jpg', { type: 'image/jpeg' });
-        return uploadFile(file).then(function(r) { return r.url; });
-      });
+      var blobType = entry.blob.type || 'image/jpeg';
+      var blobExt = (blobType.split('/')[1] || 'jpg').replace('jpeg', 'jpg');
+      var croppedFile = new File([entry.blob], 'listing-' + Date.now() + '-' + Math.random().toString(36).slice(2,6) + '.' + blobExt, { type: blobType });
+      return uploadFile(croppedFile).then(function(r) { return r.url; });
     }
     if (entry.src.startsWith('data:')) {
       var arr = entry.src.split(','), mime = arr[0].match(/:(.*?);/)[1];
       var bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
       while (n--) u8arr[n] = bstr.charCodeAt(n);
       var sourceFile = new File([u8arr], 'listing-' + Date.now() + '.' + mime.split('/')[1], { type: mime });
-      return _aiWatermarkBlob(sourceFile, aiMediaDisclosure).then(function(markedBlob) {
-        var file = new File([markedBlob], 'listing-' + Date.now() + '.jpg', { type: 'image/jpeg' });
-        return uploadFile(file).then(function(r) { return r.url; });
-      });
+      return uploadFile(sourceFile).then(function(r) { return r.url; });
     }
     return Promise.resolve(entry.src);
   });
@@ -1264,8 +1208,6 @@ function _updateListingLivePreview() {
     slideImg.src = img.src;
     slideImg.alt = 'Vorschau';
     slide.appendChild(slideImg);
-    var watermark = _aiMediaWatermarkHtml(previewDisclosure, 'ai-media-watermark-live');
-    if (watermark) slide.insertAdjacentHTML('beforeend', watermark);
     track.appendChild(slide);
   });
 

--- a/js/modules/ui/24-favoriten-inserate-admin.js
+++ b/js/modules/ui/24-favoriten-inserate-admin.js
@@ -93,11 +93,11 @@ function renderMyListings() {
             return '<div class="my-listing-card">' +
               '<div class="my-listing-img"' + _aiDisclosureAttrs(evt) + '>' +
                 '<img src="' + _escHtml(evt.image) + '" alt="' + _escHtml(evt.title) + '" />' +
-                _aiMediaWatermarkHtml(evt) + _aiTextDisclosureHtml(evt) +
                 '<span class="status-badge status-active">Aktiv</span>' +
               '</div>' +
               '<div class="my-listing-info">' +
                 '<h3>' + _escHtml(evt.title) + '</h3>' +
+                _aiDisclosureLabelsHtml(evt, 'ai-disclosure-admin') +
                 '<p>' + _escHtml(evt.categoryLabel) + ' · ' + _escHtml(evt.location) + '</p>' +
                 '<p class="my-listing-price">' + _escHtml(evt.priceLabel) + '</p>' +
                 '<div class="my-listing-stats">' +
@@ -175,11 +175,11 @@ function renderMyListings() {
           return '<div class="my-listing-card">' +
             '<div class="my-listing-img"' + _aiDisclosureAttrs(l) + '>' +
               '<img src="' + _escHtml(l.image) + '" alt="' + _escHtml(l.title) + '" />' +
-              _aiMediaWatermarkHtml(l) + _aiTextDisclosureHtml(l) +
               '<span class="status-badge status-active">Aktiv</span>' +
             '</div>' +
             '<div class="my-listing-info">' +
               '<h3>' + _escHtml(l.title) + '</h3>' +
+              _aiDisclosureLabelsHtml(l, 'ai-disclosure-admin') +
               '<p>' + _escHtml(l.categoryLabel) + ' · ' + _escHtml(l.location) + '</p>' +
               '<p class="my-listing-price">' + _escHtml(l.priceLabel) + '</p>' +
               '<div class="my-listing-stats">' +

--- a/release-vision.css
+++ b/release-vision.css
@@ -87,8 +87,6 @@ body.dark-mode .feed-radar-map .leaflet-tile-pane,[data-theme="dark"] .feed-rada
 @media(max-width:420px){.feed-radar-map{height:350px}.feed-radar-map-radius{display:none!important}.feed-radar-legend{font-size:.6rem}.feed-radar-result{grid-template-columns:minmax(0,1fr) 38px}.feed-radar-result-map{grid-template-columns:72px minmax(0,1fr);padding:7px}.feed-radar-result-map>img{width:72px;height:78px}.feed-radar-result-map small{font-size:.66rem}}
 @media(prefers-reduced-motion:reduce){.feed-radar-live-dot.scannt{animation:none}.feed-radar-marker{transition:none}}
 
-/* AI labels need an image wrapper so the declaration stays attached to the
-   exact Radar thumbnail rather than floating over the distance copy. */
-.feed-radar-result-image{position:relative;display:block;width:104px;height:92px;overflow:hidden;border-radius:11px}.feed-radar-result-image>img{display:block;width:100%;height:100%;object-fit:cover}.feed-radar-result-image .ai-media-watermark,.feed-radar-result-image .ai-text-watermark{left:4px;max-width:calc(100% - 8px);padding:3px 4px;font-size:6px}.feed-radar-result-image .ai-media-watermark{bottom:4px}.feed-radar-result-image .ai-text-watermark{bottom:20px}
+.feed-radar-result-image{position:relative;display:block;width:104px;height:92px;overflow:hidden;border-radius:11px}.feed-radar-result-image>img{display:block;width:100%;height:100%;object-fit:cover}
 @media(max-width:700px){.feed-radar-result-image{width:84px;height:84px}}
 @media(max-width:420px){.feed-radar-result-image{width:72px;height:78px}}

--- a/styles.css
+++ b/styles.css
@@ -16995,77 +16995,38 @@ body.dark-mode .radar-chip.aktiv { background: var(--primary); color: #fff; }
 .form-optional { font-weight: 400; color: var(--text-light); font-size: .8em; }
 body.dark-mode .geo-treffer-btn { background: var(--bg-alt); color: var(--text); }
 
-/* ===== AI TRANSPARENCY / ART. 50 AI ACT ===== */
-.ai-media-watermark,
-.ai-text-watermark {
-  position: absolute;
-  left: 10px;
-  z-index: 30;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  max-width: calc(100% - 20px);
-  padding: 5px 8px;
-  border: 1px solid rgba(255,255,255,.72);
-  border-radius: 7px;
-  color: #fff;
-  box-shadow: 0 2px 10px rgba(0,0,0,.28);
-  font-size: 10px;
-  font-weight: 850;
-  line-height: 1;
-  letter-spacing: .055em;
-  text-transform: uppercase;
-  pointer-events: none;
-  white-space: nowrap;
-}
-.ai-media-watermark { bottom: 10px; background: rgba(12,15,24,.88); }
-.ai-text-watermark { bottom: 40px; background: rgba(70,24,114,.93); }
-.ai-watermark-open { border-style: dashed; background: rgba(55,65,81,.9); color: #f9fafb; }
-.ai-text-watermark .material-icons-round { font-size: 12px; }
-.hero-marquee-card { position: relative; }
-.hero-marquee-card .ai-media-watermark { top: 101px; bottom: auto; left: 8px; padding: 4px 6px; font-size: 8px; }
-.hero-marquee-card .ai-text-watermark { top: 74px; bottom: auto; left: 8px; padding: 4px 6px; font-size: 8px; }
-.explore-item .ai-media-watermark { top: 10px; bottom: auto; }
-.explore-item .ai-text-watermark { top: 40px; bottom: auto; }
+/* ===== Dezente KI-Transparenz ===== */
 .detail-hero-img,
 .feed-card-media,
 .my-listing-img,
 .eb-lpick-thumb { position: relative; }
 .feed-card-media .feed-card-image { display: block; width: 100%; }
-.detail-hero-img .ai-media-watermark { bottom: 14px; }
-.ai-media-watermark-picker,
-.ai-text-watermark-picker { left: 3px; right: 3px; max-width: none; padding: 3px; font-size: 6px; overflow: hidden; }
-.ai-media-watermark-picker { bottom: 3px; }
-.ai-text-watermark-picker { bottom: 17px; }
-.ai-media-watermark-preview,
-.ai-media-watermark-live { bottom: 8px; }
 
 .ai-disclosure-stack {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: block;
+  margin-top: 3px;
+  line-height: 1.2;
 }
 .ai-content-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 5px 8px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-alt);
-  color: var(--text);
-  font-size: 11px;
-  font-weight: 750;
-  line-height: 1.15;
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-light);
+  font-size: 10px;
+  font-weight: 450;
+  line-height: 1.2;
 }
-.ai-content-label .material-icons-round { color: #6d28d9; font-size: 14px; }
-.ai-content-label-open { border-style: dashed; color: var(--text-light); }
-.ai-content-label-open .material-icons-round { color: #6b7280; }
-.detail-ai-disclosure { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.ai-content-label-open { font-style: italic; }
+.detail-ai-disclosure { display: block; margin-top: 7px; }
 .detail-ai-disclosure:empty { display: none; }
-.detail-ai-disclosure small { color: var(--text-light); font-size: 11px; }
-.ai-disclosure-radar-popup { margin-top: 4px; }
-.ai-disclosure-radar-popup .ai-content-label { padding: 3px 5px; font-size: 8px; }
+.detail-ai-disclosure small { display: block; margin-top: 2px; color: var(--text-light); font-size: 9px; }
+.ai-disclosure-radar-popup,
+.ai-disclosure-radar-result { margin: 2px 0 3px; }
+.ai-disclosure-radar-popup .ai-content-label,
+.ai-disclosure-radar-result .ai-content-label { font-size: 9px; }
+.ai-disclosure-picker { margin-top: 0; }
+.ai-disclosure-picker .ai-content-label { font-size: 9px; }
 
 .ai-declaration {
   display: grid;
@@ -17101,5 +17062,4 @@ body.dark-mode .geo-treffer-btn { background: var(--bg-alt); color: var(--text);
 @media (max-width: 720px) {
   .ai-declaration-group { grid-template-columns: 1fr; }
   .ai-declaration { padding: 15px; }
-  .ai-media-watermark, .ai-text-watermark { font-size: 9px; }
 }

--- a/tests/e2e/ki-transparenz.spec.js
+++ b/tests/e2e/ki-transparenz.spec.js
@@ -1,5 +1,5 @@
-// KI-Transparenz: keine stillen Defaults, sichtbare Kennzeichnung auf jeder
-// Inseratflaeche und ein belastbarer Meldeweg fuer falsche Deklarationen.
+// KI-Transparenz: keine stillen Defaults, dezente Kennzeichnung ausserhalb
+// der Bilder und ein belastbarer Meldeweg fuer falsche Deklarationen.
 const { test, expect } = require('@playwright/test');
 const { openApp, expectNoPageErrors } = require('./helpers');
 const fs = require('node:fs');
@@ -9,6 +9,8 @@ const ROOT = path.join(__dirname, '..', '..');
 const FUNCTIONS = fs.readFileSync(path.join(ROOT, 'functions.php'), 'utf8');
 const SHELL = fs.readFileSync(path.join(ROOT, 'app-shell.html'), 'utf8');
 const BASIS = fs.readFileSync(path.join(ROOT, 'js/modules/core/00-basis.js'), 'utf8');
+const DEMOS = fs.readFileSync(path.join(ROOT, 'js/modules/core/01-demo-daten.js'), 'utf8');
+const CARDS = fs.readFileSync(path.join(ROOT, 'js/modules/search/10-karten-home-feed.js'), 'utf8');
 const UPLOADS = fs.readFileSync(path.join(ROOT, 'js/modules/ui/22-inserat-settings-uploads.js'), 'utf8');
 const DETAIL = fs.readFileSync(path.join(ROOT, 'js/modules/search/12-detail-provider.js'), 'utf8');
 const VISION = fs.readFileSync(path.join(ROOT, 'js/modules/ui/52-release-vision.js'), 'utf8');
@@ -35,17 +37,19 @@ test.describe('Deklaration ist ausdruecklich und dauerhaft', () => {
     expect(update).toMatch(/\$params\['aiMediaDisclosure'\] \?\? ''/);
   });
 
-  test('Migration erfindet fuer Altinhalte keine menschliche Urheberschaft', () => {
-    expect(FUNCTIONS).toMatch(/define\( 'EB_DB_VERSION', '2\.6' \)/);
+  test('bestaetigter Live-Bestand und Demo-Inserate sind korrekt nachdeklariert', () => {
+    expect(FUNCTIONS).toMatch(/define\( 'EB_DB_VERSION', '2\.7' \)/);
     expect(FUNCTIONS).toMatch(/ai_text_disclosure varchar\(20\) NOT NULL DEFAULT 'undeclared'/);
     expect(FUNCTIONS).toMatch(/ai_media_disclosure varchar\(20\) NOT NULL DEFAULT 'undeclared'/);
-    expect(BASIS).toContain('Medien: KI-Status offen');
-    expect(BASIS).toContain('Text: KI-Status offen');
+    expect(FUNCTIONS).toMatch(/ai_text_disclosure = 'none', ai_media_disclosure = 'none' WHERE id IN \(5, 7, 8\)/);
+    expect(FUNCTIONS).toMatch(/ai_text_disclosure = 'generated', ai_media_disclosure = 'generated' WHERE id IN \(9, 10, 12, 13\)/);
+    expect(DEMOS).toContain("listing.aiTextDisclosure = 'generated'");
+    expect(DEMOS).toContain("listing.aiMediaDisclosure = 'generated'");
   });
 });
 
-test.describe('Kennzeichnung bleibt an jedem Inhalt', () => {
-  test('Helfer liefern sichtbare und maschinenlesbare Kennzeichnung', async ({ page }) => {
+test.describe('Kennzeichnung bleibt dezent am Inhalt', () => {
+  test('Helfer liefern eine kleine Textzeile und maschinenlesbare Werte', async ({ page }) => {
     const errors = await openApp(page);
     const result = await page.evaluate(() => {
       const ai = { aiTextDisclosure: 'assisted', aiMediaDisclosure: 'generated' };
@@ -53,78 +57,65 @@ test.describe('Kennzeichnung bleibt an jedem Inhalt', () => {
       const legacy = {};
       return {
         attrs: _aiDisclosureAttrs(ai),
-        media: _aiMediaWatermarkHtml(ai),
-        text: _aiTextDisclosureHtml(ai),
         labels: _aiDisclosureLabelsHtml(ai),
-        humanMedia: _aiMediaWatermarkHtml(human),
-        humanText: _aiTextDisclosureHtml(human),
-        legacyMedia: _aiMediaWatermarkHtml(legacy),
-        legacyText: _aiTextDisclosureHtml(legacy),
+        humanLabels: _aiDisclosureLabelsHtml(human),
+        legacyLabels: _aiDisclosureLabelsHtml(legacy),
       };
     });
     expect(result.attrs).toContain('data-ai-text="assisted"');
     expect(result.attrs).toContain('data-ai-media="generated"');
-    expect(result.media).toContain('KI-GENERIERT');
-    expect(result.text).toContain('KI-Text bearbeitet');
-    expect(result.labels).toContain('KI-generiert');
-    expect(result.humanMedia).toBe('');
-    expect(result.humanText).toBe('');
-    expect(result.legacyMedia).toContain('KI-STATUS OFFEN');
-    expect(result.legacyText).toContain('Text-KI offen');
+    expect(result.labels).toContain('KI-generierter Inhalt');
+    expect(result.labels).not.toContain('material-icons-round');
+    expect(result.humanLabels).toBe('');
+    expect(result.legacyLabels).toContain('KI-Status offen');
     expectNoPageErrors(errors, 'KI-Kennzeichnungshelfer');
   });
 
-  test('Inseratkarte traegt Datenattribute und beide sichtbaren Hinweise', async ({ page }) => {
+  test('Inseratkarte zeigt den Text im Inhaltsteil und nie auf dem Bild', async ({ page }) => {
     const errors = await openApp(page);
-    const html = await page.evaluate(() => renderListingCard({
-      id: 991,
-      title: 'Deklarierter Testinhalt',
-      image: window.EB_IMG_FALLBACK,
-      images: [window.EB_IMG_FALLBACK],
-      providerName: 'Transparenz-Test',
-      providerImg: window.EB_IMG_FALLBACK,
-      providerId: 1,
-      priceLabel: '100 €',
-      rating: 5,
-      reviews: 1,
-      region: 'Berlin',
-      aiTextDisclosure: 'generated',
-      aiMediaDisclosure: 'assisted',
-    }));
-    expect(html).toContain('data-ai-text="generated"');
-    expect(html).toContain('data-ai-media="assisted"');
-    expect(html).toContain('KI-BEARBEITET');
-    expect(html).toContain('KI-Text');
+    const result = await page.evaluate(() => {
+      const host = document.createElement('div');
+      host.innerHTML = renderListingCard({
+        id: 991,
+        title: 'Deklarierter Testinhalt',
+        categoryLabel: 'Dekoration',
+        location: 'Berlin',
+        image: window.EB_IMG_FALLBACK,
+        images: [window.EB_IMG_FALLBACK],
+        providerName: 'Transparenz-Test',
+        providerImg: window.EB_IMG_FALLBACK,
+        providerId: 1,
+        priceLabel: '100 €',
+        rating: 5,
+        reviews: 1,
+        region: 'Berlin',
+        aiTextDisclosure: 'generated',
+        aiMediaDisclosure: 'assisted',
+      });
+      const card = host.firstElementChild;
+      return {
+        text: card.textContent,
+        imageText: card.querySelector('.listing-card-img').textContent,
+        bodyText: card.querySelector('.listing-card-body').textContent,
+        aiText: card.getAttribute('data-ai-text'),
+        aiMedia: card.getAttribute('data-ai-media'),
+      };
+    });
+    expect(result.aiText).toBe('generated');
+    expect(result.aiMedia).toBe('assisted');
+    expect(result.text).toContain('KI-generierter Inhalt');
+    expect(result.imageText).not.toContain('KI');
+    expect(result.bodyText).toContain('KI-generierter Inhalt');
     expectNoPageErrors(errors, 'KI-Inseratkarte');
   });
 
-  test('neue KI-Bilder bekommen das Wasserzeichen in die Pixel', async ({ page }) => {
-    const errors = await openApp(page);
-    const marked = await page.evaluate(async () => {
-      const source = document.createElement('canvas');
-      source.width = 900;
-      source.height = 600;
-      const sourceCtx = source.getContext('2d');
-      sourceCtx.fillStyle = '#ffffff';
-      sourceCtx.fillRect(0, 0, source.width, source.height);
-      const original = await new Promise((resolve) => source.toBlob(resolve, 'image/png'));
-      const result = await _aiWatermarkBlob(original, 'generated');
-      const bitmap = await createImageBitmap(result);
-      const out = document.createElement('canvas');
-      out.width = bitmap.width;
-      out.height = bitmap.height;
-      const ctx = out.getContext('2d');
-      ctx.drawImage(bitmap, 0, 0);
-      const pixels = ctx.getImageData(0, Math.floor(out.height * .78), out.width, Math.ceil(out.height * .22)).data;
-      let dark = 0;
-      for (let i = 0; i < pixels.length; i += 4) {
-        if (pixels[i] < 100 && pixels[i + 1] < 100 && pixels[i + 2] < 100) dark++;
-      }
-      return { type: result.type, dark };
-    });
-    expect(marked.type).toBe('image/jpeg');
-    expect(marked.dark, 'eingebrannte dunkle Wasserzeichenflaeche fehlt').toBeGreaterThan(1000);
-    expectNoPageErrors(errors, 'Pixel-Wasserzeichen');
+  test('Bilddateien und Bildflaechen bleiben frei von Wasserzeichen', () => {
+    expect(BASIS).not.toContain('_aiMediaWatermarkHtml');
+    expect(BASIS).not.toContain('_aiTextDisclosureHtml');
+    expect(UPLOADS).not.toContain('_aiWatermarkBlob');
+    expect(CARDS).not.toContain('_aiMediaWatermarkHtml');
+    expect(CARDS).not.toContain('_aiTextDisclosureHtml');
+    expect(UPLOADS).toMatch(/new File\(\[entry\.blob\]/);
   });
 });
 

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -7,7 +7,7 @@ tags: [layer/L0, domain/kern, share/internal, typ/messung]
 
 # ⚡ Impuls-Strom — der lebende Zustand
 
-> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-14**
+> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-15**
 > Nicht von Hand bearbeiten — jeder Lauf überschreibt die Datei.
 > Diese Notiz misst, was im Netz tatsächlich fließt. Die Ströme selbst
 > sind in [[00-Kern/Wissensstroeme]] beschrieben.
@@ -63,23 +63,23 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **28** |
-| Commits (30 Tage) | 127 |
-| Letzter Commit | `3e530dc · Merge pull request #154 from Sabindro53/agent/fix-radar-popup-contrast` (2026-08-14) |
+| Commits (7 Tage) | **30** |
+| Commits (30 Tage) | 128 |
+| Letzter Commit | `71a6ebd · Merge pull request #155 from Sabindro53/agent/add-ai-transparency` (2026-08-14) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
 38 app.js
   37 tests/e2e/kern.spec.js
   33 CLAUDE.md
-  29 vault/50-Evolution/Roadmap/Current-Sprint.md
+  30 vault/50-Evolution/Roadmap/Current-Sprint.md
   28 styles.css
 ```
 
 **Codegröße:**
-- `app.js` — 26.599 Zeilen
-- `styles.css` — 17.105 Zeilen
-- `functions.php` — 10.198 Zeilen
+- `app.js` — 26.532 Zeilen
+- `styles.css` — 17.065 Zeilen
+- `functions.php` — 10.209 Zeilen
 - `app-shell.html` — 4.122 Zeilen
 
 ## Verwandt

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -9,7 +9,7 @@ tags: [layer/L5, domain/evolution, share/internal]
 
 > Ziel: Die beste und funktionalste Eventplattform für jedermann
 
-## Stand heute (2026-08-14)
+## Stand heute (2026-08-15)
 
 Diese Zahlen gelten JETZT. Weiter unten stehen abgeschlossene Sprints mit den
 Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
@@ -36,15 +36,16 @@ einen alten Abschnitt gelesen und nicht diesen.
 
 - [x] **KI-Transparenz fuer Inserate:** Beim Veröffentlichen sind Text und
   Medien getrennt und ohne Vorbelegung als ohne generative KI, wesentlich
-  KI-unterstützt oder KI-generiert zu deklarieren. KI-Medien tragen auf allen
-  Inseratflächen ein sichtbares Wasserzeichen; neue lokale Uploads bekommen
-  die Kennzeichnung zusätzlich in die Bildpixel. API und Markup führen den
-  Status maschinenlesbar. Altinhalte werden nicht zu „menschlich" umgedeutet,
-  sondern bleiben sichtbar „KI-Status offen", bis der Anbieter nachdeklariert.
+  KI-unterstützt oder KI-generiert zu deklarieren. Die Oberfläche zeigt dafür
+  nur eine kleine Textzeile „KI-generierter Inhalt" bei den Inseratdaten;
+  Bilder und Bilddateien bleiben frei von Wasserzeichen. API und Markup führen
+  den getrennten Status weiterhin maschinenlesbar. Der bestätigte Live-Bestand
+  ist nachdeklariert: DJ Julian und Sandros Inserate sind ohne KI, die übrigen
+  aktuellen Inserate sowie die redaktionellen Demo-Inserate KI-generiert.
   Direkt am Inserat nimmt ein begründeter DSA-Meldeweg falsche Kennzeichnung
   und Irreführung entgegen, speichert vor E-Mail-Versand, vergibt eine
   Vorgangsnummer und löscht Meldedaten nach drei Jahren (außer Legal Hold).
-  Community-, Upload-, DSA- und Datenschutzhinweise sind auf Stand 14.08.2026.
+  Die Upload-Richtlinie bildet die dezente Darstellung auf Stand 15.08.2026 ab.
   Absicherung: 10 neue KI-Transparenztests, Gesamtsuite 303/303 grün.
 - [x] **Die Belegschaft läuft wieder — und ihr Ausfall ist jetzt sichtbar.**
   Zwischen dem 07. und 11.08. sind **elf Läufe hintereinander fehlgeschlagen**
@@ -486,7 +487,7 @@ YouTube-Transkripte (das Tor steht, es fehlt nur der Abholer).
   - [x] `Paket` (Mehrfachpositionen mit je eigener Zeit/Preis/Notiz)
 
 ---
-*Zuletzt aktualisiert: 2026-07-16*
+*Zuletzt aktualisiert: 2026-08-15*
 
 ## Verknüpfte Notizen
 - [[50-Evolution/Roadmap/Feature-Ideen]] — Ideen-Sammlung


### PR DESCRIPTION
## Was geändert wurde

- große KI-Badges und alle Bild-/Pixel-Wasserzeichen entfernt
- eine einzelne, dezente Textzeile „KI-generierter Inhalt“ bei den Inseratdaten ergänzt
- DJ Julian sowie Sandros Inserate 5 und 8 als nicht KI-generiert nachdeklariert
- die übrigen aktuellen Live-Inserate und alle redaktionellen Demo-Inserate als KI-generiert nachdeklariert
- Pflichtauswahl sowie maschinenlesbare Text-/Medienstatus beibehalten
- Upload-Richtlinie, Roadmap und Regressionstests an die dezente Darstellung angepasst

## Warum

Die bisherige doppelte Kennzeichnung lag direkt auf den Bildern, dominierte die Karten und beeinträchtigte die Optik. Die Transparenz soll sichtbar bleiben, ohne das Inserat visuell zu überladen oder hochgeladene Bilddateien zu verändern.

## Auswirkungen

KI-generierte Inserate tragen außerhalb des Bildes eine kleine Textzeile. Menschlich erstellte Inserate zeigen keinen KI-Hinweis. Neue Uploads werden nicht mehr mit einem eingebrannten Wasserzeichen verändert.

## Prüfungen

- 303/303 Playwright-Tests
- Projekt-Gate vollständig grün
- PHP- und JavaScript-Syntaxcheck
- Build-Drift- und Diff-Check
