### PR TITLE
Fix listing detail image aspect ratio

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4232,11 +4232,10 @@ body.dark-mode .ai-sug-chip:hover { background: rgba(255,56,92,0.15); }
   position: relative;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  aspect-ratio: 16 / 9;
-  /* Bild kompakt halten, damit es ohne Scrollen komplett sichtbar ist:
-     auf hohen Bildschirmen moderat gedeckelt, auf niedrigen an die
-     Fensterhöhe gekoppelt (max. ~42% der sichtbaren Höhe). */
-  max-height: min(380px, 42vh);
+  /* Keep this aligned with the upload preview: listing images are reviewed in
+     4:3 there and must not switch to a narrower 16:9/viewport crop after
+     publication. */
+  aspect-ratio: 4 / 3;
   margin-bottom: 24px;
   width: 100%;
   max-width: 640px;
@@ -4246,10 +4245,10 @@ body.dark-mode .ai-sug-chip:hover { background: rgba(255,56,92,0.15); }
   margin-right: 0;
   box-shadow: none;
 }
-@supports not (aspect-ratio: 16 / 9) {
+@supports not (aspect-ratio: 4 / 3) {
   .detail-gallery {
     height: 0;
-    padding-top: 56.25%;
+    padding-top: 75%;
   }
 }
 /* === CINEMATIC PREVIEW === */
@@ -8394,7 +8393,7 @@ body.dark-mode .stripe-onboarding-steps > div {
   .detail-container > .detail-provider-row { order: 5; margin-bottom: 16px; padding-bottom: 16px; border-bottom: 1px solid var(--border-light); }
   .detail-container > .detail-layout { order: 6; }
 
-  .detail-gallery { aspect-ratio: 16 / 9; max-height: none; border-radius: 0; box-shadow: none; width: 100vw; max-width: none; left: 50%; transform: translateX(-50%); }
+  .detail-gallery { aspect-ratio: 4 / 3; max-height: none; border-radius: 0; box-shadow: none; width: 100vw; max-width: none; left: 50%; transform: translateX(-50%); }
   .detail-gallery-arrow { display: none !important; }
   .listing-live-preview-gallery { aspect-ratio: 4 / 3; }
   .listing-live-preview-arrow { display: none !important; }

--- a/tests/e2e/bild-upload.spec.js
+++ b/tests/e2e/bild-upload.spec.js
@@ -44,6 +44,32 @@ test.describe('Bild-Upload', () => {
     expect(hinweis).toContain('15 MB');
   });
 
+  test('Vorschau und veroeffentlichte Detailansicht nutzen dasselbe Bildformat', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 640 });
+    await openApp(page);
+
+    const desktop = await page.evaluate(() => {
+      const preview = getComputedStyle(document.querySelector('.listing-live-preview-gallery'));
+      const detail = getComputedStyle(document.querySelector('.detail-gallery'));
+      return {
+        previewRatio: preview.aspectRatio,
+        detailRatio: detail.aspectRatio,
+        detailMaxHeight: detail.maxHeight,
+      };
+    });
+    expect(desktop.previewRatio).toBe('4 / 3');
+    expect(desktop.detailRatio).toBe(desktop.previewRatio);
+    expect(desktop.detailMaxHeight).toBe('none');
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    const mobile = await page.evaluate(() => ({
+      previewRatio: getComputedStyle(document.querySelector('.listing-live-preview-gallery')).aspectRatio,
+      detailRatio: getComputedStyle(document.querySelector('.detail-gallery')).aspectRatio,
+    }));
+    expect(mobile.detailRatio).toBe(mobile.previewRatio);
+    expect(mobile.detailRatio).toBe('4 / 3');
+  });
+
   test('Falscher Dateityp wird abgelehnt und begründet', async ({ page }) => {
     const errors = await openApp(page);
     const meldung = await page.evaluate(async () => {


### PR DESCRIPTION
## Änderung
- Detailgalerie nutzt wie die Upload-Vorschau ein 4:3-Seitenverhältnis
- viewportabhängige Höhenbegrenzung entfernt
- Desktop- und Mobil-Regressionstest ergänzt

## Verifikation
- lokale Browserprüfung: 640×480 px (Desktop), 390×293 px (Mobil)
- Vorschau und Detailansicht jeweils `aspect-ratio: 4 / 3`
- `git diff --check` erfolgreich

Hinweis: Die vollständige Playwright-Suite konnte lokal nicht gestartet werden, da Node/npm in der Arbeitsumgebung fehlen; CI führt sie im PR aus.