### PR TITLE
Jarvis: HUD-Ringe am Sprech-Kreis und eine echte Stimme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,28 @@ in der Mitte der KI-Kreis mit Sprache. Ein Impuls auf einer Bahn entspricht
 **einem echten Ereignis** — keine Dauer-Animation, sonst sieht ein
 stillstehendes System aus wie ein arbeitendes.
 
+### Die Stimme des HQ
+
+`/wp-json/eventboerse/v1/hq/stimme` erzeugt die Sprachausgabe **serverseitig**
+(OpenAI TTS, `gpt-4o-mini-tts`) — der Schlüssel erreicht den Browser nie, es
+gehen nur Text hin und fertiges Audio zurück. Opt-in über `EB_OPENAI_API_KEY`.
+
+**Ohne Schlüssel fällt das HQ hörbar auf `speechSynthesis` zurück**, die Stimme
+des Betriebssystems. Der Rückfall ist Absicht und muss hörbar bleiben: eine
+Sprachausgabe, die still bleibt, ist für den Nutzer nicht von einem Absturz zu
+unterscheiden. Das Ergebnis wird einmal gemerkt (`stimmeServer`), sonst kostet
+jede Antwort einen Aufruf für einen Schlüssel, den es nicht gibt.
+
+**Neue Stopp-Stelle → `stimmeStoppen()`, nicht `speechSynthesis.cancel()`.**
+Sonst spricht die Serverstimme weiter, während das Mikrofon schon wieder zuhört.
+
+Die **HUD-Ringe** am Sprech-Kreis (`.nn-hud-*`) stehen im Ruhezustand **still**
+und drehen nur bei `.hoert`. Dieselbe Regel wie für die Impulse auf den Bahnen:
+eine Dauer-Animation lässt ein stillstehendes System wie ein arbeitendes
+aussehen. Unter `prefers-reduced-motion` werden sie ganz abgeschaltet — der
+globale Block setzt nur die Dauer auf ~0, und eine Endlosrotation steht damit
+nicht still, sie flimmert.
+
 `/wp-json/eventboerse/v1/hq/probe/{anthropic|openai|openrouter}` prüft die KI-Schlüssel
 **serverseitig** — Gültigkeit und Rate-Limit-Kontingent, ohne dass der Schlüssel
 den Browser erreicht. Opt-in: nur aktiv, wenn die Server-Konstante gesetzt ist.
@@ -238,13 +260,13 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-356 Tests in 19 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+371 Tests in 20 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
 Sicherheitsrahmen), **Recht** (Speicherschlüssel ↔ Cookie-Liste, Einwilligung,
 Pflichtseiten, KI-Transparenz), KI-Transparenz (Kennzeichnung in jeder
-Ansicht), TOTP (RFC-6238-Vektoren, Wiederverwendung, Zeitangriff), Radar
+Ansicht), **Stimme** (Serverstimme, hörbarer Rückfall, HUD-Ringe), TOTP (RFC-6238-Vektoren, Wiederverwendung, Zeitangriff), Radar
 (Umkreis, lokale Position, Migrations-Verhalten), Vision-Release, Kern
 (Impuls-Ehrlichkeit + Autonomie + offenes Ensemble), Barrierefreiheit (axe,
 beide Farbmodi), Design-System, CSS-Minify. `pr-check.yml` blockiert PRs bei

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-21T17:13:07.162Z",
+  "erzeugt": "2026-08-21T17:31:54.901Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/functions.php
+++ b/functions.php
@@ -9774,7 +9774,105 @@ add_action( 'rest_api_init', function () {
         'callback'            => 'eb_hq_probe_openai',
         'permission_callback' => 'eb_hq_proxy_darf',
     ) );
+
+    register_rest_route( 'eventboerse/v1', '/hq/stimme', array(
+        'methods'             => 'POST',
+        'callback'            => 'eb_hq_stimme',
+        'permission_callback' => 'eb_hq_proxy_darf',
+        'args'                => array(
+            'text' => array( 'required' => true, 'type' => 'string' ),
+        ),
+    ) );
 } );
