### PR TITLE
Der Auto-Merge kennt die Datei, die der Autopilot mitliefert

### DIFF
--- a/.github/workflows/openrouter-auto-merge.yml
+++ b/.github/workflows/openrouter-auto-merge.yml
@@ -93,7 +93,23 @@ jobs:
               core.setFailed(`Rahmen nicht geladen (${safeSources.size} Dateien) — kein Merge.`);
               return;
             }
-            const generated = new Set(['app.js']);
+            // Erzeugte Dateien: nicht vom Modell geschrieben, sondern von
+            // einem Skript aus geprueften Quellen abgeleitet.
+            //
+            // `assets/eb-auftragsstrom.json` kam am 14.08. dazu und hat den
+            // Autopiloten seitdem lahmgelegt: `create-pull-request` committet
+            // alles, was gegen `base` abweicht, und der Auto-Merge kannte die
+            // Datei nicht. Ergebnis war fuenfmal derselbe Abbruch am selben
+            // PR — "nicht freigegeben: assets/eb-auftragsstrom.json" — und ein
+            // gruener PR, der tagelang offen lag. Die Autonomie hielt einen
+            // Schritt vor dem Ziel an, und der Grund stand nur in einem
+            // Kommentar auf dem PR.
+            //
+            // Ein Modell kann diese Datei nicht faelschen: sie faellt nicht
+            // unter die Dateien, die ein Patch anfassen darf, und
+            // `auftragsstrom.mjs --check` prueft im PR-Check Herkunft und
+            // Rahmen jedes Eintrags.
+            const generated = new Set(['app.js', 'assets/eb-auftragsstrom.json']);
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number, per_page: 100,
             });

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-15T18:13:54.064Z",
+  "erzeugt": "2026-08-15T18:31:24.257Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -404,6 +404,34 @@ test.describe('OpenRouter-Autopilot', () => {
     expect(wirksam).toMatch(/safeSources\.size\s*<\s*\d+[\s\S]{0,200}setFailed/);
   });
 
+  test('der Auto-Merge kennt jede Datei, die der Autopilot zwangsläufig mitliefert', () => {
+    // Fünfmal zwischen dem 14. und 15.08. brach der Auto-Merge an derselben
+    // Stelle ab: „nicht freigegeben: assets/eb-auftragsstrom.json". Der PR war
+    // grün und lag trotzdem tagelang offen — die Autonomie hielt einen Schritt
+    // vor dem Ziel an, und der Grund stand nur in einem PR-Kommentar.
+    //
+    // Ursache: `create-pull-request` committet alles, was gegen `base`
+    // abweicht. Jede erzeugte Datei, die dabei mitkommt, MUSS der Auto-Merge
+    // kennen — sonst weist er den eigenen, regelkonformen PR ab.
+    const wirksam = merge.split('\n').filter((z) => !/^\s*#/.test(z)).join('\n');
+    const gen = wirksam.match(/const generated = new Set\(\[([^\]]*)\]\)/);
+    expect(gen, 'die Liste erzeugter Dateien muss auffindbar sein').not.toBeNull();
+    const erzeugt = new Set([...gen[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+
+    for (const pflicht of ['app.js', 'assets/eb-auftragsstrom.json']) {
+      expect([...erzeugt], `${pflicht} wird bei jedem Lauf neu geschrieben`).toContain(pflicht);
+    }
+
+    // Aber erzeugte Dateien allein reichen nie: ein PR ohne freigegebene
+    // Quelldatei ist kein Autopilot-Ergebnis, sondern nur ein Artefakt.
+    expect(wirksam).toMatch(/!sourceFiles\.length/);
+
+    // Und der Autopilot darf nicht deshalb ins Größenlimit laufen, weil eine
+    // erzeugte Datei unbemerkt wächst. app.js ist mit ~26 600 Zeilen schon
+    // groß; das Limit zählt nur den Diff, nicht die Datei.
+    expect(wirksam).toMatch(/additions \+ f\.deletions/);
+  });
+
   test('Autopilot veröffentlicht echten Codeflow mit Ziel, Dateien und Lieferstatus', () => {
     expect(CODEFLOW.version).toBe(1);
     expect(CODEFLOW.mitarbeiter).toHaveLength(4);


### PR DESCRIPTION
## Das ist die Antwort auf „es tut sich nichts auf Eventbörse.de"

Fünfmal zwischen dem 14. und 15.08. brach der Auto-Merge an derselben Stelle ab:

> ⛔ **Auto-Merge gestoppt:** nicht freigegeben: `assets/eb-auftragsstrom.json`.

PR #156 („Barrierefreiheit: konsistente ARIA-Labels") war seit dem **14.08.** vollständig grün — `E2E-Testsuite`, `Lint & Pattern-Scan`, `PR-Validierung` — und lag trotzdem offen.

Der Autopilot hat also gearbeitet, alle Tore bestanden, einen PR erzeugt. Und der letzte Schritt hat ihn abgewiesen. Der Grund stand nur in einem Kommentar auf dem PR, den niemand liest.

## Ursache — meine eigene Änderung

`peter-evans/create-pull-request` committet **alles**, was gegen `base` abweicht; ein `add-paths` gibt es nicht. Seit der Auftragsstrom-Arbeit landet `assets/eb-auftragsstrom.json` damit in jedem Autopilot-PR.

Die Liste erzeugter Dateien im Auto-Merge kannte aber nur `app.js`:

```js
const generated = new Set(['app.js']);
```

Alles andere fällt in `forbidden` → Abbruch, Kommentar, Label `openrouter-autonomous` entfernt, Lauf rot.

## Warum das sicher ist

Eine erzeugte Datei ist keine Modellarbeit:

- Sie steht **nicht** in `scripts/lib/sichere-dateien.mjs` — ein Patch darf sie nicht anfassen.
- `auftragsstrom.mjs --check` prüft im PR-Check **Herkunft und Rahmen jedes Eintrags**.
- Der Auto-Merge verlangt weiter **mindestens eine freigegebene Quelldatei** (`!sourceFiles.length` → Abbruch). Ein PR aus lauter Artefakten ist kein Autopilot-Ergebnis.
- Das Größenlimit von 700 Zeilen zählt weiter alle Dateien zusammen — die JSON hat 33.

## Geprüft

Mutation: nimmt man `assets/eb-auftragsstrom.json` wieder aus der Liste, fällt es dem neuen Test auf.

**334 Tests in 18 Suiten.** Die vier Radar-Tests brauchen Leaflet von `unpkg.com`, das der Proxy dieser Umgebung sperrt (403) — in CI laufen sie durch.

---

Beim nächsten Autopilot-Lauf schließt sich die Schleife damit zum ersten Mal von selbst. **#156 bleibt davon unberührt** — der Auto-Merge reagiert nur auf einen frischen Autopilot-Lauf, nicht rückwirkend. Ob dieser eine PR von Hand gemerged werden soll, ist deine Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_