### PR TITLE
Bild-Upload: 15 MB, Auto-Verkleinerung und verlässliches Drag & Drop

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -108,3 +108,28 @@ DirectoryIndex index.php index.html
 
 # Custom Error Page
 ErrorDocument 404 /index.html
+
+# ── Upload-Limit: 15 MB pro Bild ────────────────────────────────────────
+# Reicht PHP nicht so viel durch, bricht der Upload ab, bevor functions.php
+# ihn sieht — $_FILES ist dann leer und der Nutzer bekommt nur "Upload-Fehler".
+# post_max_size etwas größer als upload_max_filesize, weil neben der Datei
+# noch Formularfelder mitkommen.
+# ACHTUNG: Diese Datei wird ins Theme-Verzeichnis deployt
+# (/public/wp-content/themes/eventboerse/). Bei mod_php greift der Block dort
+# noch; unter FastCGI/PHP-FPM — dem IONOS-Standard — wird er ignoriert. Dann
+# muss das Limit im IONOS-PHP-Panel oder in /public/.user.ini stehen:
+#   upload_max_filesize = 16M
+#   post_max_size = 20M
+# Ist es zu klein, antwortet eb_handle_upload() mit 413 und nennt den Wert.
+<IfModule mod_php.c>
+  php_value upload_max_filesize 16M
+  php_value post_max_size 20M
+</IfModule>
+<IfModule mod_php7.c>
+  php_value upload_max_filesize 16M
+  php_value post_max_size 20M
+</IfModule>
+<IfModule mod_php8.c>
+  php_value upload_max_filesize 16M
+  php_value post_max_size 20M
+</IfModule>

--- a/app-shell.html
+++ b/app-shell.html
@@ -1806,7 +1806,7 @@
             <div class="upload-zone small" id="galleryUploadZone" onclick="document.getElementById('galleryInput').click()">
               <span class="material-icons-round">add_photo_alternate</span>
               <p>Galerie-Bilder hochladen</p>
-              <p class="upload-hint">JPG, PNG · Max. 12 Bilder · Max. 5MB pro Bild</p>
+              <p class="upload-hint">JPG, PNG, WebP, GIF · Max. 12 Bilder · Max. 15 MB pro Bild</p>
               <input type="file" id="galleryInput" multiple accept="image/*" style="display:none" onchange="handleGalleryUpload(this)" />
             </div>
             <div class="upload-preview" id="galleryPreview"></div>
@@ -2376,7 +2376,7 @@
               <span class="material-icons-round">cloud_upload</span>
               <h3>Bilder hochladen</h3>
               <p>Ziehe Bilder hierher oder klicke zum Auswählen</p>
-              <p class="upload-hint">JPG, PNG · Max. 10 Bilder · Max. 5MB pro Bild</p>
+              <p class="upload-hint">JPG, PNG, WebP, GIF · Max. 10 Bilder · Max. 15 MB pro Bild<br><span class="upload-hint-soft">Größere Bilder werden automatisch verkleinert.</span></p>
               <input type="file" id="fileInput" multiple accept="image/*" style="display:none" onchange="handleUpload(this)" />
             </div>
             <div class="upload-preview" id="uploadPreview"></div>
@@ -2817,7 +2817,7 @@ Datum: ___________________________________________________
         <h2>6. Verantwortung für Inhalte</h2>
         <p>Der Hochladende bleibt für die Rechtmäßigkeit und Richtigkeit seiner Inhalte verantwortlich. Für fremde gespeicherte Inhalte gelten die Voraussetzungen des Art. 6 DSA; erhält die Plattform hinreichende Kenntnis von rechtswidrigen Inhalten, prüft sie die Meldung und sperrt oder entfernt rechtswidrige Inhalte zügig. Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
         <h2>7. Datenformate und Größenlimits</h2>
-        <ul><li>Bilder: JPG, PNG, WEBP — max. 10 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
+        <ul><li>Bilder: JPG, PNG, WEBP, GIF — max. 15 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
         <h2>8. Speicherort und Datenschutz</h2>
         <p>Speicherung auf den IONOS-Servern in Deutschland. Verarbeitung gemäß Datenschutzerklärung. Bei Löschung des Accounts werden Inhalte gemäß Löschkonzept entfernt.</p>
       </div>

--- a/app.js
+++ b/app.js
@@ -457,6 +457,147 @@ window._fitExploreImg = function(img) {
     img.classList.add('explore-item-img-contain');
   }
 };