+
+/**
+ * Sprachausgabe fuer das HQ — serverseitig, damit der Schluessel bleibt, wo er hingehoert.
+ *
+ * Warum ueberhaupt: das HQ sprach bisher ausschliesslich ueber
+ * `window.speechSynthesis`, also die Stimme des Betriebssystems. Die klingt
+ * auf Windows und Android blechern, in manchen Browsern fehlt sie ganz. Das
+ * ist keine Modellfrage gewesen, sondern gar kein Modell.
+ *
+ * Drei Eigenschaften, die diese Route durchhaelt:
+ *
+ * 1. DER SCHLUESSEL ERREICHT DEN BROWSER NIE. Der Text geht hin, die fertigen
+ *    Audiodaten kommen zurueck. Genau wie bei den Probe-Routen.
+ *
+ * 2. OHNE SCHLUESSEL EIN EHRLICHES NEIN. Kein Fehler, kein leerer Klang: die
+ *    Route sagt „nicht hinterlegt", und der Browser faellt sichtbar auf seine
+ *    eigene Stimme zurueck. Eine Sprachausgabe, die still bleibt, waere fuer
+ *    den Nutzer nicht von einem Absturz zu unterscheiden.
+ *
+ * 3. LAENGE BEGRENZT. Sprachausgabe kostet pro Zeichen. 1200 Zeichen sind
+ *    rund zwei Minuten — laenger hoert ohnehin niemand zu, und ein
+ *    unbegrenztes Feld waere eine offene Rechnung.
+ */
+function eb_hq_stimme( WP_REST_Request $request ) {
+    if ( ! defined( 'EB_OPENAI_API_KEY' ) || ! EB_OPENAI_API_KEY ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'EB_OPENAI_API_KEY ist auf dem Server nicht hinterlegt.',
+        ), 200 );
+    }
+
+    $text = trim( (string) $request->get_param( 'text' ) );
+    if ( $text === '' ) {
+        return new WP_REST_Response( array( 'verfuegbar' => false, 'grund' => 'Kein Text.' ), 400 );
+    }
+    // mb_substr, nicht substr: ein Schnitt mitten durch ein Mehrbyte-Zeichen
+    // erzeugt ungueltiges UTF-8, und die Gegenstelle antwortet dann mit 400.
+    $text = function_exists( 'mb_substr' ) ? mb_substr( $text, 0, 1200 ) : substr( $text, 0, 1200 );
+
+    // Ein sprechender Kreis, den man in Dauerschleife anwerfen kann, ist eine
+    // offene Rechnung. 30 Ausgaben je Minute reichen fuer ein Gespraech.
+    $limit = eventboerse_check_rate_limit( 'hq_stimme', 30, MINUTE_IN_SECONDS );
+    if ( is_wp_error( $limit ) ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => $limit->get_error_message(),
+        ), 429 );
+    }
+
+    $res = wp_remote_post( 'https://api.openai.com/v1/audio/speech', array(
+        'timeout' => 25,
+        'headers' => array(
+            'Authorization' => 'Bearer ' . EB_OPENAI_API_KEY,
+            'Content-Type'  => 'application/json',
+        ),
+        'body' => wp_json_encode( array(
+            'model'           => 'gpt-4o-mini-tts',
+            'voice'           => 'onyx',
+            'input'           => $text,
+            'response_format' => 'mp3',
+        ) ),
+    ) );
+
+    if ( is_wp_error( $res ) ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'Sprachdienst nicht erreichbar: ' . $res->get_error_message(),
+        ), 200 );
+    }
+    $code = (int) wp_remote_retrieve_response_code( $res );
+    if ( $code !== 200 ) {
+        // Den Text der Gegenstelle NICHT durchreichen: er kann den
+        // Organisationsnamen und Kontodetails enthalten.
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'Sprachdienst antwortete mit HTTP ' . $code . '.',
+        ), 200 );
+    }
+
+    $audio = wp_remote_retrieve_body( $res );
+    if ( $audio === '' ) {
+        return new WP_REST_Response( array( 'verfuegbar' => false, 'grund' => 'Leere Antwort.' ), 200 );
+    }
+    return new WP_REST_Response( array(
+        'verfuegbar' => true,
+        'format'     => 'mp3',
+        'audio'      => base64_encode( $audio ),
+    ), 200 );
+}
 
 /**
  * HQ-Gespräch: der Kreis spricht mit einem echten Modell.

--- a/hq.html
+++ b/hq.html
@@ -276,6 +276,48 @@
 
   /* Der Circle in der Mitte */
   .nn-orb-hit { cursor: pointer; }
