### PR TITLE
Die Einwilligung wirkt, Zugänge vergibt man im HQ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,19 @@ DSGVO Art. 13), **Einwilligung** (liest überhaupt eine Schreibstelle die
 Antwort?), **Pflichtseiten** (jeder Slug der Compliance-Übersicht braucht eine
 Route in `functions.php`) und **KI-Transparenz** (EU AI Act Art. 50).
 
-Blockierend ist nur, was derselbe Commit beheben kann. Die **wirkungslose
-Einwilligung** wird gemeldet, nicht gesperrt: ihre Behebung ändert sichtbares
-Verhalten und ist eine Entscheidung des Inhabers. Ein Tor, das jeden PR sperrt,
-bis eine Produktentscheidung fällt, wird abgeschaltet — und prüft danach nichts.
+Blockierend ist nur, was derselbe Commit beheben kann.
+
+**Die Einwilligung wirkt seit dem 20.08.** `ebSpeichern()` in
+`js/modules/core/00-basis.js` prüft vor jedem nicht-essenziellen Schreibvorgang;
+alle 20 betroffenen Schreibstellen laufen darüber. Die Klassentabelle
+`EB_SPEICHER_KLASSEN` ist die Codeseite der Cookie-Liste — `recht.mjs` prüft,
+dass **jeder** Schlüssel eine Klasse hat und beide Seiten dieselbe nennen.
+Essenzielles (Anmeldung, laufende Zahlung, die Antwort selbst) schreibt weiter
+direkt; ein unbekannter Schlüssel gilt als profilbildend, nicht als essenziell.
+
+**Neue nicht-essenzielle Schreibstelle → `ebSpeichern()`, nicht
+`localStorage.setItem()`.** Sonst ist die Einwilligung dort wirkungslos, und
+`recht.spec.js` bricht ab.
 
 **Neuer Speicherschlüssel = neue Zeile in `Cookie-Liste.md`,** sonst bricht der
 PR-Check ab. Der Prüfer löst Konstanten, Hilfsfunktionen (auch über
@@ -229,7 +238,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-345 Tests in 19 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+356 Tests in 19 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +

--- a/app-shell.html
+++ b/app-shell.html
@@ -2671,26 +2671,30 @@
       <div class="container legal-page">
         <h1>Cookie-Richtlinie</h1>
         <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Wir verwenden ausschließlich technisch notwendige Cookies gemäß § 25 Abs. 2 Nr. 2 TDDDG. Diese Richtlinie wird mit Eintragung der UG im Handelsregister verbindlich.</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Technisch notwendige Speicherung erfolgt ohne Einwilligung (§ 25 Abs. 2 Nr. 2 TDDDG); Komfort- und Vorschlagsfunktionen nur nach Ihrer Zustimmung (§ 25 Abs. 1 TDDDG). Diese Richtlinie wird mit Eintragung der UG im Handelsregister verbindlich.</p>
         <p>Information nach § 25 TDDDG sowie Art. 13 DSGVO über eingesetzte Cookies und vergleichbare Technologien (localStorage, sessionStorage, IndexedDB, Web-Beacons).</p>
         <h2>1. Eingesetzte Cookies und Technologien</h2>
         <table class="legal-table">
           <thead><tr><th>Name / Zweck</th><th>Kategorie</th><th>Speicherdauer</th><th>Anbieter</th></tr></thead>
           <tbody>
-            <tr><td>PHPSESSID — Session-Cookie für Login</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
-            <tr><td>wp-* — WordPress-Funktion (Login, CSRF-Schutz)</td><td>Technisch erforderlich</td><td>Sitzung / 30 Tage</td><td>Eventbörse UG</td></tr>
-            <tr><td>eb_cookie_consent — Speicherung Banner-Auswahl</td><td>Technisch erforderlich</td><td>12 Monate</td><td>Eventbörse UG</td></tr>
-            <tr><td>XSRF-Token — Schutz vor CSRF</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
-            <tr><td>Stripe-Cookies (m, stripemid) — Betrugsabwehr</td><td>Technisch erforderlich (Zahlung)</td><td>Bis zu 12 Monate</td><td>Stripe Payments Europe Ltd.</td></tr>
+            <tr><td>wordpress_logged_in_*, wordpress_sec_* — Anmeldung und Sitzung</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
+            <tr><td>wp-settings-* — Oberflächen-Einstellungen im Verwaltungsbereich</td><td>Funktional</td><td>1 Jahr</td><td>Eventbörse UG</td></tr>
+            <tr><td>Einmalcode während der Anmeldung (Browser-Sitzungsspeicher)</td><td>Technisch erforderlich</td><td>bis Ende der Sitzung</td><td>Eventbörse UG</td></tr>
+            <tr><td>Laufender Zahlungsvorgang (Browser-Speicher)</td><td>Technisch erforderlich (Zahlung)</td><td>bis Abschluss</td><td>Eventbörse UG</td></tr>
+            <tr><td>eb_cookie_consent — Ihre Antwort auf den Cookie-Hinweis</td><td>Technisch erforderlich</td><td>12 Monate</td><td>Eventbörse UG</td></tr>
+            <tr><td><strong>Komfort</strong> — Farbmodus, Favoriten, Planungsboard, eigene Beiträge und Kommentare, Gesprächsverlauf des Planungs-Assistenten, zuletzt gewählter Standort für die Umkreissuche (Browser-Speicher)</td><td><strong>Nur mit Einwilligung</strong></td><td>bis zum Widerruf</td><td>Eventbörse UG</td></tr>
+            <tr><td><strong>Vorschläge</strong> — aus Such- und Klickverhalten abgeleitete Vorlieben, unbeantwortete Fragen an den Hilfe-Assistenten (Browser-Speicher)</td><td><strong>Nur mit Einwilligung</strong></td><td>bis zum Widerruf</td><td>Eventbörse UG</td></tr>
+            <tr><td>Stripe (__stripe_mid, __stripe_sid) — Betrugsabwehr</td><td>Technisch erforderlich (Zahlung)</td><td>Bis zu 12 Monate</td><td>Stripe Payments Europe Ltd.</td></tr>
           </tbody>
         </table>
         <h2>2. Rechtsgrundlage</h2>
-        <p>Diese Cookies sind technisch erforderlich, um die angefragten Plattformfunktionen bereitzustellen (Login, Buchung, Bezahlung, Schutz vor Missbrauch). Wir setzen sie gemäß § 25 Abs. 2 Nr. 2 TDDDG ohne Einwilligung. Soweit eine Verarbeitung personenbezogener Daten verbunden ist: Art. 6 Abs. 1 lit. b oder f DSGVO.</p>
+        <p>Die als <em>technisch erforderlich</em> gekennzeichneten Einträge stellen die angefragten Plattformfunktionen bereit (Anmeldung, Buchung, Bezahlung, Schutz vor Missbrauch). Wir setzen sie gemäß § 25 Abs. 2 Nr. 2 TDDDG ohne Einwilligung. Soweit eine Verarbeitung personenbezogener Daten verbunden ist: Art. 6 Abs. 1 lit. b oder f DSGVO.</p>
+        <p>Alles, was mit <strong>„Nur mit Einwilligung“</strong> gekennzeichnet ist, wird erst gespeichert, wenn Sie im Cookie-Hinweis zugestimmt haben — Rechtsgrundlage § 25 Abs. 1 TDDDG i.V.m. Art. 6 Abs. 1 lit. a DSGVO. Lehnen Sie ab, bleibt es aus. Sie können Ihre Auswahl jederzeit über „Cookie-Einstellungen“ im Fußbereich ändern; ein Widerruf löscht auch das bereits Gespeicherte (Art. 7 Abs. 3 DSGVO). Diese Angaben verlassen Ihren Browser nicht.</p>
         <h2>3. Marketing- und Analyse-Cookies</h2>
         <p>Wir setzen aktuell <strong>keine</strong> Marketing-, Analyse- oder Tracking-Cookies ein. Sollten wir solche Dienste künftig aktivieren, holen wir vorab Ihre ausdrückliche Einwilligung gemäß § 25 Abs. 1 TDDDG i.V.m. Art. 6 Abs. 1 lit. a DSGVO über einen Consent-Banner ein.</p>
         <h2>4. Verwaltung Ihrer Browser-Einstellungen</h2>
         <p>Sie können Cookies in den Einstellungen Ihres Browsers jederzeit verwalten oder löschen. Die vollständige Deaktivierung kann dazu führen, dass Plattformfunktionen eingeschränkt nutzbar sind (insbesondere Login und Buchung).</p>
-        <p>Sie können <a href="#" onclick="event.preventDefault(); localStorage.removeItem('eb_cookie_consent'); if(typeof initCookieConsent==='function')initCookieConsent();">Ihre Cookie-Einstellungen jederzeit erneut aufrufen</a>.</p>
+        <p>Sie können <a href="#" onclick="event.preventDefault(); if(typeof openCookieSettings==='function')openCookieSettings();">Ihre Cookie-Einstellungen jederzeit erneut aufrufen</a>.</p>
       </div>
     </section>
 
@@ -3229,7 +3233,9 @@ Datum: ___________________________________________________
         <p>Bei jedem Aufruf erfassen wir: IP-Adresse (anonymisiert nach 7 Tagen), Datum/Uhrzeit, Zeitzonendifferenz, Inhalt der Anforderung, HTTP-Statuscode, übertragene Datenmenge, Referrer-URL, Browser, OS, Sprache. Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO.</p>
 
         <h2>5. Cookies und Endgeräte-Speicherung</h2>
-        <p>Wir setzen ausschließlich technisch notwendige Cookies ein (Session-Cookie nach Login, Cookie-Banner-Status). Rechtsgrundlage: § 25 Abs. 2 Nr. 2 TDDDG. Sonstige Cookies (Analyse, Marketing) werden derzeit nicht verwendet. Details: <a href="#" onclick="navigateTo('cookies');return false;">Cookie-Richtlinie</a>.</p>
+        <p><strong>Technisch notwendig</strong> — ohne Einwilligung, § 25 Abs. 2 Nr. 2 TDDDG: Anmeldung und Sitzung, Einmalcode bei der Anmeldung, ein laufender Zahlungsvorgang sowie Ihre Antwort auf den Cookie-Hinweis selbst.</p>
+        <p><strong>Nur mit Ihrer Einwilligung</strong> (§ 25 Abs. 1 TDDDG, Art. 6 Abs. 1 lit. a DSGVO) speichern wir zusätzlich im Speicher Ihres Browsers: <em>Komfort</em> — Farbmodus, Favoriten, Ihr Planungsboard, eigene Beiträge und Kommentare, den Gesprächsverlauf des Planungs-Assistenten sowie den zuletzt gewählten Standort für die Umkreissuche; und <em>Vorschläge</em> — aus Such- und Klickverhalten abgeleitete Vorlieben sowie unbeantwortete Fragen an den Hilfe-Assistenten. Lehnen Sie ab, wird nichts davon gespeichert; ein Widerruf löscht bereits Gespeichertes.</p>
+        <p>Diese Angaben liegen ausschließlich im Speicher Ihres Browsers und werden nicht an Dritte übertragen. <strong>Analyse- und Marketing-Cookies setzen wir nicht ein.</strong> Ihre Auswahl ändern Sie jederzeit über „Cookie-Einstellungen“ im Fußbereich. Details: <a href="#" onclick="navigateTo('cookies');return false;">Cookie-Richtlinie</a>.</p>
 
         <h2>6. Registrierung und Nutzerkonto</h2>
         <p>Verarbeitete Daten: Name, E-Mail, Passwort (gespeichert als Hash), Geburtsdatum (Altersnachweis), Postleitzahl/Ort, optional Telefonnummer und Profilbild. Zweck: Vertragsanbahnung/-durchführung, Authentifizierung. Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO. Speicherdauer: für die Dauer des Kontos; nach Löschung gemäß Löschkonzept (steuerrechtlich relevante Daten 6/10 Jahre).</p>
@@ -3374,7 +3380,7 @@ Datum: ___________________________________________________
           <a href="#" onclick="navigateTo('agb-dienstleister')">AGB Dienstleister</a>
           <a href="#" onclick="navigateTo('marktplatz')">Marktplatzbedingungen</a>
           <a href="#" onclick="navigateTo('widerruf')">Widerrufsbelehrung</a>
-          <a href="#" onclick="event.preventDefault(); localStorage.removeItem('eb_cookie_consent'); initCookieConsent();">Cookie-Einstellungen</a>
+          <a href="#" onclick="event.preventDefault(); openCookieSettings();">Cookie-Einstellungen</a>
         </div>
         <div class="footer-col">
           <h4>Plattform &amp; Compliance</h4>
@@ -4100,23 +4106,32 @@ Datum: ___________________________________________________
     <div class="cookie-banner-inner">
       <div class="cookie-banner-row">
         <p class="cookie-banner-msg">
-          Wir verwenden ausschließlich technisch notwendige Cookies (Login, CSRF-Schutz, Stripe). Keine Analyse- oder Marketing-Cookies.
+          Notwendiges speichern wir immer (Anmeldung, laufende Zahlung). Darüber hinaus möchten wir
+          <strong>Komfort</strong> merken — etwa Farbmodus, Favoriten und deine Planung — und aus deinen
+          Suchen <strong>Vorschläge</strong> ableiten. Beides nur mit deiner Zustimmung.
           <button type="button" class="cookie-banner-link" onclick="toggleCookieDetails()" aria-expanded="false" id="cookieDetailsToggle">Details anzeigen</button>
         </p>
-        <button class="btn-primary btn-sm" id="cookieAcceptAll">Verstanden</button>
+        <div class="cookie-banner-actions">
+          <button class="btn-secondary btn-sm" id="cookieRejectAll">Nur Notwendiges</button>
+          <button class="btn-primary btn-sm" id="cookieAcceptAll">Alles erlauben</button>
+        </div>
       </div>
       <div class="cookie-banner-details" id="cookieBannerDetails" hidden>
         <table class="cookie-banner-table">
-          <thead><tr><th>Cookie</th><th>Zweck</th><th>Dauer</th></tr></thead>
+          <thead><tr><th>Was</th><th>Wozu</th><th>Ohne Zustimmung</th></tr></thead>
           <tbody>
-            <tr><td>PHPSESSID</td><td>Session-Login</td><td>Sitzung</td></tr>
-            <tr><td>wp-*</td><td>WordPress / CSRF</td><td>Sitzung–30 Tage</td></tr>
-            <tr><td>eb_cookie_consent</td><td>Banner-Auswahl</td><td>12 Monate</td></tr>
-            <tr><td>XSRF-Token</td><td>CSRF-Schutz</td><td>Sitzung</td></tr>
-            <tr><td>Stripe (m, stripemid)</td><td>Betrugsabwehr</td><td>bis 12 Monate</td></tr>
+            <tr><td>Anmeldung &amp; Sitzung</td><td>angemeldet bleiben, Einmalcode</td><td>wird gespeichert</td></tr>
+            <tr><td>Laufende Zahlung</td><td>Checkout über Stripe zu Ende führen</td><td>wird gespeichert</td></tr>
+            <tr><td>Diese Auswahl</td><td>damit wir nicht erneut fragen</td><td>wird gespeichert</td></tr>
+            <tr><td>Komfort</td><td>Farbmodus, Favoriten, Planungsboard, eigene Beiträge, Chatverlauf des Assistenten, zuletzt gewählter Umkreis-Standort</td><td>bleibt aus</td></tr>
+            <tr><td>Vorschläge</td><td>Vorlieben aus Such- und Klickverhalten, offene Fragen an den KI-Bot</td><td>bleibt aus</td></tr>
           </tbody>
         </table>
-        <p class="cookie-banner-legal">Rechtsgrundlage: § 25 Abs. 2 Nr. 2 TDDDG sowie Art. 6 Abs. 1 lit. b/f DSGVO.</p>
+        <p class="cookie-banner-legal">
+          Alles bleibt in deinem Browser — nichts davon wird an Dritte übertragen. Du kannst die Auswahl
+          jederzeit über „Cookie-Einstellungen“ im Fußbereich ändern; ein Widerruf löscht das bereits
+          Gespeicherte. Rechtsgrundlage: § 25 TDDDG, Art. 6 Abs. 1 lit. a/b/f DSGVO.
+        </p>
       </div>
     </div>
   </div>

--- a/app.js
+++ b/app.js
@@ -598,6 +598,114 @@ function ebPrepareImageFiles(files, opts) {
     });
   }, Promise.resolve()).then(function() { return out; });
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   SPEICHER UND EINWILLIGUNG (TDDDG § 25)
+
+   Bis zum 20.08.2026 wurde die Einwilligung erhoben und von KEINER
+   schreibenden Stelle gelesen. Der Banner sagte zusätzlich „ausschließlich
+   technisch notwendige Cookies" — während `eb_taste_v1` ein Präferenzprofil
+   aus dem Klickverhalten ablegte und `eb_radar_ort` den Standort. Das war
+   nicht nur eine wirkungslose Einwilligung, sondern eine falsche Aussage
+   gegenüber Nutzern.
+
+   Seitdem entscheidet die Antwort wirklich. Drei Klassen, eine Quelle:
+
+     essenziell   Anmeldung, laufende Zahlung, die Einwilligung selbst.
+                  Ohne sie funktioniert die Plattform nicht — keine
+                  Einwilligung nötig (§ 25 Abs. 2 Nr. 2 TDDDG).
+     funktional   Komfort und selbst angelegte Inhalte.
+     profil       leitet aus Verhalten Vorlieben ab. Immer einwilligungspflichtig.
+
+   Diese Tabelle ist die Codeseite von vault/40-Governance/Legal/Cookie-Liste.md.
+   `node scripts/recht.mjs --check` vergleicht beide und bricht ab, sobald ein
+   Schlüssel hier oder dort fehlt — eine Klassifizierung, die nur in einer
+   Prosa-Notiz steht, wird beim nächsten Feature vergessen.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+var EB_SPEICHER_KLASSEN = {
+  eb_cookie_consent: 'essenziell',
+  eb_user: 'essenziell',
+  eb_demo_session: 'essenziell',
+  eb_demo_users: 'essenziell',
+  eb_demo_passkeys: 'essenziell',
+  eb_pending_payment: 'essenziell',
+  eventboerse_pending_login_otp: 'essenziell',
+
+  eb_dark_mode: 'funktional',
+  eb_favs_: 'funktional',
+  eb_board_projects: 'funktional',
+  eb_board_projects_: 'funktional',
+  eb_board_tombstones_: 'funktional',
+  eb_accepted_bookings: 'funktional',
+  eb_social_posts: 'funktional',
+  eb_post_comments: 'funktional',
+  eb_liked_posts: 'funktional',
+  eb_nav_search: 'funktional',
+  eb_passkey_prompt_dismissed_: 'funktional',
+  eb_stripe_onboarding_prompt_: 'funktional',
+  eb_ai_chat_v1_: 'funktional',
+  eb_radar_ort: 'funktional',
+
+  eb_kb_misses: 'profil',
+  eb_taste_v1: 'profil'
+};
+
+/**
+ * Klasse eines Schlüssels. Längster passender Eintrag gewinnt, damit
+ * `eb_board_projects_17` nicht am kürzeren `eb_board_projects` hängen bleibt.
+ *
+ * Unbekannt heißt 'profil', nicht 'essenziell': ein neuer Schlüssel, den
+ * niemand eingeordnet hat, wird zurückhaltend behandelt statt großzügig.
+ * Der Fehler faellt dann in der Oberflaeche auf — und nicht erst, wenn
+ * jemand fragt, warum ohne Einwilligung Daten liegen.
+ */
+function ebSpeicherKlasse(key) {
+  var k = String(key || '');
+  var treffer = '';
+  for (var muster in EB_SPEICHER_KLASSEN) {
+    if (!Object.prototype.hasOwnProperty.call(EB_SPEICHER_KLASSEN, muster)) continue;
+    if (k === muster || k.indexOf(muster) === 0) {
+      if (muster.length > treffer.length) treffer = muster;
+    }
+  }
+  return treffer ? EB_SPEICHER_KLASSEN[treffer] : 'profil';
+}
+
+/** Darf dieser Schlüssel gerade geschrieben werden? */
+function ebDarfSpeichern(key) {
+  if (ebSpeicherKlasse(key) === 'essenziell') return true;
+  var c = (typeof _getCookieConsent === 'function') ? _getCookieConsent() : null;
+  // Vor der Antwort wird nichts Nicht-Essenzielles gesetzt. Das ist Schritt 2
+  // der dokumentierten Bannerlogik, der vorher fehlte.
+  if (!c) return false;
+  return ebSpeicherKlasse(key) === 'profil' ? !!c.profil : !!c.funktional;
+}
+
+/** Schreiben, wenn erlaubt. Gibt zurück, ob wirklich geschrieben wurde. */
+function ebSpeichern(key, wert) {
+  if (!ebDarfSpeichern(key)) return false;
+  try { localStorage.setItem(key, wert); return true; } catch (e) { return false; }
+}
+
+/**
+ * Alles wegräumen, was die aktuelle Antwort nicht mehr deckt.
+ *
+ * Ohne diesen Schritt wäre ein Widerruf wirkungslos für alles, was vor dem
+ * Widerruf schon dalag — und genau das ist der Punkt an Art. 7 Abs. 3 DSGVO:
+ * Widerruf so einfach wie Erteilung.
+ */
+function ebSpeicherAufraeumen() {
+  var weg = [];
+  try {
+    for (var i = 0; i < localStorage.length; i++) {
+      var k = localStorage.key(i);
+      if (k && !ebDarfSpeichern(k)) weg.push(k);
+    }
+    weg.forEach(function(k) { try { localStorage.removeItem(k); } catch (e) {} });
+  } catch (e) { /* privater Modus o. Ä. — dann liegt ohnehin nichts */ }
+  return weg;
+}
 // ========== DEMO DATA ==========
 const LISTINGS = [
   {
@@ -1268,7 +1376,7 @@ function forceBrowsePage() {
 
 function _saveFavoritesToStorage() {
   var key = currentUser ? 'eb_favs_' + currentUser.id : 'eb_favs_guest';
-  try { localStorage.setItem(key, JSON.stringify([...favorites])); } catch(e) {}
+  try { ebSpeichern(key, JSON.stringify([...favorites])); } catch(e) {}
 }
 
 function _loadFavoritesFromStorage() {
@@ -1747,7 +1855,7 @@ function renderListingCard(listing) {
   return `
     <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
-        <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bilder: ${_escHtml(listing.title)}">
+        <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bildergalerie: ${_escHtml(listing.title)}">
           ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
         </div>
         ${imgs.length > 1 ? '<button class="grid-gallery-arrow prev" aria-label="Vorheriges Bild" data-gallery-id="' + listing.id + '" data-dir="-1"><span class="material-icons-round">chevron_left</span></button><button class="grid-gallery-arrow next" aria-label="Nächstes Bild" data-gallery-id="' + listing.id + '" data-dir="1"><span class="material-icons-round">chevron_right</span></button><div class="grid-gallery-dots" id="gridGalleryDots_' + listing.id + '" role="group" aria-label="Bildauswahl">' + imgs.map(function(_, i) { return '<button class="grid-gallery-dot' + (i === 0 ? ' active' : '') + '" data-gallery-id="' + listing.id + '" data-idx="' + i + '" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') + '</div>' : ''}
@@ -2541,7 +2649,7 @@ function _ebTasteSave() {
             .slice(max).forEach(function(k) { delete t[bucket][k]; });
       }
     });
-    localStorage.setItem(EB_TASTE_KEY, JSON.stringify(t));
+    ebSpeichern(EB_TASTE_KEY, JSON.stringify(t));
   } catch (e) {}
 }
 
@@ -6135,7 +6243,7 @@ function _radarGrob(lat, lng) {
 function _radarMerken(pos, quelle) {
   try {
     var g = _radarGrob(pos.lat, pos.lng);
-    localStorage.setItem(RADAR_SPEICHER, JSON.stringify({ lat: g.lat, lng: g.lng, quelle: quelle }));
+    ebSpeichern(RADAR_SPEICHER, JSON.stringify({ lat: g.lat, lng: g.lng, quelle: quelle }));
   } catch (e) { /* Privater Modus: dann eben nur diese Sitzung. */ }
 }
 
@@ -7352,7 +7460,7 @@ function _markBookingAccepted(msgId) {
   try {
     var s = JSON.parse(localStorage.getItem('eb_accepted_bookings') || '[]');
     var k = _acceptedBookingKey(msgId);
-    if (s.indexOf(k) === -1) { s.push(k); localStorage.setItem('eb_accepted_bookings', JSON.stringify(s)); }
+    if (s.indexOf(k) === -1) { s.push(k); ebSpeichern('eb_accepted_bookings', JSON.stringify(s)); }
   } catch (e) {}
 }
 function _isBookingAccepted(msgId) {
@@ -10706,7 +10814,7 @@ function initDarkMode() {
 }
 
 function toggleDarkMode(on) {
-  localStorage.setItem('eb_dark_mode', on ? '1' : '0');
+  ebSpeichern('eb_dark_mode', on ? '1' : '0');
   _applyDarkMode(on);
   var icon = document.getElementById('darkModeIcon');
   var label = document.getElementById('darkModeLabel');
@@ -12989,7 +13097,7 @@ function _stripeOnboardingPromptRecentlyShown(context) {
 
 function _markStripeOnboardingPromptShown(context) {
   var key = _stripeOnboardingPromptStorageKey(context);
-  if (key) localStorage.setItem(key, String(Date.now()));
+  if (key) ebSpeichern(key, String(Date.now()));
 }
 
 function _stripeOnboardingModalVisible() {
@@ -13068,7 +13176,7 @@ function dismissStripeOnboardingPrompt() {
 
 function dismissPasskeySetupPrompt() {
   var storageKey = _passkeyPromptStorageKey();
-  if (storageKey) localStorage.setItem(storageKey, '1');
+  if (storageKey) ebSpeichern(storageKey, '1');
   closeModal('passkeySetupModal');
 }
 
@@ -14925,7 +15033,7 @@ function _ebKbNoteMiss(q) {
     if (!q) return;
     _ebKbMiss.push({ q: String(q).slice(0, 140), t: Date.now() });
     if (_ebKbMiss.length > 50) _ebKbMiss.shift();
-    localStorage.setItem('eb_kb_misses', JSON.stringify(_ebKbMiss));
+    ebSpeichern('eb_kb_misses', JSON.stringify(_ebKbMiss));
   } catch (e) {}
 }
 
@@ -15152,33 +15260,74 @@ function toggleCookieDetails() {
   }
 }
 
-function _saveCookieConsent() {
+/**
+ * Die Antwort festhalten — und sie sofort wirksam machen.
+ *
+ * Vorher schrieb diese Funktion immer dasselbe (`analytics:false,
+ * marketing:false`), weil der Banner nur einen Knopf hatte. Die Antwort war
+ * damit keine Wahl, und gelesen hat sie ohnehin niemand: `eb_taste_v1`
+ * (Präferenzprofil) und `eb_radar_ort` (Standort) wurden unabhängig davon
+ * gesetzt. Der Banner behauptete gleichzeitig „ausschließlich technisch
+ * notwendige Cookies".
+ *
+ * @param {boolean} erlaubt  true = Komfort und Vorschläge zugelassen
+ */
+function _saveCookieConsent(erlaubt) {
   localStorage.setItem('eb_cookie_consent', JSON.stringify({
+    v: 2,
     necessary: true,
+    funktional: !!erlaubt,
+    profil: !!erlaubt,
+    // Wir setzen weiterhin weder Analyse- noch Marketing-Cookies. Die Felder
+    // bleiben, damit eine aeltere Antwort lesbar bleibt.
     analytics: false,
     marketing: false,
     timestamp: new Date().toISOString()
   }));
+  // Art. 7 Abs. 3 DSGVO: Widerruf so einfach wie Erteilung. Ohne das
+  // Aufraeumen bliebe alles liegen, was VOR dem Widerruf gespeichert wurde —
+  // und der Widerruf waere fuer genau die Daten wirkungslos, um die es geht.
+  if (typeof ebSpeicherAufraeumen === 'function') ebSpeicherAufraeumen();
   var banner = document.getElementById('cookieBanner');
   if (banner) banner.classList.remove('show');
 }
 
-function initCookieConsent() {
-  var consent = _getCookieConsent();
-  if (consent) return; // already answered
-
+/** Aus dem Fußbereich erneut aufrufbar — Schritt 5 der Bannerlogik. */
+function openCookieSettings() {
   var banner = document.getElementById('cookieBanner');
   if (!banner) return;
+  banner.classList.add('show');
+  _bindCookieButtons();
+  var erster = document.getElementById('cookieRejectAll');
+  if (erster) erster.focus();
+}
 
-  // Show banner with slight delay for smooth entry
-  setTimeout(function() { banner.classList.add('show'); }, 400);
+function _bindCookieButtons() {
+  [['cookieAcceptAll', true], ['cookieRejectAll', false]].forEach(function(paar) {
+    var btn = document.getElementById(paar[0]);
+    // Ohne diese Marke haengt bei jedem Oeffnen der Einstellungen ein
+    // weiterer Handler am selben Knopf.
+    if (!btn || btn.dataset.ebGebunden === '1') return;
+    btn.dataset.ebGebunden = '1';
+    btn.addEventListener('click', function() { _saveCookieConsent(paar[1]); });
+  });
+}
 
-  var acceptBtn = document.getElementById('cookieAcceptAll');
-  if (acceptBtn) {
-    acceptBtn.addEventListener('click', function() {
-      _saveCookieConsent();
-    });
+function initCookieConsent() {
+  var banner = document.getElementById('cookieBanner');
+  if (!banner) return;
+  _bindCookieButtons();
+
+  var consent = _getCookieConsent();
+  if (consent) {
+    // Schon beantwortet. Trotzdem aufraeumen: die Antwort kann aus einer Zeit
+    // stammen, in der noch niemand sie gelesen hat — dann liegt hier Zeug,
+    // das sie nie gedeckt hat.
+    if (typeof ebSpeicherAufraeumen === 'function') ebSpeicherAufraeumen();
+    return;
   }
+
+  setTimeout(function() { banner.classList.add('show'); }, 400);
 }
 
 // ========== UPDATE NOTIFICATION ==========
@@ -15749,7 +15898,7 @@ function _loadBoardTombstones() {
 function _saveBoardTombstones() {
   var k = _boardTombstoneStorageKey();
   if (!k) return;
-  try { localStorage.setItem(k, JSON.stringify(_boardTombstones)); } catch(e) {}
+  try { ebSpeichern(k, JSON.stringify(_boardTombstones)); } catch(e) {}
 }
 
 function _addBoardTombstone(id) {
@@ -15865,7 +16014,7 @@ function _migrateBoardProjects() {
   if (!localStorage.getItem(newKey)) {
     var old = localStorage.getItem('eb_board_projects');
     if (old && old !== '[]') {
-      localStorage.setItem(newKey, old);
+      ebSpeichern(newKey, old);
     }
   }
   // Clean up old global key
@@ -15878,7 +16027,7 @@ function _loadBoardProjects() {
   // 1) Schneller Cache: lokal geladene Projekte sofort anzeigen
   _boardProjects = key ? JSON.parse(localStorage.getItem(key) || '[]') : [];
   if (_migrateBoardStageModel(_boardProjects) && key) {
-    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch (e) {}
+    try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch (e) {}
   }
   // Lokal bereits getombstoned? Raus damit.
   if (_boardTombstones.length) {
@@ -16050,7 +16199,7 @@ function _syncBoardFromServer(opts) {
         _notifyBoardTransitions(_preSyncSnapshot, _boardProjects);
       }
       if (key) {
-        try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch(e) {}
+        try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch(e) {}
       }
       if (res.uploadNeeded) {
         console.info('[Board] Lokale Änderungen werden zum Server synchronisiert.');
@@ -16263,7 +16412,7 @@ function _saveBoardProjects(opts) {
   }
   var key = _boardStorageKey();
   if (key) {
-    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch(e) {}
+    try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch(e) {}
   }
   if (!currentUser) return;
   _boardDirty = true;
@@ -23092,7 +23241,7 @@ var _socialPosts = (function() {
     _socialPosts.forEach(function(p) {
       if (p && p._isDemo && tpl[p.id] && p.time !== tpl[p.id]) { p.time = tpl[p.id]; changed = true; }
     });
-    if (changed) { try { localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {} }
+    if (changed) { try { ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {} }
   } catch (e) {}
 })();
 
@@ -23135,8 +23284,8 @@ function _visibleSocialPosts() {
 var _likedPosts = new Set(JSON.parse(localStorage.getItem('eb_liked_posts') || '[]'));
 
 function _saveSocialData() {
-  localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts));
-  localStorage.setItem('eb_liked_posts', JSON.stringify([..._likedPosts]));
+  ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts));
+  ebSpeichern('eb_liked_posts', JSON.stringify([..._likedPosts]));
 }
 
 function _generateDemoSocialPosts() {
@@ -23433,7 +23582,7 @@ function _applyDemoFeed(posts, accounts) {
     };
   });
   _socialPosts = eigene.concat(neue);
-  try { localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {}
+  try { ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {}
 
   // Inserats-Zeiten hängen am selben Anker — sonst driften Feed und Karten.
   try {
@@ -23713,7 +23862,7 @@ function _demoCommentSeed() {
 }
 function _seedDemoComments() {
   var seed = _demoCommentSeed();
-  try { localStorage.setItem('eb_post_comments', JSON.stringify(seed)); } catch (e) {}
+  try { ebSpeichern('eb_post_comments', JSON.stringify(seed)); } catch (e) {}
   return seed;
 }
 // Bestehende (evtl. veraltete) Demo-Kommentar-Zeiten auf die festen Anker-Zeiten
@@ -23732,7 +23881,7 @@ function _seedDemoComments() {
   } catch (e) {}
 })();
 function _savePostComments() {
-  try { localStorage.setItem('eb_post_comments', JSON.stringify(_postComments)); } catch (e) {}
+  try { ebSpeichern('eb_post_comments', JSON.stringify(_postComments)); } catch (e) {}
 }
 function _postCommentCount(postId) {
   var arr = _postComments[postId];
@@ -25692,7 +25841,7 @@ function _aiLoad() {
   return _aiMsgs;
 }
 function _aiSave() {
-  try { localStorage.setItem(_aiKey(), JSON.stringify((_aiMsgs || []).slice(-60))); } catch (e) {}
+  try { ebSpeichern(_aiKey(), JSON.stringify((_aiMsgs || []).slice(-60))); } catch (e) {}
 }
 function _aiCtxProject() {
   if (_aiCtxProjectId) {

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-20T16:53:18.637Z",
+  "erzeugt": "2026-08-20T17:26:49.542Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/functions.php
+++ b/functions.php
@@ -519,6 +519,11 @@ function eb_serve_hq() {
         exit;
     }
     $html = str_replace( '__EB_HQ_REST_NONCE__', esc_js( wp_create_nonce( 'wp_rest' ) ), $html );
+    // Wer das HQ sieht, darf nicht automatisch Zugaenge vergeben: Mitarbeiter
+    // mit `eb_hq_access` sehen dieselbe Seite. Das Flag blendet die Maske aus.
+    // Die Sperre bleibt eb_hq_verwaltung_darf() auf der Route — dies hier ist
+    // Oberflaeche, keine Sicherheit.
+    $html = str_replace( '__EB_HQ_IST_ADMIN__', eb_hq_verwaltung_darf() ? '1' : '0', $html );
     echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- statische Datei + gezielt escapeter Nonce
     exit;
 }

--- a/hq.html
+++ b/hq.html
@@ -797,6 +797,32 @@
     </div>
     <div class="bereiche" id="bereiche-grid"></div>
 
+    <!-- Zugänge — nur für Administratoren.
+         Der Abschnitt wird per JS entfernt, wenn der Betrachter kein
+         Administrator ist. Serverseitig entscheidet ohnehin
+         eb_hq_verwaltung_darf(); das hier ist Oberfläche, keine Sperre. -->
+    <div id="zugang-block" hidden>
+      <div class="section-header" id="zugaenge">
+        <div class="section-title">🔑 Zugänge <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— wer ins HQ darf</span></div>
+      </div>
+      <div class="journal">
+        <p style="margin:0 0 14px;color:var(--muted);font-size:.86rem;line-height:1.55;">
+          Gibt einem <strong>bestehenden</strong> WordPress-Konto Zugang zum HQ — ohne Adminrechte,
+          also ohne Zugriff auf Inhalte, Nutzer oder Einstellungen. Beim ersten Aufruf von
+          <code>/hq</code> richtet die Person ihren Authenticator ein; ohne zweiten Faktor kommt
+          sie nicht hinein. Neue Konten legt bewusst ein Mensch in WordPress an, nicht diese Maske.
+        </p>
+        <form id="zugang-form" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;">
+          <input id="zugang-mail" type="email" required placeholder="E-Mail des Kontos"
+                 autocomplete="off" aria-label="E-Mail des Kontos"
+                 style="flex:1 1 260px;padding:9px 11px;border-radius:9px;border:1px solid var(--line);background:var(--bg);color:var(--fg);font-size:.9rem;">
+          <button type="submit" class="icon-btn with-label" id="zugang-geben">✓ Zugang geben</button>
+          <button type="button" class="icon-btn with-label" id="zugang-nehmen" style="color:#fca5a5;">✕ Zugang entziehen</button>
+        </form>
+        <div id="zugang-antwort" role="status" aria-live="polite" style="margin-top:12px;font-size:.87rem;"></div>
+      </div>
+    </div>
+
     <!-- Wartet auf dich -->
     <div class="wartet" id="wartet"></div>
 
@@ -984,6 +1010,10 @@ const ROLLBACK_WORKFLOW = 'hq-rollback.yml';
 // functions.php ersetzt den Platzhalter nur in der admin-geschuetzten,
 // nicht cachebaren /hq-Antwort. Lokal bleibt er harmloser Text.
 const HQ_REST_NONCE = '__EB_HQ_REST_NONCE__';
+// Wer das HQ sieht, darf nicht automatisch Zugaenge vergeben: Mitarbeiter mit
+// `eb_hq_access` sehen dieselbe Seite. functions.php ersetzt den Platzhalter
+// durch '1' oder '0'. Lokal bleibt er Text und faellt damit auf 'kein Admin'.
+const HQ_IST_ADMIN = '__EB_HQ_IST_ADMIN__' === '1';
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const state = {
@@ -4039,6 +4069,61 @@ window.addEventListener('DOMContentLoaded', init);
     if (e.key === 'Escape') close();
   });
   syncDialogControls();
+})();
+
+/* ═══ Zugänge vergeben ═════════════════════════════════════════════════
+   Bis hierher ging das nur per API-Aufruf von Hand. Eine Fähigkeit, die
+   niemand bedienen kann, wird nicht benutzt — und dann bekommt der Kollege
+   eben doch Adminrechte, weil das der einzige Knopf war.
+
+   Die Sperre sitzt auf dem Server (eb_hq_verwaltung_darf). Das Ausblenden
+   hier ist Höflichkeit, keine Sicherheit: ein Mitarbeiter mit eb_hq_access
+   sieht dieselbe Seite und soll keinen Knopf sehen, der ihm 403 antwortet.
+   ═══════════════════════════════════════════════════════════════════════ */
+(function () {
+  const block = document.getElementById('zugang-block');
+  if (!block) return;
+  if (!HQ_IST_ADMIN) { block.remove(); return; }
+  block.hidden = false;
+
+  const form = document.getElementById('zugang-form');
+  const mail = document.getElementById('zugang-mail');
+  const antwort = document.getElementById('zugang-antwort');
+
+  function melde(text, ok) {
+    antwort.textContent = text;
+    antwort.style.color = ok ? '#4ade80' : '#fca5a5';
+  }
+
+  async function senden(zugang) {
+    const email = (mail.value || '').trim();
+    if (!email) { melde('Bitte eine E-Mail eingeben.', false); return; }
+    melde('Wird gesendet…', true);
+    try {
+      const r = await fetch('/wp-json/eventboerse/v1/hq/mitarbeiter', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': HQ_REST_NONCE },
+        body: JSON.stringify({ email: email, zugang: zugang }),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) { melde(d.message || ('Fehlgeschlagen (' + r.status + ').'), false); return; }
+      // Den Hinweis des Servers durchreichen statt einen eigenen zu erfinden:
+      // ohne zweiten Faktor kommt der Mitarbeiter nicht hinein, und das soll
+      // er vorher wissen.
+      melde(
+        (zugang ? '✓ Zugang erteilt an ' : '✕ Zugang entzogen für ') + d.email +
+        (d.hinweis ? ' — ' + d.hinweis : (zugang && d.totp === false ? ' — Authenticator noch nicht eingerichtet.' : '')),
+        true,
+      );
+      if (!zugang) mail.value = '';
+    } catch (e) {
+      melde('Netzwerkfehler — nichts geändert.', false);
+    }
+  }
+
+  form.addEventListener('submit', function (e) { e.preventDefault(); senden(true); });
+  document.getElementById('zugang-nehmen').addEventListener('click', function () { senden(false); });
 })();
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -2732,26 +2732,30 @@
       <div class="container legal-page">
         <h1>Cookie-Richtlinie</h1>
         <p class="legal-date">Stand: 04. Mai 2026 · Versionsentwurf 1.0</p>
-        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Wir verwenden ausschließlich technisch notwendige Cookies gemäß § 25 Abs. 2 Nr. 2 TDDDG. Diese Richtlinie wird mit Eintragung der UG im Handelsregister verbindlich.</p>
+        <p class="legal-beta-note"><strong>Hinweis:</strong> Die Plattform befindet sich in einer Vorgründungs- und Beta-Phase. Technisch notwendige Speicherung erfolgt ohne Einwilligung (§ 25 Abs. 2 Nr. 2 TDDDG); Komfort- und Vorschlagsfunktionen nur nach Ihrer Zustimmung (§ 25 Abs. 1 TDDDG). Diese Richtlinie wird mit Eintragung der UG im Handelsregister verbindlich.</p>
         <p>Information nach § 25 TDDDG sowie Art. 13 DSGVO über eingesetzte Cookies und vergleichbare Technologien (localStorage, sessionStorage, IndexedDB, Web-Beacons).</p>
         <h2>1. Eingesetzte Cookies und Technologien</h2>
         <table class="legal-table">
           <thead><tr><th>Name / Zweck</th><th>Kategorie</th><th>Speicherdauer</th><th>Anbieter</th></tr></thead>
           <tbody>
-            <tr><td>PHPSESSID — Session-Cookie für Login</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
-            <tr><td>wp-* — WordPress-Funktion (Login, CSRF-Schutz)</td><td>Technisch erforderlich</td><td>Sitzung / 30 Tage</td><td>Eventbörse UG</td></tr>
-            <tr><td>eb_cookie_consent — Speicherung Banner-Auswahl</td><td>Technisch erforderlich</td><td>12 Monate</td><td>Eventbörse UG</td></tr>
-            <tr><td>XSRF-Token — Schutz vor CSRF</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
-            <tr><td>Stripe-Cookies (m, stripemid) — Betrugsabwehr</td><td>Technisch erforderlich (Zahlung)</td><td>Bis zu 12 Monate</td><td>Stripe Payments Europe Ltd.</td></tr>
+            <tr><td>wordpress_logged_in_*, wordpress_sec_* — Anmeldung und Sitzung</td><td>Technisch erforderlich</td><td>Sitzung</td><td>Eventbörse UG</td></tr>
+            <tr><td>wp-settings-* — Oberflächen-Einstellungen im Verwaltungsbereich</td><td>Funktional</td><td>1 Jahr</td><td>Eventbörse UG</td></tr>
+            <tr><td>Einmalcode während der Anmeldung (Browser-Sitzungsspeicher)</td><td>Technisch erforderlich</td><td>bis Ende der Sitzung</td><td>Eventbörse UG</td></tr>
+            <tr><td>Laufender Zahlungsvorgang (Browser-Speicher)</td><td>Technisch erforderlich (Zahlung)</td><td>bis Abschluss</td><td>Eventbörse UG</td></tr>
+            <tr><td>eb_cookie_consent — Ihre Antwort auf den Cookie-Hinweis</td><td>Technisch erforderlich</td><td>12 Monate</td><td>Eventbörse UG</td></tr>
+            <tr><td><strong>Komfort</strong> — Farbmodus, Favoriten, Planungsboard, eigene Beiträge und Kommentare, Gesprächsverlauf des Planungs-Assistenten, zuletzt gewählter Standort für die Umkreissuche (Browser-Speicher)</td><td><strong>Nur mit Einwilligung</strong></td><td>bis zum Widerruf</td><td>Eventbörse UG</td></tr>
+            <tr><td><strong>Vorschläge</strong> — aus Such- und Klickverhalten abgeleitete Vorlieben, unbeantwortete Fragen an den Hilfe-Assistenten (Browser-Speicher)</td><td><strong>Nur mit Einwilligung</strong></td><td>bis zum Widerruf</td><td>Eventbörse UG</td></tr>
+            <tr><td>Stripe (__stripe_mid, __stripe_sid) — Betrugsabwehr</td><td>Technisch erforderlich (Zahlung)</td><td>Bis zu 12 Monate</td><td>Stripe Payments Europe Ltd.</td></tr>
           </tbody>
         </table>
         <h2>2. Rechtsgrundlage</h2>
-        <p>Diese Cookies sind technisch erforderlich, um die angefragten Plattformfunktionen bereitzustellen (Login, Buchung, Bezahlung, Schutz vor Missbrauch). Wir setzen sie gemäß § 25 Abs. 2 Nr. 2 TDDDG ohne Einwilligung. Soweit eine Verarbeitung personenbezogener Daten verbunden ist: Art. 6 Abs. 1 lit. b oder f DSGVO.</p>
+        <p>Die als <em>technisch erforderlich</em> gekennzeichneten Einträge stellen die angefragten Plattformfunktionen bereit (Anmeldung, Buchung, Bezahlung, Schutz vor Missbrauch). Wir setzen sie gemäß § 25 Abs. 2 Nr. 2 TDDDG ohne Einwilligung. Soweit eine Verarbeitung personenbezogener Daten verbunden ist: Art. 6 Abs. 1 lit. b oder f DSGVO.</p>
+        <p>Alles, was mit <strong>„Nur mit Einwilligung“</strong> gekennzeichnet ist, wird erst gespeichert, wenn Sie im Cookie-Hinweis zugestimmt haben — Rechtsgrundlage § 25 Abs. 1 TDDDG i.V.m. Art. 6 Abs. 1 lit. a DSGVO. Lehnen Sie ab, bleibt es aus. Sie können Ihre Auswahl jederzeit über „Cookie-Einstellungen“ im Fußbereich ändern; ein Widerruf löscht auch das bereits Gespeicherte (Art. 7 Abs. 3 DSGVO). Diese Angaben verlassen Ihren Browser nicht.</p>
         <h2>3. Marketing- und Analyse-Cookies</h2>
         <p>Wir setzen aktuell <strong>keine</strong> Marketing-, Analyse- oder Tracking-Cookies ein. Sollten wir solche Dienste künftig aktivieren, holen wir vorab Ihre ausdrückliche Einwilligung gemäß § 25 Abs. 1 TDDDG i.V.m. Art. 6 Abs. 1 lit. a DSGVO über einen Consent-Banner ein.</p>
         <h2>4. Verwaltung Ihrer Browser-Einstellungen</h2>
         <p>Sie können Cookies in den Einstellungen Ihres Browsers jederzeit verwalten oder löschen. Die vollständige Deaktivierung kann dazu führen, dass Plattformfunktionen eingeschränkt nutzbar sind (insbesondere Login und Buchung).</p>
-        <p>Sie können <a href="#" onclick="event.preventDefault(); localStorage.removeItem('eb_cookie_consent'); if(typeof initCookieConsent==='function')initCookieConsent();">Ihre Cookie-Einstellungen jederzeit erneut aufrufen</a>.</p>
+        <p>Sie können <a href="#" onclick="event.preventDefault(); if(typeof openCookieSettings==='function')openCookieSettings();">Ihre Cookie-Einstellungen jederzeit erneut aufrufen</a>.</p>
       </div>
     </section>
 
@@ -3290,7 +3294,9 @@ Datum: ___________________________________________________
         <p>Bei jedem Aufruf erfassen wir: IP-Adresse (anonymisiert nach 7 Tagen), Datum/Uhrzeit, Zeitzonendifferenz, Inhalt der Anforderung, HTTP-Statuscode, übertragene Datenmenge, Referrer-URL, Browser, OS, Sprache. Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO.</p>
 
         <h2>5. Cookies und Endgeräte-Speicherung</h2>
-        <p>Wir setzen ausschließlich technisch notwendige Cookies ein (Session-Cookie nach Login, Cookie-Banner-Status). Rechtsgrundlage: § 25 Abs. 2 Nr. 2 TDDDG. Sonstige Cookies (Analyse, Marketing) werden derzeit nicht verwendet. Details: <a href="#" onclick="navigateTo('cookies');return false;">Cookie-Richtlinie</a>.</p>
+        <p><strong>Technisch notwendig</strong> — ohne Einwilligung, § 25 Abs. 2 Nr. 2 TDDDG: Anmeldung und Sitzung, Einmalcode bei der Anmeldung, ein laufender Zahlungsvorgang sowie Ihre Antwort auf den Cookie-Hinweis selbst.</p>
+        <p><strong>Nur mit Ihrer Einwilligung</strong> (§ 25 Abs. 1 TDDDG, Art. 6 Abs. 1 lit. a DSGVO) speichern wir zusätzlich im Speicher Ihres Browsers: <em>Komfort</em> — Farbmodus, Favoriten, Ihr Planungsboard, eigene Beiträge und Kommentare, den Gesprächsverlauf des Planungs-Assistenten sowie den zuletzt gewählten Standort für die Umkreissuche; und <em>Vorschläge</em> — aus Such- und Klickverhalten abgeleitete Vorlieben sowie unbeantwortete Fragen an den Hilfe-Assistenten. Lehnen Sie ab, wird nichts davon gespeichert; ein Widerruf löscht bereits Gespeichertes.</p>
+        <p>Diese Angaben liegen ausschließlich im Speicher Ihres Browsers und werden nicht an Dritte übertragen. <strong>Analyse- und Marketing-Cookies setzen wir nicht ein.</strong> Ihre Auswahl ändern Sie jederzeit über „Cookie-Einstellungen“ im Fußbereich. Details: <a href="#" onclick="navigateTo('cookies');return false;">Cookie-Richtlinie</a>.</p>
 
         <h2>6. Registrierung und Nutzerkonto</h2>
         <p>Verarbeitete Daten: Name, E-Mail, Passwort (gespeichert als Hash), Geburtsdatum (Altersnachweis), Postleitzahl/Ort, optional Telefonnummer und Profilbild. Zweck: Vertragsanbahnung/-durchführung, Authentifizierung. Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO. Speicherdauer: für die Dauer des Kontos; nach Löschung gemäß Löschkonzept (steuerrechtlich relevante Daten 6/10 Jahre).</p>
@@ -3435,7 +3441,7 @@ Datum: ___________________________________________________
           <a href="#" onclick="navigateTo('agb-dienstleister')">AGB Dienstleister</a>
           <a href="#" onclick="navigateTo('marktplatz')">Marktplatzbedingungen</a>
           <a href="#" onclick="navigateTo('widerruf')">Widerrufsbelehrung</a>
-          <a href="#" onclick="event.preventDefault(); localStorage.removeItem('eb_cookie_consent'); initCookieConsent();">Cookie-Einstellungen</a>
+          <a href="#" onclick="event.preventDefault(); openCookieSettings();">Cookie-Einstellungen</a>
         </div>
         <div class="footer-col">
           <h4>Plattform &amp; Compliance</h4>
@@ -4161,23 +4167,32 @@ Datum: ___________________________________________________
     <div class="cookie-banner-inner">
       <div class="cookie-banner-row">
         <p class="cookie-banner-msg">
-          Wir verwenden ausschließlich technisch notwendige Cookies (Login, CSRF-Schutz, Stripe). Keine Analyse- oder Marketing-Cookies.
+          Notwendiges speichern wir immer (Anmeldung, laufende Zahlung). Darüber hinaus möchten wir
+          <strong>Komfort</strong> merken — etwa Farbmodus, Favoriten und deine Planung — und aus deinen
+          Suchen <strong>Vorschläge</strong> ableiten. Beides nur mit deiner Zustimmung.
           <button type="button" class="cookie-banner-link" onclick="toggleCookieDetails()" aria-expanded="false" id="cookieDetailsToggle">Details anzeigen</button>
         </p>
-        <button class="btn-primary btn-sm" id="cookieAcceptAll">Verstanden</button>
+        <div class="cookie-banner-actions">
+          <button class="btn-secondary btn-sm" id="cookieRejectAll">Nur Notwendiges</button>
+          <button class="btn-primary btn-sm" id="cookieAcceptAll">Alles erlauben</button>
+        </div>
       </div>
       <div class="cookie-banner-details" id="cookieBannerDetails" hidden>
         <table class="cookie-banner-table">
-          <thead><tr><th>Cookie</th><th>Zweck</th><th>Dauer</th></tr></thead>
+          <thead><tr><th>Was</th><th>Wozu</th><th>Ohne Zustimmung</th></tr></thead>
           <tbody>
-            <tr><td>PHPSESSID</td><td>Session-Login</td><td>Sitzung</td></tr>
-            <tr><td>wp-*</td><td>WordPress / CSRF</td><td>Sitzung–30 Tage</td></tr>
-            <tr><td>eb_cookie_consent</td><td>Banner-Auswahl</td><td>12 Monate</td></tr>
-            <tr><td>XSRF-Token</td><td>CSRF-Schutz</td><td>Sitzung</td></tr>
-            <tr><td>Stripe (m, stripemid)</td><td>Betrugsabwehr</td><td>bis 12 Monate</td></tr>
+            <tr><td>Anmeldung &amp; Sitzung</td><td>angemeldet bleiben, Einmalcode</td><td>wird gespeichert</td></tr>
+            <tr><td>Laufende Zahlung</td><td>Checkout über Stripe zu Ende führen</td><td>wird gespeichert</td></tr>
+            <tr><td>Diese Auswahl</td><td>damit wir nicht erneut fragen</td><td>wird gespeichert</td></tr>
+            <tr><td>Komfort</td><td>Farbmodus, Favoriten, Planungsboard, eigene Beiträge, Chatverlauf des Assistenten, zuletzt gewählter Umkreis-Standort</td><td>bleibt aus</td></tr>
+            <tr><td>Vorschläge</td><td>Vorlieben aus Such- und Klickverhalten, offene Fragen an den KI-Bot</td><td>bleibt aus</td></tr>
           </tbody>
         </table>
-        <p class="cookie-banner-legal">Rechtsgrundlage: § 25 Abs. 2 Nr. 2 TDDDG sowie Art. 6 Abs. 1 lit. b/f DSGVO.</p>
+        <p class="cookie-banner-legal">
+          Alles bleibt in deinem Browser — nichts davon wird an Dritte übertragen. Du kannst die Auswahl
+          jederzeit über „Cookie-Einstellungen“ im Fußbereich ändern; ein Widerruf löscht das bereits
+          Gespeicherte. Rechtsgrundlage: § 25 TDDDG, Art. 6 Abs. 1 lit. a/b/f DSGVO.
+        </p>
       </div>
     </div>
   </div>

--- a/js/modules/ai/50-planungs-assistent.js
+++ b/js/modules/ai/50-planungs-assistent.js
@@ -40,7 +40,7 @@ function _aiLoad() {
   return _aiMsgs;
 }
 function _aiSave() {
-  try { localStorage.setItem(_aiKey(), JSON.stringify((_aiMsgs || []).slice(-60))); } catch (e) {}
+  try { ebSpeichern(_aiKey(), JSON.stringify((_aiMsgs || []).slice(-60))); } catch (e) {}
 }
 function _aiCtxProject() {
   if (_aiCtxProjectId) {

--- a/js/modules/board/40-board-kanban.js
+++ b/js/modules/board/40-board-kanban.js
@@ -31,7 +31,7 @@ function _loadBoardTombstones() {
 function _saveBoardTombstones() {
   var k = _boardTombstoneStorageKey();
   if (!k) return;
-  try { localStorage.setItem(k, JSON.stringify(_boardTombstones)); } catch(e) {}
+  try { ebSpeichern(k, JSON.stringify(_boardTombstones)); } catch(e) {}
 }
 
 function _addBoardTombstone(id) {
@@ -147,7 +147,7 @@ function _migrateBoardProjects() {
   if (!localStorage.getItem(newKey)) {
     var old = localStorage.getItem('eb_board_projects');
     if (old && old !== '[]') {
-      localStorage.setItem(newKey, old);
+      ebSpeichern(newKey, old);
     }
   }
   // Clean up old global key
@@ -160,7 +160,7 @@ function _loadBoardProjects() {
   // 1) Schneller Cache: lokal geladene Projekte sofort anzeigen
   _boardProjects = key ? JSON.parse(localStorage.getItem(key) || '[]') : [];
   if (_migrateBoardStageModel(_boardProjects) && key) {
-    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch (e) {}
+    try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch (e) {}
   }
   // Lokal bereits getombstoned? Raus damit.
   if (_boardTombstones.length) {
@@ -332,7 +332,7 @@ function _syncBoardFromServer(opts) {
         _notifyBoardTransitions(_preSyncSnapshot, _boardProjects);
       }
       if (key) {
-        try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch(e) {}
+        try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch(e) {}
       }
       if (res.uploadNeeded) {
         console.info('[Board] Lokale Änderungen werden zum Server synchronisiert.');
@@ -545,7 +545,7 @@ function _saveBoardProjects(opts) {
   }
   var key = _boardStorageKey();
   if (key) {
-    try { localStorage.setItem(key, JSON.stringify(_boardProjects)); } catch(e) {}
+    try { ebSpeichern(key, JSON.stringify(_boardProjects)); } catch(e) {}
   }
   if (!currentUser) return;
   _boardDirty = true;

--- a/js/modules/board/42-guide-social-feed.js
+++ b/js/modules/board/42-guide-social-feed.js
@@ -904,7 +904,7 @@ var _socialPosts = (function() {
     _socialPosts.forEach(function(p) {
       if (p && p._isDemo && tpl[p.id] && p.time !== tpl[p.id]) { p.time = tpl[p.id]; changed = true; }
     });
-    if (changed) { try { localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {} }
+    if (changed) { try { ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {} }
   } catch (e) {}
 })();
 
@@ -947,8 +947,8 @@ function _visibleSocialPosts() {
 var _likedPosts = new Set(JSON.parse(localStorage.getItem('eb_liked_posts') || '[]'));
 
 function _saveSocialData() {
-  localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts));
-  localStorage.setItem('eb_liked_posts', JSON.stringify([..._likedPosts]));
+  ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts));
+  ebSpeichern('eb_liked_posts', JSON.stringify([..._likedPosts]));
 }
 
 function _generateDemoSocialPosts() {
@@ -1245,7 +1245,7 @@ function _applyDemoFeed(posts, accounts) {
     };
   });
   _socialPosts = eigene.concat(neue);
-  try { localStorage.setItem('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {}
+  try { ebSpeichern('eb_social_posts', JSON.stringify(_socialPosts)); } catch (e) {}
 
   // Inserats-Zeiten hängen am selben Anker — sonst driften Feed und Karten.
   try {
@@ -1525,7 +1525,7 @@ function _demoCommentSeed() {
 }
 function _seedDemoComments() {
   var seed = _demoCommentSeed();
-  try { localStorage.setItem('eb_post_comments', JSON.stringify(seed)); } catch (e) {}
+  try { ebSpeichern('eb_post_comments', JSON.stringify(seed)); } catch (e) {}
   return seed;
 }
 // Bestehende (evtl. veraltete) Demo-Kommentar-Zeiten auf die festen Anker-Zeiten
@@ -1544,7 +1544,7 @@ function _seedDemoComments() {
   } catch (e) {}
 })();
 function _savePostComments() {
-  try { localStorage.setItem('eb_post_comments', JSON.stringify(_postComments)); } catch (e) {}
+  try { ebSpeichern('eb_post_comments', JSON.stringify(_postComments)); } catch (e) {}
 }
 function _postCommentCount(postId) {
   var arr = _postComments[postId];

--- a/js/modules/chat/20-chat-nachrichten.js
+++ b/js/modules/chat/20-chat-nachrichten.js
@@ -472,7 +472,7 @@ function _markBookingAccepted(msgId) {
   try {
     var s = JSON.parse(localStorage.getItem('eb_accepted_bookings') || '[]');
     var k = _acceptedBookingKey(msgId);
-    if (s.indexOf(k) === -1) { s.push(k); localStorage.setItem('eb_accepted_bookings', JSON.stringify(s)); }
+    if (s.indexOf(k) === -1) { s.push(k); ebSpeichern('eb_accepted_bookings', JSON.stringify(s)); }
   } catch (e) {}
 }
 function _isBookingAccepted(msgId) {

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -598,3 +598,111 @@ function ebPrepareImageFiles(files, opts) {
     });
   }, Promise.resolve()).then(function() { return out; });
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   SPEICHER UND EINWILLIGUNG (TDDDG § 25)
+
+   Bis zum 20.08.2026 wurde die Einwilligung erhoben und von KEINER
+   schreibenden Stelle gelesen. Der Banner sagte zusätzlich „ausschließlich
+   technisch notwendige Cookies" — während `eb_taste_v1` ein Präferenzprofil
+   aus dem Klickverhalten ablegte und `eb_radar_ort` den Standort. Das war
+   nicht nur eine wirkungslose Einwilligung, sondern eine falsche Aussage
+   gegenüber Nutzern.
+
+   Seitdem entscheidet die Antwort wirklich. Drei Klassen, eine Quelle:
+
+     essenziell   Anmeldung, laufende Zahlung, die Einwilligung selbst.
+                  Ohne sie funktioniert die Plattform nicht — keine
+                  Einwilligung nötig (§ 25 Abs. 2 Nr. 2 TDDDG).
+     funktional   Komfort und selbst angelegte Inhalte.
+     profil       leitet aus Verhalten Vorlieben ab. Immer einwilligungspflichtig.
+
+   Diese Tabelle ist die Codeseite von vault/40-Governance/Legal/Cookie-Liste.md.
+   `node scripts/recht.mjs --check` vergleicht beide und bricht ab, sobald ein
+   Schlüssel hier oder dort fehlt — eine Klassifizierung, die nur in einer
+   Prosa-Notiz steht, wird beim nächsten Feature vergessen.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+var EB_SPEICHER_KLASSEN = {
+  eb_cookie_consent: 'essenziell',
+  eb_user: 'essenziell',
+  eb_demo_session: 'essenziell',
+  eb_demo_users: 'essenziell',
+  eb_demo_passkeys: 'essenziell',
+  eb_pending_payment: 'essenziell',
+  eventboerse_pending_login_otp: 'essenziell',
+
+  eb_dark_mode: 'funktional',
+  eb_favs_: 'funktional',
+  eb_board_projects: 'funktional',
+  eb_board_projects_: 'funktional',
+  eb_board_tombstones_: 'funktional',
+  eb_accepted_bookings: 'funktional',
+  eb_social_posts: 'funktional',
+  eb_post_comments: 'funktional',
+  eb_liked_posts: 'funktional',
+  eb_nav_search: 'funktional',
+  eb_passkey_prompt_dismissed_: 'funktional',
+  eb_stripe_onboarding_prompt_: 'funktional',
+  eb_ai_chat_v1_: 'funktional',
+  eb_radar_ort: 'funktional',
+
+  eb_kb_misses: 'profil',
+  eb_taste_v1: 'profil'
+};
+
+/**
+ * Klasse eines Schlüssels. Längster passender Eintrag gewinnt, damit
+ * `eb_board_projects_17` nicht am kürzeren `eb_board_projects` hängen bleibt.
+ *
+ * Unbekannt heißt 'profil', nicht 'essenziell': ein neuer Schlüssel, den
+ * niemand eingeordnet hat, wird zurückhaltend behandelt statt großzügig.
+ * Der Fehler faellt dann in der Oberflaeche auf — und nicht erst, wenn
+ * jemand fragt, warum ohne Einwilligung Daten liegen.
+ */
+function ebSpeicherKlasse(key) {
+  var k = String(key || '');
+  var treffer = '';
+  for (var muster in EB_SPEICHER_KLASSEN) {
+    if (!Object.prototype.hasOwnProperty.call(EB_SPEICHER_KLASSEN, muster)) continue;
+    if (k === muster || k.indexOf(muster) === 0) {
+      if (muster.length > treffer.length) treffer = muster;
+    }
+  }
+  return treffer ? EB_SPEICHER_KLASSEN[treffer] : 'profil';
+}
+
+/** Darf dieser Schlüssel gerade geschrieben werden? */
+function ebDarfSpeichern(key) {
+  if (ebSpeicherKlasse(key) === 'essenziell') return true;
+  var c = (typeof _getCookieConsent === 'function') ? _getCookieConsent() : null;
+  // Vor der Antwort wird nichts Nicht-Essenzielles gesetzt. Das ist Schritt 2
+  // der dokumentierten Bannerlogik, der vorher fehlte.
+  if (!c) return false;
+  return ebSpeicherKlasse(key) === 'profil' ? !!c.profil : !!c.funktional;
+}
+
+/** Schreiben, wenn erlaubt. Gibt zurück, ob wirklich geschrieben wurde. */
+function ebSpeichern(key, wert) {
+  if (!ebDarfSpeichern(key)) return false;
+  try { localStorage.setItem(key, wert); return true; } catch (e) { return false; }
+}
+
+/**
+ * Alles wegräumen, was die aktuelle Antwort nicht mehr deckt.
+ *
+ * Ohne diesen Schritt wäre ein Widerruf wirkungslos für alles, was vor dem
+ * Widerruf schon dalag — und genau das ist der Punkt an Art. 7 Abs. 3 DSGVO:
+ * Widerruf so einfach wie Erteilung.
+ */
+function ebSpeicherAufraeumen() {
+  var weg = [];
+  try {
+    for (var i = 0; i < localStorage.length; i++) {
+      var k = localStorage.key(i);
+      if (k && !ebDarfSpeichern(k)) weg.push(k);
+    }
+    weg.forEach(function(k) { try { localStorage.removeItem(k); } catch (e) {} });
+  } catch (e) { /* privater Modus o. Ä. — dann liegt ohnehin nichts */ }
+  return weg;
+}

--- a/js/modules/core/02-router-navigation.js
+++ b/js/modules/core/02-router-navigation.js
@@ -112,7 +112,7 @@ function forceBrowsePage() {
 
 function _saveFavoritesToStorage() {
   var key = currentUser ? 'eb_favs_' + currentUser.id : 'eb_favs_guest';
-  try { localStorage.setItem(key, JSON.stringify([...favorites])); } catch(e) {}
+  try { ebSpeichern(key, JSON.stringify([...favorites])); } catch(e) {}
 }
 
 function _loadFavoritesFromStorage() {

--- a/js/modules/core/30-auth.js
+++ b/js/modules/core/30-auth.js
@@ -522,7 +522,7 @@ function _stripeOnboardingPromptRecentlyShown(context) {
 
 function _markStripeOnboardingPromptShown(context) {
   var key = _stripeOnboardingPromptStorageKey(context);
-  if (key) localStorage.setItem(key, String(Date.now()));
+  if (key) ebSpeichern(key, String(Date.now()));
 }
 
 function _stripeOnboardingModalVisible() {
@@ -601,7 +601,7 @@ function dismissStripeOnboardingPrompt() {
 
 function dismissPasskeySetupPrompt() {
   var storageKey = _passkeyPromptStorageKey();
-  if (storageKey) localStorage.setItem(storageKey, '1');
+  if (storageKey) ebSpeichern(storageKey, '1');
   closeModal('passkeySetupModal');
 }
 

--- a/js/modules/search/10-karten-home-feed.js
+++ b/js/modules/search/10-karten-home-feed.js
@@ -6,7 +6,7 @@ function renderListingCard(listing) {
   return `
     <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
-        <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bilder: ${_escHtml(listing.title)}">
+        <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bildergalerie: ${_escHtml(listing.title)}">
           ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
         </div>
         ${imgs.length > 1 ? '<button class="grid-gallery-arrow prev" aria-label="Vorheriges Bild" data-gallery-id="' + listing.id + '" data-dir="-1"><span class="material-icons-round">chevron_left</span></button><button class="grid-gallery-arrow next" aria-label="Nächstes Bild" data-gallery-id="' + listing.id + '" data-dir="1"><span class="material-icons-round">chevron_right</span></button><div class="grid-gallery-dots" id="gridGalleryDots_' + listing.id + '" role="group" aria-label="Bildauswahl">' + imgs.map(function(_, i) { return '<button class="grid-gallery-dot' + (i === 0 ? ' active' : '') + '" data-gallery-id="' + listing.id + '" data-idx="' + i + '" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') + '</div>' : ''}

--- a/js/modules/search/11-suche-ki.js
+++ b/js/modules/search/11-suche-ki.js
@@ -68,7 +68,7 @@ function _ebTasteSave() {
             .slice(max).forEach(function(k) { delete t[bucket][k]; });
       }
     });
-    localStorage.setItem(EB_TASTE_KEY, JSON.stringify(t));
+    ebSpeichern(EB_TASTE_KEY, JSON.stringify(t));
   } catch (e) {}
 }
 

--- a/js/modules/search/13-event-radar.js
+++ b/js/modules/search/13-event-radar.js
@@ -69,7 +69,7 @@ function _radarGrob(lat, lng) {
 function _radarMerken(pos, quelle) {
   try {
     var g = _radarGrob(pos.lat, pos.lng);
-    localStorage.setItem(RADAR_SPEICHER, JSON.stringify({ lat: g.lat, lng: g.lng, quelle: quelle }));
+    ebSpeichern(RADAR_SPEICHER, JSON.stringify({ lat: g.lat, lng: g.lng, quelle: quelle }));
   } catch (e) { /* Privater Modus: dann eben nur diese Sitzung. */ }
 }
 

--- a/js/modules/ui/23-darkmode-staedte-picker.js
+++ b/js/modules/ui/23-darkmode-staedte-picker.js
@@ -7,7 +7,7 @@ function initDarkMode() {
 }
 
 function toggleDarkMode(on) {
-  localStorage.setItem('eb_dark_mode', on ? '1' : '0');
+  ebSpeichern('eb_dark_mode', on ? '1' : '0');
   _applyDarkMode(on);
   var icon = document.getElementById('darkModeIcon');
   var label = document.getElementById('darkModeLabel');

--- a/js/modules/ui/31-modals-toast-qabot.js
+++ b/js/modules/ui/31-modals-toast-qabot.js
@@ -394,7 +394,7 @@ function _ebKbNoteMiss(q) {
     if (!q) return;
     _ebKbMiss.push({ q: String(q).slice(0, 140), t: Date.now() });
     if (_ebKbMiss.length > 50) _ebKbMiss.shift();
-    localStorage.setItem('eb_kb_misses', JSON.stringify(_ebKbMiss));
+    ebSpeichern('eb_kb_misses', JSON.stringify(_ebKbMiss));
   } catch (e) {}
 }
 

--- a/js/modules/ui/32-consent-init-map.js
+++ b/js/modules/ui/32-consent-init-map.js
@@ -24,33 +24,74 @@ function toggleCookieDetails() {
   }
 }
 
-function _saveCookieConsent() {
+/**
+ * Die Antwort festhalten — und sie sofort wirksam machen.
+ *
+ * Vorher schrieb diese Funktion immer dasselbe (`analytics:false,
+ * marketing:false`), weil der Banner nur einen Knopf hatte. Die Antwort war
+ * damit keine Wahl, und gelesen hat sie ohnehin niemand: `eb_taste_v1`
+ * (Präferenzprofil) und `eb_radar_ort` (Standort) wurden unabhängig davon
+ * gesetzt. Der Banner behauptete gleichzeitig „ausschließlich technisch
+ * notwendige Cookies".
+ *
+ * @param {boolean} erlaubt  true = Komfort und Vorschläge zugelassen
+ */
+function _saveCookieConsent(erlaubt) {
   localStorage.setItem('eb_cookie_consent', JSON.stringify({
+    v: 2,
     necessary: true,
+    funktional: !!erlaubt,
+    profil: !!erlaubt,
+    // Wir setzen weiterhin weder Analyse- noch Marketing-Cookies. Die Felder
+    // bleiben, damit eine aeltere Antwort lesbar bleibt.
     analytics: false,
     marketing: false,
     timestamp: new Date().toISOString()
   }));
+  // Art. 7 Abs. 3 DSGVO: Widerruf so einfach wie Erteilung. Ohne das
+  // Aufraeumen bliebe alles liegen, was VOR dem Widerruf gespeichert wurde —
+  // und der Widerruf waere fuer genau die Daten wirkungslos, um die es geht.
+  if (typeof ebSpeicherAufraeumen === 'function') ebSpeicherAufraeumen();
   var banner = document.getElementById('cookieBanner');
   if (banner) banner.classList.remove('show');
 }
 
-function initCookieConsent() {
-  var consent = _getCookieConsent();
-  if (consent) return; // already answered
-
+/** Aus dem Fußbereich erneut aufrufbar — Schritt 5 der Bannerlogik. */
+function openCookieSettings() {
   var banner = document.getElementById('cookieBanner');
   if (!banner) return;
+  banner.classList.add('show');
+  _bindCookieButtons();
+  var erster = document.getElementById('cookieRejectAll');
+  if (erster) erster.focus();
+}
 
-  // Show banner with slight delay for smooth entry
-  setTimeout(function() { banner.classList.add('show'); }, 400);
+function _bindCookieButtons() {
+  [['cookieAcceptAll', true], ['cookieRejectAll', false]].forEach(function(paar) {
+    var btn = document.getElementById(paar[0]);
+    // Ohne diese Marke haengt bei jedem Oeffnen der Einstellungen ein
+    // weiterer Handler am selben Knopf.
+    if (!btn || btn.dataset.ebGebunden === '1') return;
+    btn.dataset.ebGebunden = '1';
+    btn.addEventListener('click', function() { _saveCookieConsent(paar[1]); });
+  });
+}
 
-  var acceptBtn = document.getElementById('cookieAcceptAll');
-  if (acceptBtn) {
-    acceptBtn.addEventListener('click', function() {
-      _saveCookieConsent();
-    });
+function initCookieConsent() {
+  var banner = document.getElementById('cookieBanner');
+  if (!banner) return;
+  _bindCookieButtons();
+
+  var consent = _getCookieConsent();
+  if (consent) {
+    // Schon beantwortet. Trotzdem aufraeumen: die Antwort kann aus einer Zeit
+    // stammen, in der noch niemand sie gelesen hat — dann liegt hier Zeug,
+    // das sie nie gedeckt hat.
+    if (typeof ebSpeicherAufraeumen === 'function') ebSpeicherAufraeumen();
+    return;
   }
+
+  setTimeout(function() { banner.classList.add('show'); }, 400);
 }
 
 // ========== UPDATE NOTIFICATION ==========

--- a/scripts/recht.mjs
+++ b/scripts/recht.mjs
@@ -250,9 +250,32 @@ export function schluesselFinden(quelle, datei = '', funktionen = null) {
   const fn = funktionen || funktionenAufloesen(funktionenSammeln(text));
   const leer = new Map();
 
-  const aufruf = /\b(localStorage|sessionStorage)\s*\.\s*(?:setItem|getItem|removeItem)\s*\(/g;
+  // Die Huellen selbst benennen keinen Schluessel — sie nehmen einen entgegen.
+  //
+  // `ebSpeichern(key, wert)` enthaelt `localStorage.setItem(key, wert)`, und
+  // `key` ist dort ein Parameter. Der Aufloeser suchte die naechstgelegene
+  // Zuweisung an `key` und fand `var key = kind === 'media' ? 'aiMedia…'`
+  // aus einer voellig anderen Funktion weiter oben in derselben Datei — und
+  // meldete `aiMediaDisclosure` als Speicherschluessel. Wer die Huellen
+  // mitliest, bekommt Schluessel, die es nicht gibt.
+  const huellen = ['ebSpeichern', 'ebDarfSpeichern', 'ebSpeicherKlasse', 'ebSpeicherAufraeumen'];
+  const gesperrt = [];
+  for (const name of huellen) {
+    const von = text.indexOf(`function ${name}(`);
+    if (von === -1) continue;
+    const rumpf = text.slice(von);
+    const bis = rumpf.indexOf('\n}');
+    gesperrt.push([von, von + (bis === -1 ? rumpf.length : bis + 2)]);
+  }
+  const inHuelle = (i) => gesperrt.some(([a, b]) => i >= a && i < b);
+
+  // `ebSpeichern(` zaehlt als Schreibstelle: seit der Einwilligung laufen die
+  // nicht-essenziellen Schluessel darueber, und ein Pruefer, der nur
+  // localStorage.setItem kennt, saehe sie ab sofort gar nicht mehr.
+  const aufruf = /\b(?:(localStorage|sessionStorage)\s*\.\s*(?:setItem|getItem|removeItem)|(ebSpeichern))\s*\(/g;
   for (const m of text.matchAll(aufruf)) {
-    const speicher = m[1];
+    if (inHuelle(m.index)) continue;
+    const speicher = m[1] || 'localStorage';
     const arg = erstesArgument(text, m.index + m[0].length);
     let keys = arg === null ? null : aufloesen(arg, leer, fn);
 
@@ -357,6 +380,79 @@ export function normalisiere(key) {
 
 /* ── Die vier Prüfungen ──────────────────────────────────────────────── */
 
+/**
+ * Klassen aus `EB_SPEICHER_KLASSEN` in js/modules/core/00-basis.js lesen.
+ *
+ * Diese Tabelle entscheidet zur Laufzeit, ob ein Schluessel ohne Einwilligung
+ * geschrieben werden darf. Sie muss mit der Cookie-Liste uebereinstimmen —
+ * sonst sagt die Notiz „profilbildend, einwilligungspflichtig", waehrend der
+ * Code den Schluessel als essenziell durchwinkt. Das waere die schlimmste
+ * Sorte Abweichung: eine, die genau dort auseinanderlaeuft, wo es rechtlich
+ * zaehlt, und die niemand sieht.
+ */
+export function klassenImCode(quelle) {
+  const block = quelle.match(/var EB_SPEICHER_KLASSEN\s*=\s*\{([\s\S]*?)\n\};/);
+  const map = new Map();
+  if (!block) return map;
+  for (const m of block[1].matchAll(/^\s*([A-Za-z_][\w]*)\s*:\s*'(essenziell|funktional|profil)'/gm)) {
+    map.set(m[1], m[2]);   // roh — die Praefix-Logik steckt in klasseFuer()
+  }
+  return map;
+}
+
+/** Klassen aus der Cookie-Liste — zweite Spalte der Speicher-Tabellen. */
+export function klassenInNotiz(markdown) {
+  const map = new Map();
+  let drin = false;
+  for (const zeile of markdown.split('\n')) {
+    const u = zeile.match(/^#{2,3}\s+(.+?)\s*$/);
+    if (u) { drin = /^(localStorage|sessionStorage)$/i.test(u[1].trim()); continue; }
+    if (!drin) continue;
+    const m = zeile.match(/^\|\s*`([^`]+)`\s*\|\s*([^|]*)\|/);
+    if (!m) continue;
+    const key = m[1].trim().replace(/<[^>]*>.*$/, '');
+    if (!/^(eb_|eventboerse_)/.test(key)) continue;
+    const roh = m[2].trim().toLowerCase();
+    map.set(key, roh.startsWith('essenziell') ? 'essenziell'
+      : roh.startsWith('profil') ? 'profil'
+      : roh.startsWith('funktional') ? 'funktional' : roh);
+  }
+  return map;
+}
+
+/**
+ * Dieselbe Zuordnung wie `ebSpeicherKlasse()` im Browser: laengster
+ * passender Eintrag gewinnt.
+ *
+ * Ein erster Entwurf verglich exakt und meldete daraufhin `eb_favs_guest`
+ * als „ohne Klasse" — obwohl der Praefix `eb_favs_` ihn zur Laufzeit
+ * einwandfrei als funktional einordnet. Ein Pruefer, der die Laufzeit
+ * vereinfacht statt sie abzubilden, meldet Luecken, die es nicht gibt; und
+ * wer solche Meldungen wegzudruecken lernt, uebersieht die echte.
+ */
+export function klasseFuer(key, klassen) {
+  const k = String(key).replace(/<[^>]*>/g, '');
+  let treffer = '';
+  for (const muster of klassen.keys()) {
+    if ((k === muster || k.startsWith(muster)) && muster.length > treffer.length) treffer = muster;
+  }
+  return treffer ? klassen.get(treffer) : null;
+}
+
+export function klassenPruefen(imCode, codeKlassen, notizKlassen) {
+  const ohneKlasse = [];
+  const uneinig = [];
+  for (const e of imCode) {
+    const c = klasseFuer(e.key, codeKlassen);
+    const n = klasseFuer(e.key, notizKlassen);
+    // Ohne Eintrag behandelt ebSpeicherKlasse() den Schluessel als 'profil'
+    // — zurueckhaltend, aber unbeabsichtigt. Das gehoert gemeldet.
+    if (!c) { ohneKlasse.push(e.key); continue; }
+    if (n && n !== c) uneinig.push({ key: e.key, code: c, notiz: n });
+  }
+  return { ohneKlasse, uneinig };
+}
+
 export function speicherPruefen(imCode, inNotiz) {
   const undokumentiert = [];
   const ohneCode = [];
@@ -450,7 +546,15 @@ export function lageErheben() {
   return {
     erzeugt: new Date().toISOString(),
     dateienGeprueft: dateien.length,
-    speicher: { imCode: schluessel, dokumentiert, unaufloesbar, ...speicherPruefen(schluessel, dokumentiert) },
+    speicher: {
+      imCode: schluessel, dokumentiert, unaufloesbar,
+      ...speicherPruefen(schluessel, dokumentiert),
+      ...klassenPruefen(
+        schluessel,
+        klassenImCode(readFileSync(join(MODULE_DIR, 'core', '00-basis.js'), 'utf8')),
+        klassenInNotiz(readFileSync(COOKIE_LISTE, 'utf8')),
+      ),
+    },
     einwilligung: einwilligungPruefen(dateien),
     pflichtseiten: pflichtseitenPruefen(readFileSync(COMPLIANCE, 'utf8'), readFileSync(FUNCTIONS, 'utf8')),
     ki: kiTransparenzPruefen(dateien, existsSync(KI_NOTIZ)),
@@ -479,6 +583,12 @@ export function befunde(lage) {
   }
   for (const k of lage.speicher.ohneCode) {
     meldend.push(`\`${k}\` steht in der Cookie-Liste, wird im Frontend aber nirgends benutzt — die Notiz beschreibt eine ältere Website.`);
+  }
+  for (const k of lage.speicher.ohneKlasse || []) {
+    blockierend.push(`\`${k}\` hat keine Klasse in EB_SPEICHER_KLASSEN — ohne Eintrag gilt er als profilbildend, und das war vermutlich nicht gemeint.`);
+  }
+  for (const u of lage.speicher.uneinig || []) {
+    blockierend.push(`\`${u.key}\`: Code sagt „${u.code}", die Cookie-Liste sagt „${u.notiz}" — genau hier darf nichts auseinanderlaufen.`);
   }
   for (const u of lage.speicher.unaufloesbar) {
     meldend.push(`Schlüssel in ${u.datei} nicht auflösbar: \`${u.ausdruck}\` — von Hand prüfen.`);

--- a/styles.css
+++ b/styles.css
@@ -8696,6 +8696,15 @@ html { scrollbar-color: var(--primary) transparent; }
   margin: 0 auto;
   padding: 12px 20px;
 }
+.cookie-banner-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+/* Beide Knoepfe gleich gross: eine Ablehnung, die kleiner oder blasser ist
+   als die Zustimmung, ist keine echte Wahl (EDSA-Leitlinien 03/2022). */
+.cookie-banner-actions .btn-sm { min-width: 132px; justify-content: center; }
+
 .cookie-banner-row {
   display: flex;
   align-items: center;
@@ -8763,6 +8772,7 @@ html { scrollbar-color: var(--primary) transparent; }
 @media (max-width: 600px) {
   .cookie-banner-inner { padding: 12px 14px; }
   .cookie-banner-row { flex-direction: column; align-items: stretch; gap: 10px; }
+  .cookie-banner-actions { flex-direction: column; }
   .cookie-banner #cookieAcceptAll { width: 100%; justify-content: center; }
   .cookie-banner-table { font-size: 0.72rem; }
 }

--- a/tests/e2e/radar.spec.js
+++ b/tests/e2e/radar.spec.js
@@ -107,6 +107,11 @@ test.describe('Der Standort bleibt im Browser', () => {
     // Gerät soll nicht die Hausnummer des letzten Nutzers verraten.
     const errors = await openApp(page);
     const gespeichert = await page.evaluate(() => {
+      // Der Standort ist seit dem 20.08. einwilligungspflichtig — ohne
+      // Zustimmung wird er gar nicht erst abgelegt. Diese Prüfung gilt der
+      // GENAUIGKEIT des Gespeicherten, also muss hier zugestimmt sein.
+      localStorage.setItem('eb_cookie_consent',
+        JSON.stringify({ v: 2, necessary: true, funktional: true, profil: true }));
       // Eine absichtlich sehr genaue Position setzen.
       _radarPos = { lat: 52.5200123, lng: 13.4050987 };
       _radarMerken(_radarPos, 'geo');
@@ -893,5 +898,30 @@ test.describe('Adresse bleibt änderbar', () => {
     expect(r.teil).toBe('Wedding');
     expect(r.km, 'am eigenen Standort ist die Entfernung ~0').toBeLessThan(0.5);
     expectNoPageErrors(errors, 'DB-Inserat im Radar');
+  });
+});
+
+test.describe('Standort und Einwilligung', () => {
+  test('ohne Zustimmung wird der Standort gar nicht erst gemerkt', async ({ page }) => {
+    // Der Standort ist ein personenbezogenes Datum. Vor dem 20.08. wurde er
+    // unabhängig von der Antwort auf den Cookie-Hinweis abgelegt — der Radar
+    // funktionierte, und die Einwilligung war Zierrat.
+    const errors = await openApp(page);
+    const r = await page.evaluate(() => {
+      localStorage.removeItem('eb_radar_ort');
+      localStorage.setItem('eb_cookie_consent',
+        JSON.stringify({ v: 2, necessary: true, funktional: false, profil: false }));
+      _radarPos = { lat: 52.52, lng: 13.40 };
+      _radarMerken(_radarPos, 'geo');
+      const gemerkt = localStorage.getItem('eb_radar_ort');
+      // Der Radar selbst muss trotzdem arbeiten — die Ablehnung darf die
+      // Umkreissuche nicht kaputtmachen, nur ihr Gedächtnis.
+      const arbeitet = !!(radarStand() && radarStand().pos);
+      localStorage.removeItem('eb_cookie_consent');
+      return { gemerkt: gemerkt, arbeitet: arbeitet };
+    });
+    expect(r.gemerkt, 'ohne Zustimmung darf nichts liegen bleiben').toBeNull();
+    expect(r.arbeitet, 'die Ablehnung darf den Radar nicht abschalten').toBe(true);
+    expectNoPageErrors(errors, 'Standort ohne Einwilligung');
   });
 });

--- a/tests/e2e/recht.spec.js
+++ b/tests/e2e/recht.spec.js
@@ -349,3 +349,146 @@ test.describe('Das Tor greift wirklich', () => {
     expect(zeilen.join('\n')).toMatch(/node scripts\/recht\.mjs --check/);
   });
 });
+
+test.describe('Einwilligung wirkt wirklich', () => {
+  const BASIS = fs.readFileSync(path.join(ROOT, 'js', 'modules', 'core', '00-basis.js'), 'utf8');
+  const CONSENT = fs.readFileSync(
+    path.join(ROOT, 'js', 'modules', 'ui', '32-consent-init-map.js'), 'utf8');
+  const SHELL = fs.readFileSync(path.join(ROOT, 'app-shell.html'), 'utf8');
+
+  test('vor der Antwort wird nichts Nicht-Essenzielles gespeichert', async ({ page }) => {
+    // Schritt 2 der dokumentierten Bannerlogik — der Schritt, der fehlte.
+    await page.goto('/');
+    await page.waitForFunction(() => typeof ebDarfSpeichern === 'function');
+    const r = await page.evaluate(() => {
+      localStorage.removeItem('eb_cookie_consent');
+      return {
+        essenziell: ebDarfSpeichern('eb_user'),
+        zahlung:    ebDarfSpeichern('eb_pending_payment'),
+        komfort:    ebDarfSpeichern('eb_dark_mode'),
+        standort:   ebDarfSpeichern('eb_radar_ort'),
+        profil:     ebDarfSpeichern('eb_taste_v1'),
+      };
+    });
+    expect(r.essenziell, 'Anmeldung muss immer gehen').toBe(true);
+    expect(r.zahlung, 'laufende Zahlung muss immer gehen').toBe(true);
+    expect(r.komfort, 'Komfort ohne Antwort').toBe(false);
+    expect(r.standort, 'Standort ohne Antwort').toBe(false);
+    expect(r.profil, 'Profil ohne Antwort').toBe(false);
+  });
+
+  test('eine Ablehnung hält, eine Zustimmung öffnet', async ({ page }) => {
+    // Die Mutation im Test selbst: beide Richtungen, sonst bewiese ein
+    // „immer false" dasselbe wie eine echte Prüfung.
+    await page.goto('/');
+    await page.waitForFunction(() => typeof ebDarfSpeichern === 'function');
+    const r = await page.evaluate(() => {
+      const setze = (f, p) => localStorage.setItem('eb_cookie_consent',
+        JSON.stringify({ v: 2, necessary: true, funktional: f, profil: p }));
+      setze(false, false);
+      const nein = { komfort: ebDarfSpeichern('eb_dark_mode'), profil: ebDarfSpeichern('eb_taste_v1') };
+      setze(true, true);
+      const ja = { komfort: ebDarfSpeichern('eb_dark_mode'), profil: ebDarfSpeichern('eb_taste_v1') };
+      localStorage.removeItem('eb_cookie_consent');
+      return { nein, ja };
+    });
+    expect(r.nein).toEqual({ komfort: false, profil: false });
+    expect(r.ja).toEqual({ komfort: true, profil: true });
+  });
+
+  test('ein Widerruf löscht, was vorher schon dalag', async ({ page }) => {
+    // Art. 7 Abs. 3 DSGVO. Ohne das Aufräumen wäre der Widerruf für genau
+    // die Daten wirkungslos, um die es geht.
+    await page.goto('/');
+    await page.waitForFunction(() => typeof ebSpeicherAufraeumen === 'function');
+    const r = await page.evaluate(() => {
+      localStorage.setItem('eb_cookie_consent',
+        JSON.stringify({ v: 2, necessary: true, funktional: true, profil: true }));
+      localStorage.setItem('eb_dark_mode', '1');
+      localStorage.setItem('eb_taste_v1', '{}');
+      localStorage.setItem('eb_user', '{"id":1}');
+      localStorage.setItem('eb_cookie_consent',
+        JSON.stringify({ v: 2, necessary: true, funktional: false, profil: false }));
+      ebSpeicherAufraeumen();
+      const da = (k) => localStorage.getItem(k) !== null;
+      const out = { komfort: da('eb_dark_mode'), profil: da('eb_taste_v1'),
+                    essenziell: da('eb_user'), antwort: da('eb_cookie_consent') };
+      ['eb_dark_mode', 'eb_taste_v1', 'eb_user', 'eb_cookie_consent'].forEach((k) => localStorage.removeItem(k));
+      return out;
+    });
+    expect(r.komfort, 'Komfort muss weg sein').toBe(false);
+    expect(r.profil, 'Profil muss weg sein').toBe(false);
+    expect(r.essenziell, 'die Anmeldung darf ein Widerruf nicht kippen').toBe(true);
+    expect(r.antwort, 'die Antwort selbst muss bleiben — sonst fragt es ewig').toBe(true);
+  });
+
+  test('ein unbekannter Schlüssel gilt als profilbildend, nicht als essenziell', async ({ page }) => {
+    // Fail-Safe: ein neuer Schlüssel, den niemand eingeordnet hat, wird
+    // zurückhaltend behandelt statt großzügig.
+    await page.goto('/');
+    await page.waitForFunction(() => typeof ebSpeicherKlasse === 'function');
+    const k = await page.evaluate(() => ebSpeicherKlasse('eb_voellig_neu_' + Date.now()));
+    expect(k).toBe('profil');
+  });
+
+  test('der längste Präfix gewinnt', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => typeof ebSpeicherKlasse === 'function');
+    const r = await page.evaluate(() => ({
+      guest: ebSpeicherKlasse('eb_favs_guest'),
+      user:  ebSpeicherKlasse('eb_favs_17'),
+      board: ebSpeicherKlasse('eb_board_projects_17'),
+      taste: ebSpeicherKlasse('eb_taste_v1'),
+    }));
+    expect(r).toEqual({ guest: 'funktional', user: 'funktional', board: 'funktional', taste: 'profil' });
+  });
+
+  test('nicht-essenzielle Schreibstellen laufen über die Prüfung', () => {
+    // Die eigentliche Wirkung: würde eine dieser Stellen direkt schreiben,
+    // wäre die Einwilligung dort wirkungslos — und niemand sähe es.
+    const module = ['board/40-board-kanban.js', 'board/42-guide-social-feed.js',
+      'ai/50-planungs-assistent.js', 'ui/23-darkmode-staedte-picker.js',
+      'ui/31-modals-toast-qabot.js', 'search/13-event-radar.js',
+      'search/11-suche-ki.js', 'chat/20-chat-nachrichten.js',
+      'core/02-router-navigation.js'];
+    const essenziell = /'(eb_user|eb_demo_\w+|eb_cookie_consent)'|EB_PENDING_PAYMENT_KEY/;
+    for (const m of module) {
+      const src = fs.readFileSync(path.join(ROOT, 'js', 'modules', m), 'utf8');
+      for (const zeile of src.split('\n')) {
+        if (!/localStorage\.setItem\(/.test(zeile)) continue;
+        if (/^\s*(\/\/|\*)/.test(zeile)) continue;
+        expect(essenziell.test(zeile),
+          `${m}: schreibt an der Einwilligung vorbei → ${zeile.trim().slice(0, 70)}`).toBe(true);
+      }
+    }
+  });
+
+  test('der Banner behauptet nicht mehr, es gäbe nur Notwendiges', () => {
+    // Die Aussage war schlicht falsch, solange eb_taste_v1 ein Profil und
+    // eb_radar_ort den Standort speicherte. Das ist gravierender als eine
+    // wirkungslose Einwilligung: eine aktive Falschaussage gegenüber Nutzern.
+    expect(SHELL, 'die alte Behauptung ist zurück')
+      .not.toMatch(/ausschließlich technisch notwendige Cookies/);
+    // Erfundene Cookies in der Detailtabelle: die gab es nie.
+    expect(SHELL).not.toMatch(/PHPSESSID|XSRF-Token/);
+    // Und es muss eine echte Wahl geben, nicht nur „Verstanden".
+    expect(SHELL, 'ohne Ablehnen ist es keine Einwilligung').toMatch(/id="cookieRejectAll"/);
+    expect(SHELL).toMatch(/id="cookieAcceptAll"/);
+    expect(CONSENT, 'beide Antworten müssen dieselbe Funktion mit anderem Wert rufen')
+      .toMatch(/_saveCookieConsent\(paar\[1\]\)/);
+  });
+
+  test('die Klassifizierung steht im Code und in der Notiz — gleich', async () => {
+    const { klassenImCode, klassenInNotiz, klasseFuer, lageErheben } = await recht();
+    const code = klassenImCode(BASIS);
+    const notiz = klassenInNotiz(fs.readFileSync(
+      path.join(ROOT, 'vault', '40-Governance', 'Legal', 'Cookie-Liste.md'), 'utf8'));
+    expect(code.size, 'die Klassentabelle darf nicht leer sein').toBeGreaterThan(15);
+    for (const e of lageErheben().speicher.imCode) {
+      const c = klasseFuer(e.key, code);
+      expect(c, `${e.key} ohne Klasse`).toBeTruthy();
+      const n = klasseFuer(e.key, notiz);
+      if (n) expect(c, `${e.key}: Code ≠ Notiz`).toBe(n);
+    }
+  });
+});

--- a/tests/e2e/verbindungen.spec.js
+++ b/tests/e2e/verbindungen.spec.js
@@ -116,6 +116,39 @@ test.describe('HQ-Zugang', () => {
     }
   });
 
+  test('Zugänge vergibt nur, wer wirklich Administrator ist', () => {
+    // Die Maske im HQ ist Höflichkeit, keine Sicherheit: die Route prüft
+    // ohnehin. Aber ein Knopf, der einem Mitarbeiter 403 antwortet, sieht aus
+    // wie ein Fehler — und ein Knopf, den ein Mitarbeiter bedienen KANN, wäre
+    // einer.
+    expect(FUNCTIONS, 'das Admin-Flag wird nicht eingesetzt')
+      .toMatch(/__EB_HQ_IST_ADMIN__/);
+    const ersetzung = FUNCTIONS.slice(FUNCTIONS.indexOf("'__EB_HQ_IST_ADMIN__'"));
+    expect(ersetzung.slice(0, 200), 'das Flag muss aus der strengen Prüfung kommen')
+      .toMatch(/eb_hq_verwaltung_darf\(\)/);
+
+    // Und die Oberfläche verlässt sich darauf.
+    expect(HQ).toMatch(/const HQ_IST_ADMIN = '__EB_HQ_IST_ADMIN__' === '1'/);
+    expect(HQ, 'ohne Adminrecht muss der Block verschwinden')
+      .toMatch(/if \(!HQ_IST_ADMIN\)[\s\S]{0,80}remove\(\)/);
+    // Lokal ist der Platzhalter roher Text — dann gilt "kein Admin".
+    expect('__EB_HQ_IST_ADMIN__' === '1', 'unersetzt darf er nicht wahr sein').toBe(false);
+  });
+
+  test('die Zugangsmaske legt keine Konten an', () => {
+    // Ein Zugang, der aus einer Maske heraus entsteht, ist schwerer
+    // nachzuvollziehen als einer, den ein Mensch in WordPress angelegt hat.
+    const rumpf = rumpfVon(FUNCTIONS, 'eb_hq_mitarbeiter');
+    expect(rumpf, 'schaltet nur bestehende Konten frei').toMatch(/get_user_by\(\s*'email'/);
+    expect(rumpf, 'kein Anlegen neuer Konten')
+      .not.toMatch(/wp_insert_user|wp_create_user/);
+    // Und der Hinweis auf den fehlenden zweiten Faktor muss durchgereicht
+    // werden — ohne ihn kommt der Mitarbeiter nicht hinein.
+    expect(rumpf).toMatch(/'totp'/);
+    expect(HQ, 'die Maske verschweigt den fehlenden zweiten Faktor')
+      .toMatch(/d\.totp === false|d\.hinweis/);
+  });
+
   test('Abweisung sieht aus wie jede andere unbekannte Adresse', () => {
     // Der Fehler, der das ausgelöst hat: die Abweisung lieferte 404.html —
     // eine eingefrorene SPA-Kopie mit relativen Pfaden. Unter /hq zeigten

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -63,24 +63,24 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **15** |
-| Commits (30 Tage) | 55 |
-| Letzter Commit | `7a3d021 · Bild-Upload: 15 MB, Auto-Verkleinerung und verlässliches Drag & Drop (#168)` (2026-08-20) |
+| Commits (7 Tage) | **16** |
+| Commits (30 Tage) | 56 |
+| Letzter Commit | `53f81d8 · HQ über die Anmeldung statt über ein zweites Geheimnis (#169)` (2026-08-20) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
 32 tests/e2e/kern.spec.js
-     25 vault/50-Evolution/Roadmap/Current-Sprint.md
-     18 CLAUDE.md
+     26 vault/50-Evolution/Roadmap/Current-Sprint.md
+     19 CLAUDE.md
      17 vault/30-Betrieb/Testing.md
      17 hq.html
 ```
 
 **Codegröße:**
-- `app.js` — 26.877 Zeilen
-- `styles.css` — 17.089 Zeilen
-- `functions.php` — 10.361 Zeilen
-- `app-shell.html` — 4.122 Zeilen
+- `app.js` — 27.026 Zeilen
+- `styles.css` — 17.099 Zeilen
+- `functions.php` — 10.366 Zeilen
+- `app-shell.html` — 4.137 Zeilen
 
 ## Verwandt
 - [[00-Kern/Wissensstroeme]] — die sechs Impulse

--- a/vault/40-Governance/Legal/Cookie-Liste.md
+++ b/vault/40-Governance/Legal/Cookie-Liste.md
@@ -125,9 +125,25 @@ Nicht eingesetzt (bewusste Entscheidung — siehe [[20-System/Architecture/Perfo
 5. Im Footer "Cookie-Einstellungen" jederzeit widerrufbar
 ```
 
-**Ist (gemessen, 15.08.2026):** Schritt 1 und 4 laufen. Schritte 2, 3 und 5 nicht —
-`eb_cookie_consent` wird gesetzt und danach von **keiner** schreibenden Stelle gelesen.
-Das Banner erhebt eine Einwilligung, die nichts bewirkt.
+**Ist (gemessen, 20.08.2026): alle fünf Schritte laufen.**
+
+Bis zum 20.08. liefen nur 1 und 4. `eb_cookie_consent` wurde gesetzt und danach von
+**keiner** schreibenden Stelle gelesen — und der Banner hatte überhaupt nur einen Knopf
+(„Verstanden"), also gar keine Wahl. Dazu behaupteten Banner, Cookie-Richtlinie und
+Datenschutzerklärung übereinstimmend „ausschließlich technisch notwendige Cookies",
+während `eb_taste_v1` ein Präferenzprofil und `eb_radar_ort` den Standort ablegte. Das
+war nicht nur eine wirkungslose Einwilligung, sondern eine **Falschaussage in drei
+Rechtstexten**.
+
+Seitdem entscheidet die Antwort wirklich: `ebSpeichern()` in
+`js/modules/core/00-basis.js` prüft vor jedem nicht-essenziellen Schreibvorgang, alle 20
+betroffenen Schreibstellen laufen darüber, und ein Widerruf löscht das bereits
+Gespeicherte (`ebSpeicherAufraeumen()`, Art. 7 Abs. 3 DSGVO). Die Klassentabelle
+`EB_SPEICHER_KLASSEN` ist die Codeseite dieser Notiz; `recht.mjs --check` vergleicht
+beide und bricht bei Abweichung ab.
+
+**Weiterhin anwaltlich zu prüfen:** die Einordnung einzelner Zeilen als „funktional"
+statt „profilbildend" — besonders `eb_ai_chat_v1_*` und `eb_radar_ort`.
 
 Das ist rechtlich ungünstiger als gar kein Banner: das Banner belegt, dass die
 Einwilligungspflicht erkannt wurde, und die Software hält sie nicht ein. Die Behebung

--- a/vault/40-Governance/Legal/Rechtliche-Lage.md
+++ b/vault/40-Governance/Legal/Rechtliche-Lage.md
@@ -8,7 +8,7 @@ tags: [layer/L4, domain/governance, share/internal]
 # Rechtliche Lage — gemessen
 
 > **Erzeugt von `scripts/recht.mjs`. Nicht von Hand bearbeiten.**
-> Stand: 2026-08-20 16:56 UTC · 24 Frontend-Module geprüft.
+> Stand: 2026-08-20 17:26 UTC · 24 Frontend-Module geprüft.
 
 Diese Notiz vergleicht, was der Vault über die Plattform behauptet, mit dem,
 was der Code tut. Sie ersetzt keine Rechtsberatung: sie prüft nur, ob
@@ -16,12 +16,9 @@ Beschreibung und Software dasselbe sagen.
 
 ## Lage in einem Satz
 
-Keine Abweichung, die ein PR beheben kann — aber **1 Befund zur Kenntnis**.
+Beschreibung und Code sagen dasselbe.
 
 
-### Zur Kenntnis
-
-- Die Einwilligung wird erhoben (js/modules/ui/32-consent-init-map.js), aber von keiner der 11 schreibenden Dateien gelesen — sie bewirkt derzeit nichts (TDDDG § 25 Abs. 1).
 
 ## Speicherschlüssel im Frontend (TDDDG § 25)
 
@@ -61,10 +58,10 @@ Keine Abweichung, die ein PR beheben kann — aber **1 Befund zur Kenntnis**.
 | Frage | Messung |
 |---|---|
 | Wo wird die Antwort gesetzt? | js/modules/ui/32-consent-init-map.js |
-| Dateien, die Speicher schreiben | 11 |
-| davon prüfen die Antwort | **0** |
+| Dateien, die Speicher schreiben | 4 |
+| davon prüfen die Antwort | **1** |
 
-Die Einwilligung wird erhoben und von keiner Schreibstelle gelesen. Rechtlich ist das der ungünstigste Zustand: das Banner belegt, dass die Einwilligungspflicht erkannt wurde, und die Software hält sie nicht ein. Die Behebung ändert sichtbares Verhalten (abgelehnte Einwilligung = kein gespeichertes Theme, keine gemerkte Suche) und ist deshalb eine Entscheidung des Inhabers, kein automatischer Patch.
+Mindestens eine Schreibstelle richtet sich nach der Antwort.
 
 ## Pflichtseiten
 

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 345 Tests in 19 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 356 Tests in 19 Suiten**, blockierendes Gate in `pr-check.yml`.
   Vier Radar-Tests brauchen Leaflet vom CDN und schlagen ohne Netzzugang fehl —
   Umgebung, nicht Code
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
@@ -48,13 +48,19 @@ einen alten Abschnitt gelesen und nicht diesen.
   denen **11 nicht existierten**, und übersah **23 echte** — darunter
   `eb_radar_ort` (Standort) und `eb_taste_v1` (Präferenzprofil). Sie stammte aus
   Mai und war nie nachgeführt worden. Jetzt: 24 zu 24.
-- **Offen und wichtig: die Einwilligung bewirkt nichts.** `eb_cookie_consent`
-  wird gesetzt und von **keiner** der 11 schreibenden Dateien gelesen. Das ist
-  rechtlich ungünstiger als kein Banner — es belegt die erkannte Pflicht bei
-  gleichzeitiger Nichterfüllung. Die Behebung ändert sichtbares Verhalten
-  (abgelehnt = kein gemerkter Farbmodus, keine Suchhistorie, kein Profil) und
-  ist deshalb eine **Entscheidung des Inhabers**, kein automatischer Patch.
-  Das Tor meldet, blockiert aber nicht
+- **Die Einwilligung wirkt (20.08.).** Vorher wurde `eb_cookie_consent` gesetzt
+  und von **keiner** der 11 schreibenden Dateien gelesen — und der Banner hatte
+  nur einen Knopf, also gar keine Wahl. Dazu behaupteten Banner,
+  Cookie-Richtlinie **und** Datenschutzerklärung „ausschließlich technisch
+  notwendige Cookies", während `eb_taste_v1` ein Präferenzprofil und
+  `eb_radar_ort` den Standort ablegte: eine Falschaussage in drei Rechtstexten.
+  Jetzt: `ebSpeichern()` prüft vor jedem nicht-essenziellen Schreibvorgang,
+  20 Schreibstellen laufen darüber, ein Widerruf löscht das bereits Gespeicherte,
+  und `EB_SPEICHER_KLASSEN` wird gegen die Cookie-Liste geprüft
+- **Zugänge vergibt man im HQ** (🔑-Abschnitt, nur für Administratoren sichtbar).
+  Vorher ging das nur per API-Aufruf von Hand — eine Fähigkeit, die niemand
+  bedienen kann, wird nicht benutzt, und dann bekommt der Kollege eben doch
+  Adminrechte, weil das der einzige Knopf war
 - Repo bleibt **bewusst public** (Entscheidung des Inhabers, Open Source als
   Ziel). Geprüft und belegt: die zehn `share: secret`-Notizen enthalten
   **Beschreibungen von Maßnahmen, keine Werte** — 0 Treffer für die


### PR DESCRIPTION
Die drei offenen Punkte. Einer davon war größer als gedacht.

---

# 1 · Die Einwilligung wirkt — und drei Rechtstexte sagten die Unwahrheit

Bekannt war: `eb_cookie_consent` wird gesetzt und von **keiner** schreibenden Stelle gelesen. Beim Umbau kam dazu, dass der Banner **überhaupt nur einen Knopf** hatte („Verstanden") — es gab also gar keine Wahl, die man hätte lesen können.

Und dann das hier. Banner, **Cookie-Richtlinie** und **Datenschutzerklärung** behaupteten übereinstimmend:

> „Wir verwenden ausschließlich technisch notwendige Cookies."

Während `eb_taste_v1` ein **Präferenzprofil** aus dem Klickverhalten ablegte und `eb_radar_ort` den **Standort**. Das ist keine wirkungslose Einwilligung mehr, sondern eine Falschaussage in drei Rechtstexten (§ 5a UWG, Art. 13 DSGVO).

Die Cookie-Tabelle listete außerdem `PHPSESSID` und `XSRF-Token` — Cookies, die es **nie gab** — und keinen einzigen der Browser-Speicher, die es gibt.

> Gefunden hat das der Test, den ich für den *Banner* geschrieben hatte. Er schlug an zwei Stellen an, die ich gar nicht angesehen hatte.

## Was jetzt gilt

| | |
|---|---|
| **Klassen** | `EB_SPEICHER_KLASSEN` ordnet jeden Schlüssel ein: essenziell / funktional / profil |
| **Prüfung** | `ebSpeichern()` vor jedem nicht-essenziellen Schreibvorgang — **20 Schreibstellen** laufen darüber |
| **Unverändert** | Essenzielles (Anmeldung, laufende Zahlung, die Antwort selbst) schreibt weiter direkt |
| **Fail-Safe** | Ein unbekannter Schlüssel gilt als *profilbildend*, nicht als essenziell |
| **Echte Wahl** | Zwei **gleich große** Knöpfe. Eine Ablehnung, die kleiner oder blasser ist, ist keine Wahl (EDSA 03/2022) |
| **Widerruf** | löscht das bereits Gespeicherte (Art. 7 Abs. 3 DSGVO) — sonst wäre er für genau die Daten wirkungslos, um die es geht |
| **Rechtstexte** | Cookie-Richtlinie und Datenschutzerklärung beschreiben den **gemessenen** Bestand |

`recht.mjs` prüft zusätzlich, dass **jeder** Schlüssel eine Klasse hat und Code und Notiz **dieselbe** nennen. Eine Notiz, die „profilbildend, einwilligungspflichtig" sagt, während der Code durchwinkt, wäre die schlimmste Sorte Abweichung: genau dort, wo es rechtlich zählt, und unsichtbar.

## Zwei Fehler in meinem eigenen Prüfer

1. Er las die **Hülle** `ebSpeichern(key, wert)` mit. Der Parameter `key` traf eine unbeteiligte Zuweisung weiter oben in derselben Datei — und `aiMediaDisclosure` wurde als Speicherschlüssel gemeldet. Dieselbe Klasse Fehlalarm wie im ersten Entwurf, nur diesmal durch die generische Hülle.
2. Die neue Klassenprüfung verglich **exakt**, während die Laufzeit den **längsten Präfix** nimmt — und meldete `eb_favs_guest` als „ohne Klasse", obwohl `eb_favs_` ihn einwandfrei einordnet. Ein Prüfer, der die Laufzeit vereinfacht statt sie abzubilden, erzeugt Meldungen, die man wegzudrücken lernt — und dann übersieht man die echte.

---

# 2 · Zugänge vergibt man jetzt im HQ

Bisher ging das nur per API-Aufruf von Hand. **Eine Fähigkeit, die niemand bedienen kann, wird nicht benutzt** — und dann bekommt der Kollege eben doch Adminrechte, weil das der einzige Knopf war.

Neu: ein 🔑-Abschnitt im HQ. E-Mail eintragen → Zugang geben oder entziehen. Der Hinweis des Servers wird durchgereicht, auch der unbequeme: *„Zugang erteilt. Beim ersten Aufruf von /hq richtet das Konto seinen Authenticator ein."*

**Sichtbar nur für Administratoren.** `functions.php` setzt `__EB_HQ_IST_ADMIN__` aus `eb_hq_verwaltung_darf()`. Mitarbeiter mit `eb_hq_access` sehen dieselbe Seite und sollen keinen Knopf sehen, der ihnen 403 antwortet. Die Sperre bleibt die Route — das hier ist Oberfläche, keine Sicherheit.

Die Maske legt **keine Konten an**: ein Zugang, der aus einer Maske entsteht, ist schwerer nachzuvollziehen als einer, den ein Mensch in WordPress angelegt hat.

---

# 3 · PR #156 nachgetragen

Der Autopilot-PR kollidierte (`mergeable_state: dirty`), weil `app.js` seit dem 14.08. stark bewegt wurde. Sein eigentlicher Beitrag ist **ein Wort** in `10-karten-home-feed.js` (`aria-label="Bilder:"` → `"Bildergalerie:"`); der Konflikt steckte nur im generierten Artefakt. Nachgetragen, `app.js` neu gebaut. #156 kann geschlossen werden.

---

## ⚠️ Nicht erledigt — und nicht erledigbar

**`post_max_size` bei IONOS.** Das ist eine Einstellung im Hosting-Panel, an die ich nicht komme. Falls der Bild-Upload je mit **413** antwortet, nennt er den geltenden Wert; dann gehören `upload_max_filesize = 16M` / `post_max_size = 20M` ins PHP-Panel oder nach `/public/.user.ini`.

## Geprüft

**356 Tests in 19 Suiten.** Neue Zusicherungen mutationsgeprüft:

| Mutation | fällt auf |
|---|---|
| Farbmodus schreibt wieder direkt an der Einwilligung vorbei | ✓ |
| Admin-Flag kommt aus der laxen statt der strengen Prüfung | ✓ |
| Klasse im Code gegen die Notiz verdreht (`eb_taste_v1` → essenziell) | ✓ |
| Schlüssel aus der Klassentabelle gestrichen | ✓ |

Die vier Radar-Tests brauchen Leaflet von `unpkg.com`, das der Proxy dieser Umgebung sperrt — in CI laufen sie durch.

## Was du merken wirst

Nach dem Deploy erscheint der Cookie-Hinweis **einmal neu** (die Antwort hat jetzt ein anderes Format). Lehnst du ab, merkt sich die Seite Farbmodus, Favoriten und Planung nicht mehr — das ist der Punkt. Bestehende Daten von Nutzern, die vorher zugestimmt haben, bleiben; wer neu ablehnt, dessen Daten werden gelöscht.

**Die Einordnung einzelner Zeilen gehört anwaltlich geprüft** — besonders `eb_ai_chat_v1_*` (Gesprächsverläufe) und `eb_radar_ort` (Standort), die ich als „funktional" geführt habe und nicht als „profilbildend".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_