+
+/* ============================================================================
+ * BILD-UPLOAD — gemeinsames Limit, klare Rückmeldung, Auto-Verkleinerung
+ *
+ * Eine Quelle der Wahrheit für alle Upload-Pfade (Inserat, Galerie, Avatar,
+ * Cover, Chat, Feed). Vorher stand "5 MB" an neun Stellen im Code und in zwei
+ * Hinweistexten — jede Änderung musste alle finden.
+ *
+ * ebPrepareImageFile(file) liefert ein Promise auf eine hochladbare Datei
+ * oder auf null, wenn die Datei abgelehnt wurde. Abgelehnt wird nur noch,
+ * was sich nicht retten lässt; zu große JPG/PNG/WebP werden im Browser
+ * heruntergerechnet, statt den Nutzer mit einer Fehlermeldung wegzuschicken.
+ * Jeder Ausgang gibt Rückmeldung — stiller Abbruch ist immer ein Bug.
+ * ========================================================================== */
+
+var EB_MAX_IMAGE_BYTES   = 15 * 1024 * 1024;   // 15 MB — Client wie Server
+var EB_MAX_IMAGE_LABEL   = '15 MB';
+var EB_IMAGE_TYPES       = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+var EB_IMAGE_TYPES_LABEL = 'JPG, PNG, WebP oder GIF';
+var EB_DOWNSCALE_EDGE    = 2560;               // längste Kante nach dem Verkleinern
+var EB_DOWNSCALE_QUALITY = 0.85;
+
+function ebFormatBytes(bytes) {
+  var n = Number(bytes) || 0;
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1).replace('.', ',') + ' MB';
+  if (n >= 1024) return Math.round(n / 1024) + ' KB';
+  return n + ' B';
+}
+
+function _ebShortName(name) {
+  var s = String(name || 'Bild');
+  return s.length > 32 ? s.slice(0, 29) + '…' : s;
+}
+
+function _ebToast(msg, icon) {
+  if (typeof showToast === 'function') showToast(msg, icon || 'error');
+  else if (icon === 'error') console.warn(msg);
+}
+
+/**
+ * Zeichnet die Datei auf ein Canvas und gibt sie kleiner zurück.
+ * Reduziert notfalls mehrfach, bis das Limit unterschritten ist.
+ * @returns {Promise<File>}
+ */
+function _ebDownscaleImage(file) {
+  return new Promise(function(resolve, reject) {
+    var url = URL.createObjectURL(file);
+    var img = new Image();
+    img.onload = function() {
+      URL.revokeObjectURL(url);
+      var edge = EB_DOWNSCALE_EDGE;
+      var quality = EB_DOWNSCALE_QUALITY;
+
+      function attempt(round) {
+        var scale = Math.min(1, edge / Math.max(img.naturalWidth, img.naturalHeight));
+        var w = Math.max(1, Math.round(img.naturalWidth * scale));
+        var h = Math.max(1, Math.round(img.naturalHeight * scale));
+        var canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        var ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('Canvas nicht verfügbar')); return; }
+        ctx.drawImage(img, 0, 0, w, h);
+        canvas.toBlob(function(blob) {
+          if (!blob) { reject(new Error('Verkleinern fehlgeschlagen')); return; }
+          if (blob.size <= EB_MAX_IMAGE_BYTES || round >= 4) {
+            if (blob.size > EB_MAX_IMAGE_BYTES) { reject(new Error('Bild bleibt zu groß')); return; }
+            var base = String(file.name || 'bild').replace(/\.[^.]+$/, '');
+            resolve(new File([blob], base + '.jpg', { type: 'image/jpeg', lastModified: Date.now() }));
+          } else {
+            // Noch zu groß: Kante und Qualität weiter zurücknehmen.
+            edge = Math.round(edge * 0.75);
+            quality = Math.max(0.6, quality - 0.08);
+            attempt(round + 1);
+          }
+        }, 'image/jpeg', quality);
+      }
+      attempt(0);
+    };
+    img.onerror = function() {
+      URL.revokeObjectURL(url);
+      reject(new Error('Bild nicht lesbar'));
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Prüft Typ und Größe einer Datei und macht sie hochladbar.
+ * Gibt in jedem Fall Rückmeldung an den Nutzer.
+ * @param {File} file
+ * @param {{quiet?: boolean}} [opts] quiet unterdrückt nur den Erfolgs-Hinweis
+ * @returns {Promise<File|null>} null = abgelehnt, Grund wurde bereits angezeigt
+ */
+function ebPrepareImageFile(file, opts) {
+  opts = opts || {};
+  var name = _ebShortName(file && file.name);
+
+  if (!file) {
+    _ebToast('Keine Datei erkannt. Bitte erneut versuchen.', 'error');
+    return Promise.resolve(null);
+  }
+  if (EB_IMAGE_TYPES.indexOf(file.type) === -1) {
+    _ebToast(name + ': nicht unterstützt. Erlaubt sind ' + EB_IMAGE_TYPES_LABEL + '.', 'error');
+    return Promise.resolve(null);
+  }
+  if (file.size <= EB_MAX_IMAGE_BYTES) {
+    return Promise.resolve(file);
+  }
+  // GIFs würden beim Umzeichnen ihre Animation verlieren — lieber ehrlich ablehnen.
+  if (file.type === 'image/gif') {
+    _ebToast(name + ' ist ' + ebFormatBytes(file.size) + ' groß — max. ' + EB_MAX_IMAGE_LABEL + ' für GIFs.', 'error');
+    return Promise.resolve(null);
+  }
+
+  _ebToast('Bild wird verkleinert…', 'image');
+  var originalSize = file.size;
+  return _ebDownscaleImage(file).then(function(smaller) {
+    if (!opts.quiet) {
+      _ebToast('Bild automatisch verkleinert: ' + ebFormatBytes(originalSize) + ' → ' + ebFormatBytes(smaller.size), 'check_circle');
+    }
+    return smaller;
+  }).catch(function() {
+    _ebToast(name + ' ist ' + ebFormatBytes(originalSize) + ' groß und ließ sich nicht verkleinern (max. ' + EB_MAX_IMAGE_LABEL + ').', 'error');
+    return null;
+  });
+}
+
+/**
+ * Mehrere Dateien nacheinander prüfen/verkleinern (nacheinander, damit ein
+ * 20-MB-Stapel den Hauptthread nicht blockiert).
+ * @returns {Promise<File[]>} nur die Dateien, die durchgekommen sind
+ */
+function ebPrepareImageFiles(files, opts) {
+  var list = Array.prototype.slice.call(files || []);
+  var out = [];
+  return list.reduce(function(chain, f) {
+    return chain.then(function() {
+      return ebPrepareImageFile(f, opts).then(function(ok) { if (ok) out.push(ok); });
+    });
+  }, Promise.resolve()).then(function() { return out; });
+}
 // ========== DEMO DATA ==========
 const LISTINGS = [
   {
@@ -5273,22 +5414,24 @@ function _exitProviderEdit() {
 
 function _provEditAvatar(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild zu groß! Max. 5MB', 'error'); input.value = ''; return; }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    var img = new Image();
-    img.onload = function() {
-      _cropImg = img;
-      _cropX = 0; _cropY = 0;
-      document.getElementById('cropZoom').value = 1;
-      openModal('avatarCropModal');
-      setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
-    };
-    img.src = e.target.result;
-  };
-  reader.readAsDataURL(file);
+  var raw = input.files[0];
   input.value = '';
+  ebPrepareImageFile(raw).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = new Image();
+      img.onload = function() {
+        _cropImg = img;
+        _cropX = 0; _cropY = 0;
+        document.getElementById('cropZoom').value = 1;
+        openModal('avatarCropModal');
+        setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function _provSaveName() {
@@ -7637,7 +7780,13 @@ function _sendChatImage(input) {
   var file = input && input.files && input.files[0];
   if (input) input.value = '';
   if (!file || !currentChat || !currentChat.id) return;
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild zu groß! Max. 5 MB', 'error'); return; }
+  ebPrepareImageFile(file, { quiet: true }).then(function(ready) {
+    if (!ready) return;   // Grund wurde bereits als Toast gezeigt
+    _sendChatImageFile(ready);
+  });
+}
+
+function _sendChatImageFile(file) {
   showToast('Bild wird gesendet…', 'image');
   uploadFile(file).then(function(r) {
     var url = r && r.url;
@@ -9568,26 +9717,32 @@ async function submitListing(e) {
 
 function handleUpload(input) {
   const preview = document.getElementById('uploadPreview');
-  const files = input.files;
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-  const maxSize = 5 * 1024 * 1024; // 5 MB
   const maxImages = 10;
   const existing = preview.querySelectorAll('.upload-preview-item').length;
 
-  let queue = [];
-  for (let file of files) {
-    if (!allowedTypes.includes(file.type)) { showToast('Nur JPG, PNG, WebP oder GIF erlaubt', 'error'); continue; }
-    if (file.size > maxSize) { showToast('Bild zu groß! Max. 5 MB', 'error'); continue; }
-    if (existing + queue.length >= maxImages) { showToast('Max. ' + maxImages + ' Bilder erlaubt', 'warning'); break; }
-    queue.push(file);
-  }
+  // Erst nach Platz filtern, dann prüfen/verkleinern — sonst rechnen wir
+  // Bilder klein, die ohnehin nicht mehr hineinpassen.
+  const dropped = Array.prototype.slice.call(input.files || []);
   input.value = '';
+  if (!dropped.length) return;
 
-  // Open crop modal for each image sequentially
-  _lcropMode = 'listing';
-  _lcropQueue = queue;
-  _lcropQueueIdx = 0;
-  if (queue.length > 0) _lcropProcessNext();
+  const free = Math.max(0, maxImages - existing);
+  if (free === 0) {
+    showToast('Max. ' + maxImages + ' Bilder erlaubt — bitte erst eines entfernen.', 'warning');
+    return;
+  }
+  if (dropped.length > free) {
+    showToast('Nur noch Platz für ' + free + ' Bild' + (free > 1 ? 'er' : '') + ' — der Rest wurde übersprungen.', 'warning');
+  }
+
+  ebPrepareImageFiles(dropped.slice(0, free)).then(function(queue) {
+    if (!queue.length) return;   // Grund wurde bereits als Toast gezeigt
+    // Open crop modal for each image sequentially
+    _lcropMode = 'listing';
+    _lcropQueue = queue;
+    _lcropQueueIdx = 0;
+    _lcropProcessNext();
+  });
 }
 
 // ---- Listing Crop State ----
@@ -9971,25 +10126,23 @@ var _cropX = 0, _cropY = 0, _cropDragStart = null;
 function handleProfilePhoto(input) {
   if (!input.files || !input.files[0]) return;
   var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) {
-    showToast('Bild zu groß! Max. 5MB', 'error');
-    input.value = '';
-    return;
-  }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    var img = new Image();
-    img.onload = function() {
-      _cropImg = img;
-      _cropX = 0; _cropY = 0;
-      document.getElementById('cropZoom').value = 1;
-      openModal('avatarCropModal');
-      setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
-    };
-    img.src = e.target.result;
-  };
-  reader.readAsDataURL(file);
   input.value = '';
+  ebPrepareImageFile(file).then(function(ready) {
+    if (!ready) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = new Image();
+      img.onload = function() {
+        _cropImg = img;
+        _cropX = 0; _cropY = 0;
+        document.getElementById('cropZoom').value = 1;
+        openModal('avatarCropModal');
+        setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(ready);
+  });
 }
 
 function cropDraw() {
@@ -10125,11 +10278,15 @@ function cropConfirm() {
 
 function handleCoverUpload(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) {
-    showToast('Bild zu groß! Max. 5MB', 'error');
-    return;
-  }
+  var rawCover = input.files[0];
+  input.value = '';
+  ebPrepareImageFile(rawCover).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    _applyCoverUpload(file);
+  });
+}
+
+function _applyCoverUpload(file) {
   // Show preview immediately
   var reader = new FileReader();
   reader.onload = function(e) {
@@ -10258,22 +10415,18 @@ function handleGalleryUpload(input) {
     return;
   }
 
-  var queue = [];
-  for (var i = 0; i < files.length; i++) {
-    var file = files[i];
-    if (file.size > 5 * 1024 * 1024) {
-      showToast(file.name + ' ist zu groß (max. 5MB)', 'error');
-      continue;
-    }
-    queue.push(file);
-  }
+  var dropped = Array.prototype.slice.call(files || []);
   input.value = '';
+  if (!dropped.length) return;
 
-  // Open crop modal for each image sequentially
-  _lcropMode = 'gallery';
-  _lcropQueue = queue;
-  _lcropQueueIdx = 0;
-  if (queue.length > 0) _lcropProcessNext();
+  ebPrepareImageFiles(dropped).then(function(queue) {
+    if (!queue.length) return;   // Grund wurde bereits als Toast gezeigt
+    // Open crop modal for each image sequentially
+    _lcropMode = 'gallery';
+    _lcropQueue = queue;
+    _lcropQueueIdx = 0;
+    _lcropProcessNext();
+  });
 }
 
 function _addGalleryPreviewItem(src, blob) {
@@ -10344,27 +10497,107 @@ function updateGalleryCount() {
   }
 }
 
-// Drag & Drop support
+// ======== DRAG & DROP für alle Upload-Zonen ========
+//
+// Drei Dinge, die vorher fehlten:
+//  1. dragleave feuert auch beim Wechsel auf ein Kind-Element — die Zone
+//     flackerte. Ein Zähler pro Zone hält den Hover-Zustand stabil.
+//  2. Ein Drop neben die Zone ließ den Browser das Bild als Seite öffnen und
+//     das halb ausgefüllte Formular verwerfen. Wird jetzt global abgefangen.
+//  3. Zonen, die erst später ins DOM kommen, waren nie gebunden. Idempotente
+//     Bindung + erneuter Aufruf sind jetzt gefahrlos.
 function setupDragDrop() {
-  var zones = document.querySelectorAll('.upload-zone');
-  zones.forEach(function(zone) {
-    zone.addEventListener('dragover', function(e) {
-      e.preventDefault();
-      zone.classList.add('dragover');
-    });
-    zone.addEventListener('dragleave', function(e) {
-      e.preventDefault();
-      zone.classList.remove('dragover');
-    });
-    zone.addEventListener('drop', function(e) {
-      e.preventDefault();
-      zone.classList.remove('dragover');
-      var fileInput = zone.querySelector('input[type="file"]');
-      if (fileInput && e.dataTransfer.files.length > 0) {
-        fileInput.files = e.dataTransfer.files;
-        fileInput.dispatchEvent(new Event('change'));
+  document.querySelectorAll('.upload-zone').forEach(_ebBindDropZone);
+  _ebBlockStrayDrops();
+}
+
+function _ebBindDropZone(zone) {
+  if (!zone || zone._ebDropBound) return;
+  zone._ebDropBound = true;
+  var depth = 0;
+
+  function hasFiles(e) {
+    var dt = e.dataTransfer;
+    if (!dt) return false;
+    if (dt.types && dt.types.length) return Array.prototype.indexOf.call(dt.types, 'Files') !== -1;
+    return true;
+  }
+  function leave() { depth = 0; zone.classList.remove('dragover'); }
+
+  zone.addEventListener('dragenter', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    depth++;
+    zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragover', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    try { e.dataTransfer.dropEffect = 'copy'; } catch (_) {}
+    zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragleave', function(e) {
+    if (!hasFiles(e)) return;
+    depth = Math.max(0, depth - 1);
+    if (depth === 0) zone.classList.remove('dragover');
+  });
+  zone.addEventListener('drop', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    leave();
+
+    var fileInput = zone.querySelector('input[type="file"]');
+    var files = e.dataTransfer && e.dataTransfer.files;
+    if (!fileInput) return;
+    if (!files || !files.length) {
+      showToast('Da kam keine Datei an. Bitte aus dem Dateimanager ziehen.', 'error');
+      return;
+    }
+    // Direkte Zuweisung schlägt in manchen Browsern still fehl — dann
+    // bekäme der Nutzer gar keine Rückmeldung. Deshalb prüfen und notfalls
+    // den Handler direkt mit einem Stellvertreter-Input aufrufen.
+    var assigned = false;
+    try {
+      fileInput.files = files;
+      assigned = fileInput.files && fileInput.files.length > 0;
+    } catch (_) { assigned = false; }
+
+    if (assigned) {
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    } else {
+      var handler = fileInput.getAttribute('onchange') || '';
+      var fnName = (handler.match(/^\s*([A-Za-z_$][\w$]*)\s*\(/) || [])[1];
+      var fn = fnName && window[fnName];
+      if (typeof fn === 'function') {
+        fn({ files: files, value: '' });
+      } else {
+        showToast('Ablegen hat nicht geklappt — bitte auf die Fläche klicken und das Bild auswählen.', 'error');
       }
-    });
+    }
+  });
+}
+
+// Drop irgendwo sonst im Fenster: verhindern, dass der Browser wegnavigiert
+// und dabei ein halb ausgefülltes Formular verwirft.
+function _ebBlockStrayDrops() {
+  if (window._ebStrayDropsBlocked) return;
+  window._ebStrayDropsBlocked = true;
+  ['dragover', 'drop'].forEach(function(type) {
+    window.addEventListener(type, function(e) {
+      var dt = e.dataTransfer;
+      var isFileDrag = dt && dt.types && Array.prototype.indexOf.call(dt.types, 'Files') !== -1;
+      if (!isFileDrag) return;
+      if (e.target && e.target.closest && e.target.closest('.upload-zone')) return;
+      e.preventDefault();
+      if (type === 'drop') {
+        var zone = document.querySelector('.upload-zone');
+        var visible = zone && zone.offsetParent !== null;
+        showToast(visible
+          ? 'Bitte direkt auf das Upload-Feld ziehen.'
+          : 'Hier lassen sich keine Bilder ablegen.', 'error');
+      }
+    }, false);
   });
 }
 
@@ -23971,18 +24204,20 @@ var _postImageData = null;
 
 function _handlePostImage(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild max. 5 MB', 'error'); return; }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    _postImageData = e.target.result;
-    var preview = document.getElementById('postImgPreview');
-    var upload = document.getElementById('postImgUpload');
-    document.getElementById('postImgThumb').src = _postImageData;
-    if (preview) preview.style.display = '';
-    if (upload) upload.style.display = 'none';
-  };
-  reader.readAsDataURL(file);
+  var raw = input.files[0];
+  ebPrepareImageFile(raw).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      _postImageData = e.target.result;
+      var preview = document.getElementById('postImgPreview');
+      var upload = document.getElementById('postImgUpload');
+      document.getElementById('postImgThumb').src = _postImageData;
+      if (preview) preview.style.display = '';
+      if (upload) upload.style.display = 'none';
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function _removePostImage() {

--- a/functions.php
+++ b/functions.php
@@ -4518,11 +4518,75 @@ function eb_test_mail( WP_REST_Request $request ) {
 }
 
 /* =====================================================================
+   UPLOAD-LIMIT — eine Quelle der Wahrheit
+
+   Muss mit EB_MAX_IMAGE_BYTES im Frontend (js/modules/core/00-basis.js)
+   übereinstimmen. Das Frontend rechnet größere Bilder vorher herunter;
+   dieser Wert ist die Grenze, die der Server wirklich durchsetzt.
+
+   Achtung Hosting: PHP muss mitspielen. Sind upload_max_filesize oder
+   post_max_size kleiner, bricht der Upload ab, bevor PHP diesen Code
+   überhaupt sieht ($_FILES ist dann leer). Siehe .htaccess.
+   ===================================================================== */
+if ( ! defined( 'EB_MAX_IMAGE_BYTES' ) ) {
+    define( 'EB_MAX_IMAGE_BYTES', 15 * 1024 * 1024 ); // 15 MB
+}
+if ( ! defined( 'EB_MAX_IMAGE_LABEL' ) ) {
+    define( 'EB_MAX_IMAGE_LABEL', '15 MB' );
+}
+
+/**
+ * "16M" / "20K" / "1G" aus der php.ini in Bytes umrechnen.
+ */
+function eb_ini_bytes( $value ) {
+    $value = trim( (string) $value );
+    if ( $value === '' ) {
+        return 0;
+    }
+    $unit   = strtolower( substr( $value, -1 ) );
+    $number = (int) $value;
+    switch ( $unit ) {
+        case 'g': return $number * 1024 * 1024 * 1024;
+        case 'm': return $number * 1024 * 1024;
+        case 'k': return $number * 1024;
+    }
+    return $number;
+}
+
+/**
+ * Kleinstes tatsächlich wirksames Upload-Limit: unser eigenes gegen das,
+ * was PHP durchlässt. Nützlich für Diagnose und Fehlertexte.
+ */
+function eb_effective_upload_limit() {
+    $candidates = array_filter( array(
+        EB_MAX_IMAGE_BYTES,
+        eb_ini_bytes( ini_get( 'upload_max_filesize' ) ),
+        eb_ini_bytes( ini_get( 'post_max_size' ) ),
+    ) );
+    return $candidates ? min( $candidates ) : EB_MAX_IMAGE_BYTES;
+}
+
+/* =====================================================================
    UPLOAD HANDLER
    ===================================================================== */
 function eb_handle_upload( WP_REST_Request $request ) {
     $files = $request->get_file_params();
     if ( empty( $files['file'] ) ) {
+        // Überschreitet der Request post_max_size, verwirft PHP den ganzen Body,
+        // bevor dieser Code läuft: $_FILES und $_POST sind leer, Content-Length
+        // aber gesetzt. Ohne diesen Zweig sähe der Nutzer nur "Keine Datei
+        // hochgeladen" und wüsste nicht, dass das Hosting-Limit zu klein ist.
+        $content_length = isset( $_SERVER['CONTENT_LENGTH'] ) ? (int) $_SERVER['CONTENT_LENGTH'] : 0;
+        if ( $content_length > 0 && empty( $_POST ) ) {
+            $post_max = eb_ini_bytes( ini_get( 'post_max_size' ) );
+            return new WP_REST_Response( array(
+                'message' => sprintf(
+                    'Bild zu groß für den Server (%s). Aktuell nimmt das Hosting nur %s pro Anfrage an.',
+                    size_format( $content_length ),
+                    $post_max ? size_format( $post_max ) : ini_get( 'post_max_size' )
+                ),
+            ), 413 );
+        }
         return new WP_REST_Response( array( 'message' => 'Keine Datei hochgeladen.' ), 400 );
     }
 
@@ -4533,9 +4597,12 @@ function eb_handle_upload( WP_REST_Request $request ) {
         return new WP_REST_Response( array( 'message' => 'Upload-Fehler. Bitte erneut versuchen.' ), 400 );
     }
 
-    // 2) Größenlimit (5 MB) – früh prüfen, bevor wir Datei lesen.
-    if ( empty( $file['size'] ) || $file['size'] > 5 * 1024 * 1024 ) {
-        return new WP_REST_Response( array( 'message' => 'Datei zu groß. Max. 5MB.' ), 400 );
+    // 2) Größenlimit – früh prüfen, bevor wir Datei lesen.
+    //    Muss mit EB_MAX_IMAGE_BYTES im Frontend übereinstimmen (js/modules/core/00-basis.js).
+    if ( empty( $file['size'] ) || $file['size'] > EB_MAX_IMAGE_BYTES ) {
+        return new WP_REST_Response( array(
+            'message' => sprintf( 'Datei zu groß (%s). Max. %s.', size_format( (int) $file['size'] ), EB_MAX_IMAGE_LABEL ),
+        ), 400 );
     }
 
     // 3) Tatsächlichen MIME-Type aus den Magic-Bytes der Datei lesen,
@@ -6259,7 +6326,7 @@ function eb_provider_profile( WP_REST_Request $request ) {
    ALLOW BIGGER UPLOADS
    ===================================================================== */
 add_filter( 'upload_size_limit', function() {
-    return 5 * 1024 * 1024; // 5 MB
+    return EB_MAX_IMAGE_BYTES;
 } );
 
 /* =====================================================================

--- a/index.html
+++ b/index.html
@@ -1867,7 +1867,7 @@
             <div class="upload-zone small" id="galleryUploadZone" onclick="document.getElementById('galleryInput').click()">
               <span class="material-icons-round">add_photo_alternate</span>
               <p>Galerie-Bilder hochladen</p>
-              <p class="upload-hint">JPG, PNG · Max. 12 Bilder · Max. 5MB pro Bild</p>
+              <p class="upload-hint">JPG, PNG, WebP, GIF · Max. 12 Bilder · Max. 15 MB pro Bild</p>
               <input type="file" id="galleryInput" multiple accept="image/*" style="display:none" onchange="handleGalleryUpload(this)" />
             </div>
             <div class="upload-preview" id="galleryPreview"></div>
@@ -2437,7 +2437,7 @@
               <span class="material-icons-round">cloud_upload</span>
               <h3>Bilder hochladen</h3>
               <p>Ziehe Bilder hierher oder klicke zum Auswählen</p>
-              <p class="upload-hint">JPG, PNG · Max. 10 Bilder · Max. 5MB pro Bild</p>
+              <p class="upload-hint">JPG, PNG, WebP, GIF · Max. 10 Bilder · Max. 15 MB pro Bild<br><span class="upload-hint-soft">Größere Bilder werden automatisch verkleinert.</span></p>
               <input type="file" id="fileInput" multiple accept="image/*" style="display:none" onchange="handleUpload(this)" />
             </div>
             <div class="upload-preview" id="uploadPreview"></div>
@@ -2878,7 +2878,7 @@ Datum: ___________________________________________________
         <h2>6. Verantwortung für Inhalte</h2>
         <p>Der Hochladende bleibt für die Rechtmäßigkeit und Richtigkeit seiner Inhalte verantwortlich. Für fremde gespeicherte Inhalte gelten die Voraussetzungen des Art. 6 DSA; erhält die Plattform hinreichende Kenntnis von rechtswidrigen Inhalten, prüft sie die Meldung und sperrt oder entfernt rechtswidrige Inhalte zügig. Der Hochladende stellt die Plattform von Ansprüchen Dritter frei, soweit er die Rechtsverletzung zu vertreten hat.</p>
         <h2>7. Datenformate und Größenlimits</h2>
-        <ul><li>Bilder: JPG, PNG, WEBP — max. 10 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
+        <ul><li>Bilder: JPG, PNG, WEBP, GIF — max. 15 MB pro Datei.</li><li>Videos: MP4, WEBM — max. 50 MB pro Datei.</li><li>Audio: MP3, OGG — max. 25 MB pro Datei.</li><li>Dokumente: PDF — max. 5 MB pro Datei.</li></ul>
         <h2>8. Speicherort und Datenschutz</h2>
         <p>Speicherung auf den IONOS-Servern in Deutschland. Verarbeitung gemäß Datenschutzerklärung. Bei Löschung des Accounts werden Inhalte gemäß Löschkonzept entfernt.</p>
       </div>

--- a/js/modules/board/42-guide-social-feed.js
+++ b/js/modules/board/42-guide-social-feed.js
@@ -2016,18 +2016,20 @@ var _postImageData = null;
 
 function _handlePostImage(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild max. 5 MB', 'error'); return; }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    _postImageData = e.target.result;
-    var preview = document.getElementById('postImgPreview');
-    var upload = document.getElementById('postImgUpload');
-    document.getElementById('postImgThumb').src = _postImageData;
-    if (preview) preview.style.display = '';
-    if (upload) upload.style.display = 'none';
-  };
-  reader.readAsDataURL(file);
+  var raw = input.files[0];
+  ebPrepareImageFile(raw).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      _postImageData = e.target.result;
+      var preview = document.getElementById('postImgPreview');
+      var upload = document.getElementById('postImgUpload');
+      document.getElementById('postImgThumb').src = _postImageData;
+      if (preview) preview.style.display = '';
+      if (upload) upload.style.display = 'none';
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function _removePostImage() {

--- a/js/modules/chat/20-chat-nachrichten.js
+++ b/js/modules/chat/20-chat-nachrichten.js
@@ -900,7 +900,13 @@ function _sendChatImage(input) {
   var file = input && input.files && input.files[0];
   if (input) input.value = '';
   if (!file || !currentChat || !currentChat.id) return;
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild zu groß! Max. 5 MB', 'error'); return; }
+  ebPrepareImageFile(file, { quiet: true }).then(function(ready) {
+    if (!ready) return;   // Grund wurde bereits als Toast gezeigt
+    _sendChatImageFile(ready);
+  });
+}
+
+function _sendChatImageFile(file) {
   showToast('Bild wird gesendet…', 'image');
   uploadFile(file).then(function(r) {
     var url = r && r.url;

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -457,3 +457,144 @@ window._fitExploreImg = function(img) {
     img.classList.add('explore-item-img-contain');
   }
 };
+
+/* ============================================================================
+ * BILD-UPLOAD — gemeinsames Limit, klare Rückmeldung, Auto-Verkleinerung
+ *
+ * Eine Quelle der Wahrheit für alle Upload-Pfade (Inserat, Galerie, Avatar,
+ * Cover, Chat, Feed). Vorher stand "5 MB" an neun Stellen im Code und in zwei
+ * Hinweistexten — jede Änderung musste alle finden.
+ *
+ * ebPrepareImageFile(file) liefert ein Promise auf eine hochladbare Datei
+ * oder auf null, wenn die Datei abgelehnt wurde. Abgelehnt wird nur noch,
+ * was sich nicht retten lässt; zu große JPG/PNG/WebP werden im Browser
+ * heruntergerechnet, statt den Nutzer mit einer Fehlermeldung wegzuschicken.
+ * Jeder Ausgang gibt Rückmeldung — stiller Abbruch ist immer ein Bug.
+ * ========================================================================== */
+
+var EB_MAX_IMAGE_BYTES   = 15 * 1024 * 1024;   // 15 MB — Client wie Server
+var EB_MAX_IMAGE_LABEL   = '15 MB';
+var EB_IMAGE_TYPES       = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+var EB_IMAGE_TYPES_LABEL = 'JPG, PNG, WebP oder GIF';
+var EB_DOWNSCALE_EDGE    = 2560;               // längste Kante nach dem Verkleinern
+var EB_DOWNSCALE_QUALITY = 0.85;
+
+function ebFormatBytes(bytes) {
+  var n = Number(bytes) || 0;
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1).replace('.', ',') + ' MB';
+  if (n >= 1024) return Math.round(n / 1024) + ' KB';
+  return n + ' B';
+}
+
+function _ebShortName(name) {
+  var s = String(name || 'Bild');
+  return s.length > 32 ? s.slice(0, 29) + '…' : s;
+}
+
+function _ebToast(msg, icon) {
+  if (typeof showToast === 'function') showToast(msg, icon || 'error');
+  else if (icon === 'error') console.warn(msg);
+}
+
+/**
+ * Zeichnet die Datei auf ein Canvas und gibt sie kleiner zurück.
+ * Reduziert notfalls mehrfach, bis das Limit unterschritten ist.
+ * @returns {Promise<File>}
+ */
+function _ebDownscaleImage(file) {
+  return new Promise(function(resolve, reject) {
+    var url = URL.createObjectURL(file);
+    var img = new Image();
+    img.onload = function() {
+      URL.revokeObjectURL(url);
+      var edge = EB_DOWNSCALE_EDGE;
+      var quality = EB_DOWNSCALE_QUALITY;
+
+      function attempt(round) {
+        var scale = Math.min(1, edge / Math.max(img.naturalWidth, img.naturalHeight));
+        var w = Math.max(1, Math.round(img.naturalWidth * scale));
+        var h = Math.max(1, Math.round(img.naturalHeight * scale));
+        var canvas = document.createElement('canvas');
+        canvas.width = w; canvas.height = h;
+        var ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('Canvas nicht verfügbar')); return; }
+        ctx.drawImage(img, 0, 0, w, h);
+        canvas.toBlob(function(blob) {
+          if (!blob) { reject(new Error('Verkleinern fehlgeschlagen')); return; }
+          if (blob.size <= EB_MAX_IMAGE_BYTES || round >= 4) {
+            if (blob.size > EB_MAX_IMAGE_BYTES) { reject(new Error('Bild bleibt zu groß')); return; }
+            var base = String(file.name || 'bild').replace(/\.[^.]+$/, '');
+            resolve(new File([blob], base + '.jpg', { type: 'image/jpeg', lastModified: Date.now() }));
+          } else {
+            // Noch zu groß: Kante und Qualität weiter zurücknehmen.
+            edge = Math.round(edge * 0.75);
+            quality = Math.max(0.6, quality - 0.08);
+            attempt(round + 1);
+          }
+        }, 'image/jpeg', quality);
+      }
+      attempt(0);
+    };
+    img.onerror = function() {
+      URL.revokeObjectURL(url);
+      reject(new Error('Bild nicht lesbar'));
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Prüft Typ und Größe einer Datei und macht sie hochladbar.
+ * Gibt in jedem Fall Rückmeldung an den Nutzer.
+ * @param {File} file
+ * @param {{quiet?: boolean}} [opts] quiet unterdrückt nur den Erfolgs-Hinweis
+ * @returns {Promise<File|null>} null = abgelehnt, Grund wurde bereits angezeigt
+ */
+function ebPrepareImageFile(file, opts) {
+  opts = opts || {};
+  var name = _ebShortName(file && file.name);
+
+  if (!file) {
+    _ebToast('Keine Datei erkannt. Bitte erneut versuchen.', 'error');
+    return Promise.resolve(null);
+  }
+  if (EB_IMAGE_TYPES.indexOf(file.type) === -1) {
+    _ebToast(name + ': nicht unterstützt. Erlaubt sind ' + EB_IMAGE_TYPES_LABEL + '.', 'error');
+    return Promise.resolve(null);
+  }
+  if (file.size <= EB_MAX_IMAGE_BYTES) {
+    return Promise.resolve(file);
+  }
+  // GIFs würden beim Umzeichnen ihre Animation verlieren — lieber ehrlich ablehnen.
+  if (file.type === 'image/gif') {
+    _ebToast(name + ' ist ' + ebFormatBytes(file.size) + ' groß — max. ' + EB_MAX_IMAGE_LABEL + ' für GIFs.', 'error');
+    return Promise.resolve(null);
+  }
+
+  _ebToast('Bild wird verkleinert…', 'image');
+  var originalSize = file.size;
+  return _ebDownscaleImage(file).then(function(smaller) {
+    if (!opts.quiet) {
+      _ebToast('Bild automatisch verkleinert: ' + ebFormatBytes(originalSize) + ' → ' + ebFormatBytes(smaller.size), 'check_circle');
+    }
+    return smaller;
+  }).catch(function() {
+    _ebToast(name + ' ist ' + ebFormatBytes(originalSize) + ' groß und ließ sich nicht verkleinern (max. ' + EB_MAX_IMAGE_LABEL + ').', 'error');
+    return null;
+  });
+}
+
+/**
+ * Mehrere Dateien nacheinander prüfen/verkleinern (nacheinander, damit ein
+ * 20-MB-Stapel den Hauptthread nicht blockiert).
+ * @returns {Promise<File[]>} nur die Dateien, die durchgekommen sind
+ */
+function ebPrepareImageFiles(files, opts) {
+  var list = Array.prototype.slice.call(files || []);
+  var out = [];
+  return list.reduce(function(chain, f) {
+    return chain.then(function() {
+      return ebPrepareImageFile(f, opts).then(function(ok) { if (ok) out.push(ok); });
+    });
+  }, Promise.resolve()).then(function() { return out; });
+}

--- a/js/modules/search/12-detail-provider.js
+++ b/js/modules/search/12-detail-provider.js
@@ -977,22 +977,24 @@ function _exitProviderEdit() {
 
 function _provEditAvatar(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) { showToast('Bild zu groß! Max. 5MB', 'error'); input.value = ''; return; }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    var img = new Image();
-    img.onload = function() {
-      _cropImg = img;
-      _cropX = 0; _cropY = 0;
-      document.getElementById('cropZoom').value = 1;
-      openModal('avatarCropModal');
-      setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
-    };
-    img.src = e.target.result;
-  };
-  reader.readAsDataURL(file);
+  var raw = input.files[0];
   input.value = '';
+  ebPrepareImageFile(raw).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = new Image();
+      img.onload = function() {
+        _cropImg = img;
+        _cropX = 0; _cropY = 0;
+        document.getElementById('cropZoom').value = 1;
+        openModal('avatarCropModal');
+        setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function _provSaveName() {

--- a/js/modules/ui/22-inserat-settings-uploads.js
+++ b/js/modules/ui/22-inserat-settings-uploads.js
@@ -867,26 +867,32 @@ async function submitListing(e) {
 
 function handleUpload(input) {
   const preview = document.getElementById('uploadPreview');
-  const files = input.files;
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-  const maxSize = 5 * 1024 * 1024; // 5 MB
   const maxImages = 10;
   const existing = preview.querySelectorAll('.upload-preview-item').length;
 
-  let queue = [];
-  for (let file of files) {
-    if (!allowedTypes.includes(file.type)) { showToast('Nur JPG, PNG, WebP oder GIF erlaubt', 'error'); continue; }
-    if (file.size > maxSize) { showToast('Bild zu groß! Max. 5 MB', 'error'); continue; }
-    if (existing + queue.length >= maxImages) { showToast('Max. ' + maxImages + ' Bilder erlaubt', 'warning'); break; }
-    queue.push(file);
-  }
+  // Erst nach Platz filtern, dann prüfen/verkleinern — sonst rechnen wir
+  // Bilder klein, die ohnehin nicht mehr hineinpassen.
+  const dropped = Array.prototype.slice.call(input.files || []);
   input.value = '';
+  if (!dropped.length) return;
 
-  // Open crop modal for each image sequentially
-  _lcropMode = 'listing';
-  _lcropQueue = queue;
-  _lcropQueueIdx = 0;
-  if (queue.length > 0) _lcropProcessNext();
+  const free = Math.max(0, maxImages - existing);
+  if (free === 0) {
+    showToast('Max. ' + maxImages + ' Bilder erlaubt — bitte erst eines entfernen.', 'warning');
+    return;
+  }
+  if (dropped.length > free) {
+    showToast('Nur noch Platz für ' + free + ' Bild' + (free > 1 ? 'er' : '') + ' — der Rest wurde übersprungen.', 'warning');
+  }
+
+  ebPrepareImageFiles(dropped.slice(0, free)).then(function(queue) {
+    if (!queue.length) return;   // Grund wurde bereits als Toast gezeigt
+    // Open crop modal for each image sequentially
+    _lcropMode = 'listing';
+    _lcropQueue = queue;
+    _lcropQueueIdx = 0;
+    _lcropProcessNext();
+  });
 }
 
 // ---- Listing Crop State ----
@@ -1270,25 +1276,23 @@ var _cropX = 0, _cropY = 0, _cropDragStart = null;
 function handleProfilePhoto(input) {
   if (!input.files || !input.files[0]) return;
   var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) {
-    showToast('Bild zu groß! Max. 5MB', 'error');
-    input.value = '';
-    return;
-  }
-  var reader = new FileReader();
-  reader.onload = function(e) {
-    var img = new Image();
-    img.onload = function() {
-      _cropImg = img;
-      _cropX = 0; _cropY = 0;
-      document.getElementById('cropZoom').value = 1;
-      openModal('avatarCropModal');
-      setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
-    };
-    img.src = e.target.result;
-  };
-  reader.readAsDataURL(file);
   input.value = '';
+  ebPrepareImageFile(file).then(function(ready) {
+    if (!ready) return;   // Grund wurde bereits als Toast gezeigt
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = new Image();
+      img.onload = function() {
+        _cropImg = img;
+        _cropX = 0; _cropY = 0;
+        document.getElementById('cropZoom').value = 1;
+        openModal('avatarCropModal');
+        setTimeout(function() { cropDraw(); cropBindEvents(); }, 50);
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(ready);
+  });
 }
 
 function cropDraw() {
@@ -1424,11 +1428,15 @@ function cropConfirm() {
 
 function handleCoverUpload(input) {
   if (!input.files || !input.files[0]) return;
-  var file = input.files[0];
-  if (file.size > 5 * 1024 * 1024) {
-    showToast('Bild zu groß! Max. 5MB', 'error');
-    return;
-  }
+  var rawCover = input.files[0];
+  input.value = '';
+  ebPrepareImageFile(rawCover).then(function(file) {
+    if (!file) return;   // Grund wurde bereits als Toast gezeigt
+    _applyCoverUpload(file);
+  });
+}
+
+function _applyCoverUpload(file) {
   // Show preview immediately
   var reader = new FileReader();
   reader.onload = function(e) {
@@ -1557,22 +1565,18 @@ function handleGalleryUpload(input) {
     return;
   }
 
-  var queue = [];
-  for (var i = 0; i < files.length; i++) {
-    var file = files[i];
-    if (file.size > 5 * 1024 * 1024) {
-      showToast(file.name + ' ist zu groß (max. 5MB)', 'error');
-      continue;
-    }
-    queue.push(file);
-  }
+  var dropped = Array.prototype.slice.call(files || []);
   input.value = '';
+  if (!dropped.length) return;
 
-  // Open crop modal for each image sequentially
-  _lcropMode = 'gallery';
-  _lcropQueue = queue;
-  _lcropQueueIdx = 0;
-  if (queue.length > 0) _lcropProcessNext();
+  ebPrepareImageFiles(dropped).then(function(queue) {
+    if (!queue.length) return;   // Grund wurde bereits als Toast gezeigt
+    // Open crop modal for each image sequentially
+    _lcropMode = 'gallery';
+    _lcropQueue = queue;
+    _lcropQueueIdx = 0;
+    _lcropProcessNext();
+  });
 }
 
 function _addGalleryPreviewItem(src, blob) {
@@ -1643,27 +1647,107 @@ function updateGalleryCount() {
   }
 }
 
-// Drag & Drop support
+// ======== DRAG & DROP für alle Upload-Zonen ========
+//
+// Drei Dinge, die vorher fehlten:
+//  1. dragleave feuert auch beim Wechsel auf ein Kind-Element — die Zone
+//     flackerte. Ein Zähler pro Zone hält den Hover-Zustand stabil.
+//  2. Ein Drop neben die Zone ließ den Browser das Bild als Seite öffnen und
+//     das halb ausgefüllte Formular verwerfen. Wird jetzt global abgefangen.
+//  3. Zonen, die erst später ins DOM kommen, waren nie gebunden. Idempotente
+//     Bindung + erneuter Aufruf sind jetzt gefahrlos.
 function setupDragDrop() {
-  var zones = document.querySelectorAll('.upload-zone');
-  zones.forEach(function(zone) {
-    zone.addEventListener('dragover', function(e) {
-      e.preventDefault();
-      zone.classList.add('dragover');
-    });
-    zone.addEventListener('dragleave', function(e) {
-      e.preventDefault();
-      zone.classList.remove('dragover');
-    });
-    zone.addEventListener('drop', function(e) {
-      e.preventDefault();
-      zone.classList.remove('dragover');
-      var fileInput = zone.querySelector('input[type="file"]');
-      if (fileInput && e.dataTransfer.files.length > 0) {
-        fileInput.files = e.dataTransfer.files;
-        fileInput.dispatchEvent(new Event('change'));
+  document.querySelectorAll('.upload-zone').forEach(_ebBindDropZone);
+  _ebBlockStrayDrops();
+}
+
+function _ebBindDropZone(zone) {
+  if (!zone || zone._ebDropBound) return;
+  zone._ebDropBound = true;
+  var depth = 0;
+
+  function hasFiles(e) {
+    var dt = e.dataTransfer;
+    if (!dt) return false;
+    if (dt.types && dt.types.length) return Array.prototype.indexOf.call(dt.types, 'Files') !== -1;
+    return true;
+  }
+  function leave() { depth = 0; zone.classList.remove('dragover'); }
+
+  zone.addEventListener('dragenter', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    depth++;
+    zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragover', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    try { e.dataTransfer.dropEffect = 'copy'; } catch (_) {}
+    zone.classList.add('dragover');
+  });
+  zone.addEventListener('dragleave', function(e) {
+    if (!hasFiles(e)) return;
+    depth = Math.max(0, depth - 1);
+    if (depth === 0) zone.classList.remove('dragover');
+  });
+  zone.addEventListener('drop', function(e) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    leave();
+
+    var fileInput = zone.querySelector('input[type="file"]');
+    var files = e.dataTransfer && e.dataTransfer.files;
+    if (!fileInput) return;
+    if (!files || !files.length) {
+      showToast('Da kam keine Datei an. Bitte aus dem Dateimanager ziehen.', 'error');
+      return;
+    }
+    // Direkte Zuweisung schlägt in manchen Browsern still fehl — dann
+    // bekäme der Nutzer gar keine Rückmeldung. Deshalb prüfen und notfalls
+    // den Handler direkt mit einem Stellvertreter-Input aufrufen.
+    var assigned = false;
+    try {
+      fileInput.files = files;
+      assigned = fileInput.files && fileInput.files.length > 0;
+    } catch (_) { assigned = false; }
+
+    if (assigned) {
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    } else {
+      var handler = fileInput.getAttribute('onchange') || '';
+      var fnName = (handler.match(/^\s*([A-Za-z_$][\w$]*)\s*\(/) || [])[1];
+      var fn = fnName && window[fnName];
+      if (typeof fn === 'function') {
+        fn({ files: files, value: '' });
+      } else {
+        showToast('Ablegen hat nicht geklappt — bitte auf die Fläche klicken und das Bild auswählen.', 'error');
       }
-    });
+    }
+  });
+}
+
+// Drop irgendwo sonst im Fenster: verhindern, dass der Browser wegnavigiert
+// und dabei ein halb ausgefülltes Formular verwirft.
+function _ebBlockStrayDrops() {
+  if (window._ebStrayDropsBlocked) return;
+  window._ebStrayDropsBlocked = true;
+  ['dragover', 'drop'].forEach(function(type) {
+    window.addEventListener(type, function(e) {
+      var dt = e.dataTransfer;
+      var isFileDrag = dt && dt.types && Array.prototype.indexOf.call(dt.types, 'Files') !== -1;
+      if (!isFileDrag) return;
+      if (e.target && e.target.closest && e.target.closest('.upload-zone')) return;
+      e.preventDefault();
+      if (type === 'drop') {
+        var zone = document.querySelector('.upload-zone');
+        var visible = zone && zone.offsetParent !== null;
+        showToast(visible
+          ? 'Bitte direkt auf das Upload-Feld ziehen.'
+          : 'Hier lassen sich keine Bilder ablegen.', 'error');
+      }
+    }, false);
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -17084,3 +17084,6 @@ body.dark-mode .geo-treffer-btn { background: var(--bg-alt); color: var(--text);
   .ai-declaration-group { grid-template-columns: 1fr; }
   .ai-declaration { padding: 15px; }
 }
+
+/* Zweite Zeile im Upload-Hinweis: leiser als die harte Limit-Angabe */
+.upload-hint-soft { opacity: .75; font-size: .92em; }

--- a/tests/e2e/bild-upload.spec.js
+++ b/tests/e2e/bild-upload.spec.js
@@ -1,0 +1,160 @@
+// Bild-Upload: Limit, Auto-Verkleinerung und Drag & Drop.
+//
+// Hintergrund: Ein Nutzer zog ein Foto auf die Upload-Fläche und bekam keine
+// erkennbare Rückmeldung. Die Regeln, die das verhindern sollen:
+//   1. Jeder Ausgang meldet sich — stiller Abbruch ist ein Bug.
+//   2. Zu große JPG/PNG/WebP werden verkleinert statt abgelehnt.
+//   3. Ein Drop landet genau einmal beim Handler (setupDragDrop läuft zweimal).
+const { test, expect } = require('@playwright/test');
+const { openApp, expectNoPageErrors } = require('./helpers');
+
+// Erzeugt im Browser ein echtes JPEG mit Rauschen — komprimiert schlecht,
+// wird also bei großen Kantenlängen zuverlässig größer als das Limit.
+const MAKE_JPEG = `(w, h, q, name) => new Promise((resolve) => {
+  const c = document.createElement('canvas');
+  c.width = w; c.height = h;
+  const x = c.getContext('2d');
+  const d = x.createImageData(w, h);
+  for (let i = 0; i < d.data.length; i += 4) {
+    d.data[i] = Math.random() * 255;
+    d.data[i + 1] = Math.random() * 255;
+    d.data[i + 2] = Math.random() * 255;
+    d.data[i + 3] = 255;
+  }
+  x.putImageData(d, 0, 0);
+  c.toBlob((b) => resolve(new File([b], name || 'foto.jpg', { type: 'image/jpeg' })), 'image/jpeg', q);
+})`;
+
+test.describe('Bild-Upload', () => {
+  test('Limit steht an einer Stelle und ist 15 MB', async ({ page }) => {
+    const errors = await openApp(page);
+    const konstanten = await page.evaluate(() => ({
+      bytes: window.EB_MAX_IMAGE_BYTES,
+      label: window.EB_MAX_IMAGE_LABEL,
+    }));
+    expect(konstanten.bytes).toBe(15 * 1024 * 1024);
+    expect(konstanten.label).toBe('15 MB');
+    expectNoPageErrors(errors, 'Upload-Konstanten');
+  });
+
+  test('Hinweistext nennt dasselbe Limit wie der Code', async ({ page }) => {
+    await openApp(page);
+    const hinweis = await page.evaluate(() =>
+      document.querySelector('#uploadZone .upload-hint').textContent);
+    expect(hinweis).toContain('15 MB');
+  });
+
+  test('Falscher Dateityp wird abgelehnt und begründet', async ({ page }) => {
+    const errors = await openApp(page);
+    const meldung = await page.evaluate(async () => {
+      const gesehen = [];
+      const orig = window.showToast;
+      window.showToast = (m) => { gesehen.push(m); };
+      const raus = await ebPrepareImageFile(new File([new Uint8Array(8)], 'vertrag.pdf', { type: 'application/pdf' }));
+      window.showToast = orig;
+      return { raus, gesehen };
+    });
+    expect(meldung.raus).toBeNull();
+    expect(meldung.gesehen.join(' ')).toContain('vertrag.pdf');
+    expectNoPageErrors(errors, 'Falscher Dateityp');
+  });
+
+  test('Zu großes JPEG wird verkleinert statt abgelehnt', async ({ page }) => {
+    const errors = await openApp(page);
+    const ergebnis = await page.evaluate(async (mkSrc) => {
+      const mk = eval(mkSrc);
+      const gross = await mk(6000, 4000, 1.0, 'strand.jpg');
+      const gesehen = [];
+      const orig = window.showToast;
+      window.showToast = (m) => { gesehen.push(m); };
+      const klein = await ebPrepareImageFile(gross);
+      window.showToast = orig;
+      return {
+        vorher: gross.size,
+        nachher: klein ? klein.size : null,
+        typ: klein && klein.type,
+        gesehen,
+      };
+    }, MAKE_JPEG);
+
+    expect(ergebnis.vorher).toBeGreaterThan(15 * 1024 * 1024);
+    expect(ergebnis.nachher).not.toBeNull();
+    expect(ergebnis.nachher).toBeLessThanOrEqual(15 * 1024 * 1024);
+    expect(ergebnis.typ).toBe('image/jpeg');
+    expect(ergebnis.gesehen.join(' ')).toContain('verkleinert');
+    expectNoPageErrors(errors, 'Auto-Verkleinerung');
+  });
+
+  test('Zu großes GIF wird ehrlich abgelehnt (Animation bliebe nicht erhalten)', async ({ page }) => {
+    await openApp(page);
+    const ergebnis = await page.evaluate(async () => {
+      const gesehen = [];
+      const orig = window.showToast;
+      window.showToast = (m) => { gesehen.push(m); };
+      const raus = await ebPrepareImageFile(
+        new File([new Uint8Array(16 * 1024 * 1024)], 'party.gif', { type: 'image/gif' }));
+      window.showToast = orig;
+      return { raus, gesehen };
+    });
+    expect(ergebnis.raus).toBeNull();
+    expect(ergebnis.gesehen.join(' ')).toContain('party.gif');
+    expect(ergebnis.gesehen.join(' ')).toContain('15 MB');
+  });
+
+  test('Drop auf die Upload-Fläche erreicht den Handler genau einmal', async ({ page }) => {
+    const errors = await openApp(page);
+    const ergebnis = await page.evaluate(async (mkSrc) => {
+      const mk = eval(mkSrc);
+      const zone = document.getElementById('uploadZone');
+      const dt = new DataTransfer();
+      dt.items.add(await mk(300, 300, 0.8, 'klein.jpg'));
+      let aufrufe = 0;
+      const orig = window.handleUpload;
+      window.handleUpload = function () { aufrufe++; };
+      const ev = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt });
+      zone.dispatchEvent(ev);
+      await new Promise((r) => setTimeout(r, 300));
+      window.handleUpload = orig;
+      return { aufrufe, verhindert: ev.defaultPrevented };
+    }, MAKE_JPEG);
+
+    // Genau einmal: setupDragDrop() wird aus zwei Modulen aufgerufen —
+    // doppelte Bindung würde jedes Bild zweimal einfügen.
+    expect(ergebnis.aufrufe).toBe(1);
+    expect(ergebnis.verhindert).toBe(true);
+    expectNoPageErrors(errors, 'Drop auf Upload-Fläche');
+  });
+
+  test('Hover bleibt stabil, wenn die Maus über ein Kind-Element zieht', async ({ page }) => {
+    await openApp(page);
+    const ergebnis = await page.evaluate(() => {
+      const zone = document.getElementById('uploadZone');
+      const kind = zone.querySelector('h3');
+      const drag = (typ) => {
+        const d = new DataTransfer();
+        d.items.add(new File([new Uint8Array(1)], 'a.png', { type: 'image/png' }));
+        return new DragEvent(typ, { bubbles: true, cancelable: true, dataTransfer: d });
+      };
+      zone.dispatchEvent(drag('dragenter'));
+      kind.dispatchEvent(drag('dragenter'));
+      kind.dispatchEvent(drag('dragleave'));
+      const nochAktiv = zone.classList.contains('dragover');
+      zone.dispatchEvent(drag('dragleave'));
+      return { nochAktiv, danachWeg: !zone.classList.contains('dragover') };
+    });
+    expect(ergebnis.nochAktiv).toBe(true);
+    expect(ergebnis.danachWeg).toBe(true);
+  });
+
+  test('Drop neben die Fläche navigiert nicht weg', async ({ page }) => {
+    await openApp(page);
+    const verhindert = await page.evaluate(() => {
+      const dt = new DataTransfer();
+      dt.items.add(new File([new Uint8Array(1)], 'x.png', { type: 'image/png' }));
+      const ev = new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt });
+      document.body.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    });
+    expect(verhindert).toBe(true);
+  });
+});

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -85,6 +85,29 @@ noch `assets/eb-knowledge.json` angefasst.
 
 ## Zuletzt ausgeliefert (August 2026)
 
+- [x] **Bild-Upload: 15 MB, Auto-Verkleinerung, verlässliches Drag & Drop.**
+  Anlass war ein Nutzer, der ein Foto auf die Fläche zog und keine erkennbare
+  Rückmeldung bekam. Das Limit stand vorher an neun Code-Stellen und in zwei
+  Hinweistexten je einzeln als „5 MB"; jetzt gibt es eine Quelle der Wahrheit
+  (`EB_MAX_IMAGE_BYTES` in `js/modules/core/00-basis.js`, gespiegelt als
+  PHP-Konstante in `functions.php`) mit 15 MB. Größere JPG/PNG/WebP rechnet
+  der Browser auf 2560 px herunter, statt sie abzulehnen — mit Toast, der
+  Vorher/Nachher nennt. GIFs werden ehrlich abgelehnt, weil das Umzeichnen
+  die Animation verlöre. Jeder Ausgang meldet sich; stiller Abbruch gilt als
+  Bug. Am Drag & Drop drei Korrekturen: ein Zähler gegen das Flackern beim
+  Wechsel auf Kind-Elemente, idempotente Bindung (`setupDragDrop()` läuft aus
+  zwei Modulen — jedes Bild wurde bisher doppelt eingefügt) und ein globaler
+  Fang für Drops neben die Fläche, die den Browser sonst zur Bilddatei
+  navigieren ließen und das halb ausgefüllte Formular verwarfen. Serverseitig
+  antwortet `eb_handle_upload()` jetzt mit 413 und nennt das tatsächliche
+  Hosting-Limit, wenn PHP den Request schon vor dem Handler verwirft.
+  Acht neue Regressionstests in `tests/e2e/bild-upload.spec.js`.
+
+  **Offen (Hosting, nicht Code):** greift `upload_max_filesize` /
+  `post_max_size` unter 16M/20M, bleibt das echte Limit darunter. Der
+  `.htaccess`-Block wirkt nur unter mod_php; bei IONOS-FastCGI muss der Wert
+  ins PHP-Panel oder nach `/public/.user.ini`.
+
 - [x] **Kein Beitrag ohne Account:** Der Tages-Demo-Feed liefert nun 25 feste,
   klar gekennzeichnete Demo-Account-Profile mit stabilen IDs und Avataren.
   Autorname und Avatar öffnen das zugehörige Profil; derselbe Autor kann nicht


### PR DESCRIPTION
Der Patch aus der anderen Session, hier angewendet und nachgeprüft. Anlass war ein Bild auf der Upload-Fläche ohne erkennbare Rückmeldung.

## Was falsch lief — drei getrennte Ursachen

- **`setupDragDrop()` läuft aus zwei Modulen.** Jede Zone war doppelt gebunden, jedes abgelegte Bild landete zweimal im Formular. Bindung ist jetzt idempotent.
- **`dragleave` feuert auch beim Wechsel auf ein Kind-Element.** Die Fläche flackerte und wirkte tot. Ein Zähler pro Zone hält den Zustand stabil.
- **Ein Drop knapp neben die Fläche** ließ den Browser zur Bilddatei navigieren und verwarf dabei das halb ausgefüllte Inserat. Wird global abgefangen — Hinweis statt Datenverlust.

## Limit an einer Stelle statt an elf

„5 MB" stand in **neun Code-Zweigen** (Inserat, Galerie, Avatar, Cover, Chat, Feed, Provider-Avatar) und zusätzlich in zwei Hinweistexten. Jetzt: `EB_MAX_IMAGE_BYTES` in `js/modules/core/00-basis.js`, gespiegelt als PHP-Konstante — **15 MB**.

Größere JPG/PNG/WebP rechnet der Browser auf 2560 px herunter, statt sie abzulehnen; der Toast nennt Vorher/Nachher. **GIFs werden ehrlich abgelehnt**, weil Umzeichnen die Animation verlöre. Jeder Ausgang meldet sich mit Dateiname und tatsächlicher Größe — stiller Abbruch gilt als Bug.

Serverseitig antwortet `eb_handle_upload()` jetzt mit **413 und dem echten Hosting-Limit**, wenn PHP den Request schon vor dem Handler verwirft (`post_max_size`). Vorher kam nur „Keine Datei hochgeladen", und niemand konnte sehen, dass das Hosting die Ursache war.

## Meine Nachprüfung

Der Patch fasst Upload-Code an — den Bereich, den der Autopilot bewusst nie berühren darf. Deshalb nicht blind übernommen:

| Prüfung | Ergebnis |
|---|---|
| MIME-Prüfung aus den Magic-Bytes | **unverändert** — Schritt 3 in `eb_handle_upload()` nicht angetastet |
| Serverseitiges Größenlimit | weiterhin durchgesetzt, nur der Wert steigt |
| Schutzkonstrukte weggenommen? | nein — `_escHtml` 440→440, `encodeURIComponent` 16→16, `noopener` 10→10, `currentUser` 472→472, `catch` 384→**387** |
| Dateiname im Toast → XSS? | nein — `showToast()` schreibt per `textContent`, nicht `innerHTML` |
| Neue Speicherschlüssel? | keine — `recht.mjs`: 24 im Code, 24 beschrieben |
| `app.js` / `index.html` in Sync? | ja, gegen `js/modules/**` neu gebaut und verglichen |
| HQ-Zugangstor | 42 Prüfungen weiterhin grün |

Die Downscale-Schleife bricht nach vier Runden ab und lehnt dann ab, statt endlos zu rechnen.

## Prüfstand

**349 Tests, 345 grün.** Die vier Radar-Tests brauchen Leaflet von `unpkg.com`, das der Proxy dieser Umgebung sperrt (403) — in CI laufen sie durch. `npm run gate` sauber, `php -l` sauber.

Acht neue Regressionstests in `tests/e2e/bild-upload.spec.js`.

---

## ⚠️ Ein Schritt bleibt beim Hosting

Steht bei IONOS `post_max_size` unter 20M oder `upload_max_filesize` unter 16M, bleibt das **wirksame** Limit darunter — unabhängig von diesem Code.

Der `.htaccess`-Block greift nur unter `mod_php`. Bei FastCGI/PHP-FPM — dem IONOS-Standard — wird er ignoriert. Dann muss der Wert ins PHP-Panel oder nach `/public/.user.ini`:

```ini
upload_max_filesize = 16M
post_max_size = 20M
```

**Du siehst am Fehlertext, ob das noch offen ist:** Der Upload antwortet in dem Fall mit 413 und nennt den tatsächlich geltenden Wert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_