+
+  /* ── HUD-Ringe am Sprech-Kreis ──────────────────────────────────────
+     Vier Lagen aus reiner Geometrie. Im Ruhezustand STEHEN sie still:
+     eine Dauerrotation liesse ein stillstehendes System wie ein
+     arbeitendes aussehen — dieselbe Regel, die auch fuer die Impulse auf
+     den Bahnen gilt. Bewegung heisst hier: es hoert gerade zu oder
+     spricht gerade. */
+    /* Dunkles Feld hinter den Ringen. Ohne das geht das Cyan im violetten
+     Grund der Zentrale unter — der HUD-Eindruck lebt vom Kontrast, nicht
+     von der Anzahl der Ringe. */
+  .nn-hud-feld { fill: rgba(6,14,26,.72); stroke: rgba(34,211,238,.16); stroke-width: 1; }
+  /* Beschriftung UNTER die Scheibe: im dunklen Feld war sie kaum lesbar. */
+  .nn-hud-text { fill: rgba(165,243,252,.92); }
+  .nn-hud circle:not(.nn-hud-feld) { fill: none; }
+  .nn-hud-aussen,
+  .nn-hud-teilung,
+  .nn-hud-klammer,
+  .nn-hud-innen {
+    transform-origin: var(--nn-o-x) var(--nn-o-y);
+    transition: stroke .35s ease, opacity .35s ease;
+  }
+  /* Aussenring: lange Boegen mit Luecken. */
+  .nn-hud-aussen  { stroke: rgba(34,211,238,.45); stroke-width: 1; stroke-dasharray: 54 26 14 26; }
+  /* Teilung: viele kurze Striche — die Skala. */
+  .nn-hud-teilung { stroke: rgba(34,211,238,.52); stroke-width: 3; stroke-dasharray: 1.5 7.5; }
+  /* Klammern: vier Viertelboegen. */
+  .nn-hud-klammer { stroke: rgba(34,211,238,.58); stroke-width: 1.5; stroke-dasharray: 40 26; }
+  .nn-hud-innen   { stroke: rgba(103,232,249,.62); stroke-width: 1; }
+
+  /* Zuhoeren: die Skala dreht, der Innenring atmet. Gegenlaeufig, damit die
+     Bewegung als Mechanik lesbar ist und nicht als Ladebalken. */
+  .neural.hoert .nn-hud-aussen  { stroke: rgba(34,211,238,.55); animation: nnHudDreh 24s linear infinite; }
+  .neural.hoert .nn-hud-teilung { stroke: rgba(34,211,238,.70); animation: nnHudDreh 14s linear infinite reverse; }
+  .neural.hoert .nn-hud-klammer { stroke: rgba(34,211,238,.60); animation: nnHudDreh 9s linear infinite; }
+  .neural.hoert .nn-hud-innen   { stroke: rgba(34,211,238,.85); }
+  /* Sprechen: keine Drehung, nur Helligkeit — sonst sieht Antworten aus
+     wie Arbeiten. */
+  .neural.spricht .nn-hud-klammer,
+  .neural.spricht .nn-hud-innen { stroke: rgba(103,232,249,.9); }
+  .neural.spricht .nn-hud-teilung { stroke: rgba(103,232,249,.6); }
+  @keyframes nnHudDreh { to { transform: rotate(360deg); } }
+
   .nn-orb-ring { fill: none; stroke: rgba(255,255,255,.18); stroke-width: 1; }
   .neural.hoert .nn-orb-ring { animation: nnHoer 1.4s ease-out infinite; }
   @keyframes nnHoer { 0% { r: 40; opacity: .8; } 100% { r: 62; opacity: 0; } }
@@ -704,6 +746,11 @@
   @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after { animation-duration: .001ms !important; transition-duration: .001ms !important; }
     #bg-grid { animation: none; }
+    /* Eine Endlosrotation mit .001ms Dauer steht nicht still, sie flimmert —
+       fuer genau die Leute, die um weniger Bewegung gebeten haben. Die
+       HUD-Ringe werden deshalb ganz abgeschaltet; die Zustaende bleiben
+       ueber die Farbe lesbar. */
+    .nn-hud-aussen, .nn-hud-teilung, .nn-hud-klammer, .nn-hud-innen { animation: none !important; }
   }
 
 /* ══ EB CIRCLE — sprechender KI-Kreis ══════════════════════════════ */
@@ -2477,14 +2524,30 @@ function nnZeichnen() {
       </g>`);
   });
 
-  // Sprech-Kreis am Kern
+  // Sprech-Kreis am Kern — HUD-Ringe im Jarvis-Stil.
+  //
+  // Die Ringe stehen im Ruhezustand STILL. Das ist keine Sparsamkeit, sondern
+  // dieselbe Regel wie beim Transportstrom: eine Dauer-Animation laesst ein
+  // stillstehendes System wie ein arbeitendes aussehen. Bewegung gibt es,
+  // wenn wirklich etwas passiert — beim Zuhoeren und beim Sprechen, gesteuert
+  // ueber .hoert und .spricht am Container.
+  //
+  // Der Aufbau ist bewusst nur Geometrie, keine Bilddatei: er skaliert mit dem
+  // viewBox, faerbt sich ueber CSS-Variablen und kostet keinen Netzaufruf.
+  const O = NN_MITTE;
   teile.push(`
-    <g class="nn-orb-hit" id="nn-orb" role="button" tabindex="0" aria-label="Sprechen — KI-Kreis starten">
-      <circle class="nn-orb-ring" cx="${NN_MITTE.x}" cy="${NN_MITTE.y}" r="36"/>
-      <circle cx="${NN_MITTE.x}" cy="${NN_MITTE.y}" r="26" fill="url(#nnOrb)"/>
-      <path class="nn-welle" id="nn-welle" d="M ${NN_MITTE.x - 11} ${NN_MITTE.y} q 3.5 -7 5.5 0 t 5.5 0 t 5.5 0"/>
-      <text x="${NN_MITTE.x}" y="${NN_MITTE.y + 5}" style="font-size:14px;text-anchor:middle;fill:#fff">🎙</text>
-      <text x="${NN_MITTE.x}" y="${NN_MITTE.y + 40}" class="nn-sub" id="nn-orb-text">sprechen</text>
+    <g class="nn-orb-hit nn-hud" id="nn-orb" role="button" tabindex="0" aria-label="Sprechen — KI-Kreis starten"
+       style="--nn-o-x:${O.x}px; --nn-o-y:${O.y}px">
+      <circle class="nn-hud-feld" cx="${O.x}" cy="${O.y}" r="62"/>
+      <circle class="nn-hud-aussen" cx="${O.x}" cy="${O.y}" r="58"/>
+      <circle class="nn-hud-teilung" cx="${O.x}" cy="${O.y}" r="50"/>
+      <circle class="nn-hud-klammer" cx="${O.x}" cy="${O.y}" r="42"/>
+      <circle class="nn-hud-innen" cx="${O.x}" cy="${O.y}" r="33"/>
+      <circle class="nn-orb-ring" cx="${O.x}" cy="${O.y}" r="36"/>
+      <circle cx="${O.x}" cy="${O.y}" r="26" fill="url(#nnOrb)"/>
+      <path class="nn-welle" id="nn-welle" d="M ${O.x - 11} ${O.y} q 3.5 -7 5.5 0 t 5.5 0 t 5.5 0"/>
+      <text x="${O.x}" y="${O.y + 5}" style="font-size:14px;text-anchor:middle;fill:#fff">🎙</text>
+      <text x="${O.x}" y="${O.y + 78}" class="nn-sub nn-hud-text" id="nn-orb-text">sprechen</text>
     </g>`);
 
   svg.innerHTML = defs + teile.join('');
@@ -3903,26 +3966,101 @@ window.addEventListener('DOMContentLoaded', init);
     });
     suggestionsEl.classList.toggle('has', !!suggestionsEl.childElementCount);
   }
+  /* ── Stimme ────────────────────────────────────────────────────────────
+     Das HQ sprach ausschliesslich ueber window.speechSynthesis, also die
+     Stimme des Betriebssystems. Die klingt auf Windows und Android blechern
+     und fehlt in manchen Browsern ganz — es war nie ein schlechtes Modell,
+     es war gar keins.
+
+     Jetzt zuerst die Serverstimme (/hq/stimme, Schluessel bleibt am Server),
+     und wenn die nicht da ist, die des Browsers. Der Rueckfall ist SICHTBAR:
+     eine Sprachausgabe, die einfach still bleibt, ist fuer den Nutzer nicht
+     von einem Absturz zu unterscheiden.
+
+     `stimmeServer` merkt sich das Ergebnis der ersten Anfrage: null = noch
+     nicht geprueft, true/false = geprueft. Ohne das fragte jede Antwort
+     erneut nach einem Schluessel, den es nicht gibt. */
+  var stimmeServer = null;
+  var laufendesAudio = null;
+
+  function stimmeStoppen() {
+    try { if (laufendesAudio) { laufendesAudio.pause(); laufendesAudio = null; } } catch (e) {}
+    try { if (window.speechSynthesis) speechSynthesis.cancel(); } catch (e) {}
+  }
+
+  /* Die Zustandswechsel gelten fuer beide Stimmen — sonst bliebe der Kreis
+     bei der Serverstimme im „hoert zu"-Zustand haengen. */
+  function sprechBeginn(session) {
+    if (session !== dialogSession || !panel.classList.contains('open')) return;
+    circle.classList.add('speaking'); voiceState('Antwortet mit Stimme', 'spricht');
+  }
+  function sprechEnde(session) {
+    circle.classList.remove('speaking');
+    if (session !== dialogSession || !panel.classList.contains('open')) return;
+    voiceState('Bereit für dein Gespräch', null);
+    var darfNeuHoeren = !suppressVoiceRestart;
+    suppressVoiceRestart = false;
+    if (darfNeuHoeren && voiceMode && panel.classList.contains('open') && !listening) setTimeout(toggleMic, 120);
+  }
+
+  async function sayServer(text, session) {
+    var res = await fetch('/wp-json/eventboerse/v1/hq/stimme', {
+      method: 'POST', credentials: 'same-origin', cache: 'no-store',
+      headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': HQ_REST_NONCE },
+      body: JSON.stringify({ text: String(text).slice(0, 1200) })
+    });
+    if (!res.ok) return false;
+    var d = await res.json();
+    if (!d || !d.verfuegbar || !d.audio) return false;
+    // Inzwischen ein neues Gespraech? Dann nicht mehr abspielen.
+    if (session !== dialogSession || !panel.classList.contains('open')) return true;
+
+    var audio = new Audio('data:audio/mpeg;base64,' + d.audio);
+    laufendesAudio = audio;
+    audio.addEventListener('play',  function () { sprechBeginn(session); });
+    audio.addEventListener('ended', function () { laufendesAudio = null; sprechEnde(session); });
+    audio.addEventListener('error', function () { laufendesAudio = null; sprechEnde(session); });
+    try { await audio.play(); }
+    catch (e) {
+      // Autoplay verweigert — das ist kein Grund, stumm zu bleiben.
+      laufendesAudio = null;
+      return false;
+    }
+    return true;
+  }
+
   function say(text) {
-    if (!speakOn || !window.speechSynthesis) return;
+    if (!speakOn) return;
+    var session = dialogSession;
+    stimmeStoppen();
+
+    if (stimmeServer !== false) {
+      sayServer(text, session).then(function (ok) {
+        if (ok) { stimmeServer = true; return; }
+        // Einmal merken, dann nicht mehr fragen — und hoerbar weitermachen.
+        stimmeServer = false;
+        sayBrowser(text, session);
+      }).catch(function () {
+        stimmeServer = false;
+        sayBrowser(text, session);
+      });
+      return;
+    }
+    sayBrowser(text, session);
+  }
+
+  function sayBrowser(text, session) {
+    if (!window.speechSynthesis) return;
     try {
       speechSynthesis.cancel();
-      var session = dialogSession;
+      if (session === undefined) session = dialogSession;
       var u = new SpeechSynthesisUtterance(String(text).slice(0, 600));
       u.lang = 'de-DE'; u.rate = .98; u.pitch = .94;
       u.voice = preferredVoice || chooseVoice();
-      u.onstart = function () {
-        if (session !== dialogSession || !panel.classList.contains('open')) return;
-        circle.classList.add('speaking'); voiceState('Antwortet mit Stimme', 'spricht');
-      };
-      u.onend = function () {
-        circle.classList.remove('speaking');
-        if (session !== dialogSession || !panel.classList.contains('open')) return;
-        voiceState('Bereit für dein Gespräch', null);
-        var darfNeuHoeren = !suppressVoiceRestart;
-        suppressVoiceRestart = false;
-        if (darfNeuHoeren && voiceMode && panel.classList.contains('open') && !listening) setTimeout(toggleMic, 120);
-      };
+      // Dieselben Zustandswechsel wie bei der Serverstimme — eine Stelle,
+      // nicht zwei, sonst haengt der Kreis je nach Stimme anders fest.
+      u.onstart = function () { sprechBeginn(session); };
+      u.onend   = function () { sprechEnde(session); };
       u.onerror = function () {
         circle.classList.remove('speaking');
         if (session === dialogSession && panel.classList.contains('open')) voiceState('Sprachausgabe gestoppt', null);
@@ -4049,7 +4187,9 @@ window.addEventListener('DOMContentLoaded', init);
     if (!SR) return;
     if (listening) { try { rec.stop(); } catch (e) {} return; }
     if (asking && askController) askController.abort();
-    try { if (window.speechSynthesis && speechSynthesis.speaking) { suppressVoiceRestart = true; speechSynthesis.cancel(); } } catch (e) {}
+    // stimmeStoppen() statt nur speechSynthesis: sonst laeuft die
+    // Serverstimme weiter, waehrend das Mikrofon schon wieder zuhoert.
+    if ((window.speechSynthesis && speechSynthesis.speaking) || laufendesAudio) { suppressVoiceRestart = true; stimmeStoppen(); }
     asking = false; askController = null;
     rec = new SR(); rec.lang = 'de-DE'; rec.interimResults = true; rec.continuous = false; rec.maxAlternatives = 3;
     var finalText = '';
@@ -4113,7 +4253,7 @@ window.addEventListener('DOMContentLoaded', init);
     asking = false; askController = null; renderSuggestions([]);
     input.value = ''; recognitionAlternatives = []; recognitionConfidence = null;
     conversation = []; log.innerHTML = '';
-    try { suppressVoiceRestart = true; speechSynthesis.cancel(); } catch (e) {}
+    try { suppressVoiceRestart = true; stimmeStoppen(); } catch (e) {}
     voiceState('Gespräch beendet', null);
     syncDialogControls();
   }
@@ -4156,7 +4296,7 @@ window.addEventListener('DOMContentLoaded', init);
   spkBtn.addEventListener('click', function () {
     speakOn = !speakOn; spkBtn.classList.toggle('on', speakOn);
     spkBtn.title = speakOn ? 'Vorlesen ist an' : 'Vorlesen ist aus';
-    if (!speakOn) { try { suppressVoiceRestart = true; speechSynthesis.cancel(); } catch (e) {} }
+    if (!speakOn) { try { suppressVoiceRestart = true; stimmeStoppen(); } catch (e) {} }
   });
   /* Feedback-Loop schließen (Impuls 6).
      Die Wissenslücken liegen im localStorage DIESES Browsers — es wird nichts

--- a/tests/e2e/stimme.spec.js
+++ b/tests/e2e/stimme.spec.js
@@ -1,0 +1,200 @@
+// Die Stimme des HQ — und der Ring, der sie zeigt.
+//
+// Ausgangslage: das HQ sprach ausschliesslich ueber window.speechSynthesis,
+// also die Stimme des Betriebssystems. Auf Windows und Android klingt die
+// blechern, in manchen Browsern fehlt sie ganz. Es war nie ein schlechtes
+// Sprachmodell — es war gar keins.
+//
+// Die gefaehrliche Stelle beim Nachruesten ist nicht die Qualitaet, sondern
+// der Ausfall: eine Sprachausgabe, die einfach still bleibt, ist fuer den
+// Nutzer nicht von einem Absturz zu unterscheiden. Darum pruefen die ersten
+// beiden Tests genau das — dass jeder Weg HOERBAR endet.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const HQ = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
+const FUNCTIONS = fs.readFileSync(path.join(ROOT, 'functions.php'), 'utf8');
+
+async function hqAuf(page) {
+  await page.route('https://api.github.com/**', (r) => r.abort());
+  await page.goto('/hq.html');
+  await page.waitForTimeout(1600);
+  await page.evaluate(() => {
+    window.__gesprochen = [];
+    window.speechSynthesis.speak = (u) => {
+      window.__gesprochen.push(u.text);
+      if (u.onend) setTimeout(u.onend, 5);
+    };
+    window.__gespielt = [];
+    const Orig = window.Audio;
+    window.Audio = function (src) {
+      window.__gespielt.push(String(src).slice(0, 24));
+      const a = new Orig();
+      a.play = () => Promise.resolve();
+      return a;
+    };
+  });
+  await page.evaluate(() => window.ebCircleAPI.oeffnen());
+}
+const fragen = async (page) => {
+  await page.locator('#ebc-input').fill('Wie steht der Betrieb?');
+  await page.locator('#ebc-input').press('Enter');
+  await page.waitForTimeout(1800);
+};
+
+test.describe('Sprachausgabe', () => {
+  test('ohne Schlüssel fällt sie hörbar auf die Browserstimme zurück', async ({ page }) => {
+    let anfragen = 0;
+    await page.route('**/hq/stimme', (r) => {
+      anfragen++;
+      r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ verfuegbar: false, grund: 'nicht hinterlegt' }) });
+    });
+    await hqAuf(page);
+    await fragen(page);
+    const r = await page.evaluate(() => ({ g: window.__gesprochen.length, a: window.__gespielt.length }));
+    expect(anfragen, 'die Serverstimme wurde nicht einmal versucht').toBeGreaterThan(0);
+    expect(r.g, 'stumm geblieben, statt zurückzufallen').toBeGreaterThan(0);
+    expect(r.a, 'ohne Schlüssel darf kein Audio entstehen').toBe(0);
+  });
+
+  test('mit Schlüssel spielt die Serverstimme — und nur sie', async ({ page }) => {
+    await page.route('**/hq/stimme', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify({ verfuegbar: true, format: 'mp3', audio: 'AAAA' }) }));
+    await hqAuf(page);
+    await fragen(page);
+    const r = await page.evaluate(() => ({ g: window.__gesprochen.length, a: window.__gespielt.length }));
+    expect(r.a, 'die Serverstimme wurde nicht abgespielt').toBeGreaterThan(0);
+    expect(r.g, 'beide Stimmen gleichzeitig — das klingt wie ein Fehler').toBe(0);
+  });
+
+  test('nach einem Fehlschlag wird nicht bei jeder Antwort neu gefragt', async ({ page }) => {
+    // Sonst kostet jede Antwort einen Aufruf für einen Schlüssel, den es nicht gibt.
+    let anfragen = 0;
+    await page.route('**/hq/stimme', (r) => {
+      anfragen++;
+      r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ verfuegbar: false, grund: 'nicht hinterlegt' }) });
+    });
+    await hqAuf(page);
+    await fragen(page);
+    await fragen(page);
+    await fragen(page);
+    expect(anfragen, 'jede Antwort fragt erneut nach der Serverstimme').toBe(1);
+  });
+
+  test('Beenden stoppt beide Stimmen, nicht nur eine', async () => {
+    // Die drei Stopp-Stellen kannten nur speechSynthesis. Die Serverstimme
+    // hätte weitergesprochen, während das Mikrofon schon wieder zuhört.
+    const wirksam = HQ.split('\n').filter((z) => !/^\s*(\/\/|\*|\/\*)/.test(z)).join('\n');
+    expect(wirksam).toMatch(/function stimmeStoppen/);
+    // Nach dem Umbau darf ausserhalb von stimmeStoppen()/sayBrowser() keine
+    // nackte cancel()-Stelle mehr stehen.
+    const nackte = wirksam.split('\n').filter((z) =>
+      /speechSynthesis\.cancel\(\)/.test(z) && !/stimmeStoppen|^\s*speechSynthesis\.cancel\(\);$/.test(z));
+    expect(nackte, `Stopp-Stellen ohne Serverstimme: ${nackte.join(' | ')}`).toHaveLength(1);
+  });
+});
+
+test.describe('Die Sprach-Route', () => {
+  test('der Schlüssel erreicht den Browser nie', async () => {
+    expect(HQ, 'ein Schlüsselname im ausgelieferten HTML').not.toMatch(/EB_OPENAI_API_KEY/);
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_stimme'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    expect(rumpf, 'die Route gibt Audio zurück, keinen Schlüssel').not.toMatch(/'schluessel'|'key'/);
+    expect(rumpf).toMatch(/base64_encode/);
+    // Der Text der Gegenstelle darf nicht durchgereicht werden — er nennt
+    // Organisation und Kontodetails.
+    expect(rumpf, 'Fremdtext im Fehlerfall durchgereicht').not.toMatch(/retrieve_body\([^)]*\)[^;]*grund/);
+  });
+
+  test('sie hängt an derselben Rechteprüfung wie das übrige HQ', async () => {
+    const reg = FUNCTIONS.slice(FUNCTIONS.indexOf("'/hq/stimme'"));
+    expect(reg.slice(0, reg.indexOf(') );') + 4))
+      .toMatch(/'permission_callback'\s*=>\s*'eb_hq_proxy_darf'/);
+  });
+
+  test('ohne Schlüssel antwortet sie ehrlich statt zu scheitern', async () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_stimme'));
+    expect(fn.slice(0, 600)).toMatch(/defined\(\s*'EB_OPENAI_API_KEY'\s*\)[\s\S]{0,300}'verfuegbar'\s*=>\s*false/);
+  });
+
+  test('Länge und Häufigkeit sind begrenzt — sonst ist es eine offene Rechnung', async () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_stimme'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    // Im CODE gemessen, nicht im Kommentar. Der erste Entwurf dieser Zeile
+    // suchte bloß nach „1200" — und fand den Satz „1200 Zeichen sind rund
+    // zwei Minuten". Eine Mutation, die das Limit ersatzlos strich, blieb
+    // dadurch grün. Genau derselbe Fehler wie bei den Aufnahmekriterien des
+    // Autopilot-Rahmens, nur eine Ebene tiefer.
+    const nurCode = rumpf.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    expect(nurCode, 'kein wirksames Längenlimit').toMatch(/(mb_)?substr\([^)]*1200\s*\)/);
+    expect(nurCode, 'kein Rate-Limit').toMatch(/eventboerse_check_rate_limit\(\s*'hq_stimme'/);
+    // mb_substr: ein Schnitt mitten durch ein Mehrbyte-Zeichen erzeugt
+    // ungültiges UTF-8, und die Gegenstelle antwortet mit 400.
+    expect(rumpf, 'Umlaute am Schnitt zerbrechen').toMatch(/mb_substr/);
+  });
+});
+
+test.describe('HUD-Ringe am Sprech-Kreis', () => {
+  test('vier Lagen, und im Ruhezustand steht alles still', async ({ page }) => {
+    // Dieselbe Regel wie für die Impulse auf den Bahnen: eine Dauer-Animation
+    // lässt ein stillstehendes System wie ein arbeitendes aussehen.
+    const fehler = [];
+    page.on('pageerror', (e) => fehler.push(String(e)));
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2000);
+    expect(fehler).toEqual([]);
+    for (const k of ['feld', 'aussen', 'teilung', 'klammer', 'innen']) {
+      await expect(page.locator('.nn-hud-' + k)).toHaveCount(1);
+    }
+    const ruhe = await page.evaluate(() => ['aussen', 'teilung', 'klammer']
+      .map((k) => getComputedStyle(document.querySelector('.nn-hud-' + k)).animationName));
+    expect(ruhe, 'die Ringe drehen sich, ohne dass etwas passiert').toEqual(['none', 'none', 'none']);
+  });
+
+  test('Bewegung erst beim Zuhören', async ({ page }) => {
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2000);
+    const bewegt = await page.evaluate(() => {
+      document.getElementById('neural').classList.add('hoert');
+      return ['aussen', 'teilung', 'klammer']
+        .map((k) => getComputedStyle(document.querySelector('.nn-hud-' + k)).animationName);
+    });
+    expect(bewegt.every((n) => n === 'nnHudDreh'), `gemessen: ${bewegt.join(', ')}`).toBe(true);
+  });
+
+  test('wer weniger Bewegung will, bekommt Stillstand statt Flimmern', async ({ page }) => {
+    // Der globale Block setzt nur die Dauer auf ~0. Eine Endlosrotation steht
+    // damit nicht still, sie flimmert — ausgerechnet für die Leute, die um
+    // weniger Bewegung gebeten haben.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2000);
+    const namen = await page.evaluate(() => {
+      document.getElementById('neural').classList.add('hoert');
+      return ['aussen', 'teilung', 'klammer']
+        .map((k) => getComputedStyle(document.querySelector('.nn-hud-' + k)).animationName);
+    });
+    expect(namen, 'die Ringe animieren trotz reduzierter Bewegung').toEqual(['none', 'none', 'none']);
+  });
+
+  test('die Zustände sind auch ohne Farbe unterscheidbar', async ({ page }) => {
+    // Farbe allein wäre WCAG 1.4.1. Der Ruhe- und der Hörzustand müssen sich
+    // an mehr als am Farbwert erkennen lassen.
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2000);
+    const ruhe = await page.evaluate(() => getComputedStyle(document.querySelector('.nn-hud-teilung')).animationName);
+    const hoert = await page.evaluate(() => {
+      document.getElementById('neural').classList.add('hoert');
+      return getComputedStyle(document.querySelector('.nn-hud-teilung')).animationName;
+    });
+    expect(ruhe).not.toBe(hoert);
+  });
+});

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 356 Tests in 19 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 371 Tests in 20 Suiten**, blockierendes Gate in `pr-check.yml`.
   Vier Radar-Tests brauchen Leaflet vom CDN und schlagen ohne Netzzugang fehl —
   Umgebung, nicht Code
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,


### PR DESCRIPTION
Zwei Dinge, die zusammengehören: der Ring **sieht** aus wie Jarvis, und die Stimme **klingt** endlich nach etwas.

---

# Warum die Stimme schlecht war

Sie war kein schlechtes Sprachmodell. **Sie war gar keins.**

```js
speechSynthesis.speak(new SpeechSynthesisUtterance(text))
```

Das ist die Stimme des Betriebssystems. Auf Windows und Android klingt sie blechern, in manchen Browsern fehlt sie ganz. Serverseitige Sprach-Routen gab es keine.

## `/hq/stimme`

Erzeugt die Ausgabe serverseitig über OpenAI TTS (`gpt-4o-mini-tts`, Stimme `onyx`). **Der Schlüssel erreicht den Browser nie** — Text hin, fertiges Audio zurück, dasselbe Muster wie die bestehenden Probe-Routen. Opt-in über `EB_OPENAI_API_KEY`.

### Ohne Schlüssel fällt es *hörbar* zurück

Das ist der Kern, nicht ein Detail. **Eine Sprachausgabe, die still bleibt, ist für den Nutzer nicht von einem Absturz zu unterscheiden.** Also: Serverstimme versuchen → geht nicht → Browserstimme, sofort.

Das Ergebnis wird **einmal** gemerkt. Sonst kostet jede Antwort einen Aufruf für einen Schlüssel, den es nicht gibt — ein eigener Test hält das fest.

### Begrenzt, weil es pro Zeichen kostet

| | |
|---|---|
| Länge | 1200 Zeichen (~2 Min.) |
| Häufigkeit | 30 Ausgaben/Minute |
| Schnitt | `mb_substr`, nicht `substr` — mitten durch einen Umlaut erzeugt ungültiges UTF-8, und die Gegenstelle antwortet mit 400 |
| Fehlertext | wird **nicht** durchgereicht: er nennt Organisation und Kontodetails |

## Dabei gefunden: drei Stopp-Stellen, die nur eine Stimme kannten

„Gespräch beenden", „Mikrofon neu starten" und „Vorlesen aus" riefen alle nur `speechSynthesis.cancel()`. Die Serverstimme hätte **weitergesprochen, während das Mikrofon schon wieder zuhört**. Alle drei rufen jetzt `stimmeStoppen()`.

---

# Die Ringe

Vier Lagen aus reiner Geometrie um den Sprech-Kreis — Außenring mit Lücken, Skalenteilung, Klammerbögen, Innenring — dazu ein dunkles Feld. Ohne das Feld geht Cyan im violetten Grund der Zentrale unter; der HUD-Eindruck lebt vom Kontrast, nicht von der Anzahl der Ringe.

Kein Bild, kein Netzaufruf, skaliert mit dem `viewBox`.

## Sie stehen still

Dieselbe Regel wie für die Impulse auf den Bahnen: **eine Dauer-Animation lässt ein stillstehendes System wie ein arbeitendes aussehen.** Bewegung gibt es bei `.hoert` — gegenläufig, damit sie als Mechanik lesbar ist und nicht als Ladebalken. Beim Sprechen nur Helligkeit, keine Drehung: sonst sieht Antworten aus wie Arbeiten.

## `prefers-reduced-motion`

Der globale Block setzt nur `animation-duration: .001ms`. Eine **Endlos**rotation steht damit nicht still — sie flimmert, ausgerechnet für die Leute, die um weniger Bewegung gebeten haben. Die Ringe werden dort explizit abgeschaltet; die Zustände bleiben über die Farbe lesbar.

---

## Geprüft

12 Tests. **Sechs Mutationen — und zwei haben mich zuerst getäuscht:**

| Mutation | |
|---|---|
| Rückfall entfällt, bleibt still | ✓ fällt auf |
| Ringe drehen dauerhaft | ✓ fällt auf (2 Tests) |
| `reduced-motion`-Ausnahme weg | ✓ fällt auf |
| Rate-Limit weg | ✓ fällt auf |
| Längenbegrenzung weg | ⚠️ *erst nach Korrektur* |
| Schlüsselprüfung weg | ⚠️ *erst nach Korrektur* |

Die letzten beiden waren **fehlerhafte Mutationen**, nicht schwache Tests: die eine ersetzte nur einen Zweig eines Ternärs (der andere behielt das Limit), die andere griff wegen Escaping gar nicht. Nachgezogen — dann fielen beide auf.

**Ein Test war aber wirklich kaputt:** er suchte nach `1200` und fand den *Kommentar* „1200 Zeichen sind rund zwei Minuten". Eine Mutation, die das Limit ersatzlos strich, blieb dadurch grün. Jetzt wird im Code gemessen, nicht im Fließtext — derselbe Fehler wie bei den Aufnahmekriterien des Autopilot-Rahmens, nur eine Ebene tiefer.

**371 Tests in 20 Suiten, 367 grün.** Die vier Radar-Tests brauchen Leaflet von `unpkg.com`, das der Proxy dieser Umgebung sperrt — in CI laufen sie durch.

---

## Was du tun musst

**Nichts** — es funktioniert sofort, dann eben mit der Browserstimme.

Für die echte Stimme: `EB_OPENAI_API_KEY` in `wp-config.php`. Falls der Schlüssel schon gesetzt ist (die Probe-Route `/hq/probe/openai` nutzt denselben), ist beim nächsten Öffnen des HQ sofort die gute Stimme dran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_