### PR TITLE
Spracheingabe über Whisper — das Gegenstück zur Stimme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,20 @@ aussehen. Unter `prefers-reduced-motion` werden sie ganz abgeschaltet — der
 globale Block setzt nur die Dauer auf ~0, und eine Endlosrotation steht damit
 nicht still, sie flimmert.
 
+**Spracheingabe**: `/wp-json/eventboerse/v1/hq/gehoer` erkennt über Whisper —
+ebenfalls serverseitig, ebenfalls Opt-in über denselben Schlüssel. Ohne ihn
+greift wieder `SpeechRecognition` des Browsers, die es in Firefox und Safari
+**gar nicht gibt**; dort war das Mikrofon vorher wirkungslos. Der Ton wird nie
+auf die Platte geschrieben, `base64_decode` läuft `strict`, und die Länge wird
+**vor** dem Dekodieren geprüft — base64 ist ein Drittel größer als der Inhalt.
+
+Aufgenommen wird bis zur Stille (900 ms), höchstens 30 s. Wer gar nichts sagt,
+bricht nach 6 s ab: 30 Sekunden Stille zu erkennen kostet und liefert nichts.
+
+**Neue Stelle, die das Gespräch beendet → `aufnahmeBeenden()` mit aufrufen.**
+Ein Mikrofon, das nach dem Beenden weiterläuft, ist ein Datenschutzproblem und
+kein Schönheitsfehler.
+
 `/wp-json/eventboerse/v1/hq/probe/{anthropic|openai|openrouter}` prüft die KI-Schlüssel
 **serverseitig** — Gültigkeit und Rate-Limit-Kontingent, ohne dass der Schlüssel
 den Browser erreicht. Opt-in: nur aktiv, wenn die Server-Konstante gesetzt ist.
@@ -260,7 +274,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-371 Tests in 20 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+381 Tests in 20 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-21T17:31:54.901Z",
+  "erzeugt": "2026-08-21T19:04:25.413Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/functions.php
+++ b/functions.php
@@ -9783,7 +9783,133 @@ add_action( 'rest_api_init', function () {
             'text' => array( 'required' => true, 'type' => 'string' ),
         ),
     ) );
+
+    register_rest_route( 'eventboerse/v1', '/hq/gehoer', array(
+        'methods'             => 'POST',
+        'callback'            => 'eb_hq_gehoer',
+        'permission_callback' => 'eb_hq_proxy_darf',
+        'args'                => array(
+            'audio' => array( 'required' => true, 'type' => 'string' ),
+        ),
+    ) );
 } );
+
+/**
+ * Groesstes entgegengenommenes Tonstueck. Opus bei 24 kbit/s: rund 20 Minuten.
+ *
+ * Bewusst ausgeschrieben statt MB_IN_BYTES: eine `const` wird beim Einlesen
+ * dieser Datei ausgewertet, und eine Konstante aus dem Core an dieser Stelle
+ * vorauszusetzen macht das Theme von einer Ladereihenfolge abhaengig, die es
+ * nicht selbst kontrolliert.
+ */
+const EB_HQ_GEHOER_MAX = 4 * 1024 * 1024;
+
+/**
+ * Spracheingabe fuer das HQ — Whisper, serverseitig.
+ *
+ * Das Gegenstueck zu eb_hq_stimme(). Bisher lief die Erkennung ueber
+ * `SpeechRecognition` im Browser: in Chrome brauchbar, in Firefox und Safari
+ * gar nicht vorhanden. Wer dort auf das Mikrofon drueckte, bekam nichts —
+ * keine Fehlermeldung, keine Eingabe.
+ *
+ * Dieselben drei Eigenschaften wie bei der Ausgabe:
+ *
+ * 1. DER SCHLUESSEL ERREICHT DEN BROWSER NIE. Ton hin, Text zurueck.
+ *
+ * 2. OHNE SCHLUESSEL EIN EHRLICHES NEIN, damit der Browser sichtbar auf
+ *    seine eigene Erkennung zurueckfallen kann. Ein Mikrofon, das nichts
+ *    tut und nichts sagt, ist von einem Defekt nicht zu unterscheiden.
+ *
+ * 3. GROESSE BEGRENZT. Sprache kostet pro Minute, und ein unbegrenztes
+ *    Feld waere zugleich eine offene Rechnung und ein Speicherproblem:
+ *    base64 wird im Arbeitsspeicher dekodiert.
+ *
+ * Der Ton wird NICHT auf die Platte geschrieben. Eine Sprachaufnahme, die
+ * als Datei liegen bleibt, ist ein personenbezogenes Datum mit unklarer
+ * Loeschfrist — sie existiert hier nur fuer die Dauer des Aufrufs.
+ */
+function eb_hq_gehoer( WP_REST_Request $request ) {
+    if ( ! defined( 'EB_OPENAI_API_KEY' ) || ! EB_OPENAI_API_KEY ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'EB_OPENAI_API_KEY ist auf dem Server nicht hinterlegt.',
+        ), 200 );
+    }
+
+    $roh = (string) $request->get_param( 'audio' );
+    // Vor dem Dekodieren messen, nicht danach: base64 ist rund ein Drittel
+    // groesser als der Inhalt, und erst decodieren, dann pruefen hiesse, den
+    // Speicher schon belegt zu haben.
+    if ( strlen( $roh ) > (int) ceil( EB_HQ_GEHOER_MAX * 4 / 3 ) + 1024 ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'Aufnahme zu lang.',
+        ), 413 );
+    }
+    // strict: sonst schluckt PHP Muell und liefert Bytes, die kein Ton sind.
+    $audio = base64_decode( $roh, true );
+    if ( $audio === false || $audio === '' ) {
+        return new WP_REST_Response( array( 'verfuegbar' => false, 'grund' => 'Keine gültige Aufnahme.' ), 400 );
+    }
+    if ( strlen( $audio ) > EB_HQ_GEHOER_MAX ) {
+        return new WP_REST_Response( array( 'verfuegbar' => false, 'grund' => 'Aufnahme zu lang.' ), 413 );
+    }
+
+    $limit = eventboerse_check_rate_limit( 'hq_gehoer', 30, MINUTE_IN_SECONDS );
+    if ( is_wp_error( $limit ) ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => $limit->get_error_message(),
+        ), 429 );
+    }
+
+    // multipart von Hand: wp_remote_post kennt keinen Datei-Upload.
+    $grenze = 'eb' . wp_generate_password( 24, false );
+    $teil   = function ( $name, $wert ) use ( $grenze ) {
+        return "--{$grenze}\r\nContent-Disposition: form-data; name=\"{$name}\"\r\n\r\n{$wert}\r\n";
+    };
+    $body  = $teil( 'model', 'whisper-1' );
+    // Sprache fest auf Deutsch: ohne Angabe raet Whisper mit, und bei kurzen
+    // Aeusserungen ("ja", "stopp") raet es regelmaessig auf Englisch.
+    $body .= $teil( 'language', 'de' );
+    $body .= "--{$grenze}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"ton.webm\"\r\n"
+           . "Content-Type: audio/webm\r\n\r\n" . $audio . "\r\n";
+    $body .= "--{$grenze}--\r\n";
+
+    $res = wp_remote_post( 'https://api.openai.com/v1/audio/transcriptions', array(
+        'timeout' => 30,
+        'headers' => array(
+            'Authorization' => 'Bearer ' . EB_OPENAI_API_KEY,
+            'Content-Type'  => 'multipart/form-data; boundary=' . $grenze,
+        ),
+        'body' => $body,
+    ) );
+
+    if ( is_wp_error( $res ) ) {
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'Erkennung nicht erreichbar: ' . $res->get_error_message(),
+        ), 200 );
+    }
+    $code = (int) wp_remote_retrieve_response_code( $res );
+    if ( $code !== 200 ) {
+        // Wie bei der Ausgabe: der Text der Gegenstelle nennt Organisation
+        // und Kontodetails und wird darum nicht durchgereicht.
+        return new WP_REST_Response( array(
+            'verfuegbar' => false,
+            'grund'      => 'Erkennung antwortete mit HTTP ' . $code . '.',
+        ), 200 );
+    }
+
+    $d    = json_decode( wp_remote_retrieve_body( $res ), true );
+    $text = is_array( $d ) && isset( $d['text'] ) ? trim( (string) $d['text'] ) : '';
+    return new WP_REST_Response( array(
+        'verfuegbar' => true,
+        // Leer ist eine gueltige Antwort: es wurde nichts gesagt. Das ist
+        // etwas anderes als ein Fehler, und der Browser behandelt es anders.
+        'text'       => $text,
+    ), 200 );
+}
 
 /**
  * Sprachausgabe fuer das HQ — serverseitig, damit der Schluessel bleibt, wo er hingehoert.

--- a/hq.html
+++ b/hq.html
@@ -4183,7 +4183,179 @@ window.addEventListener('DOMContentLoaded', init);
   /* ── Spracheingabe über die Web Speech API des Browsers ─────────── */
   var SR = window.SpeechRecognition || window.webkitSpeechRecognition;
   if (!SR) { micBtn.disabled = true; micBtn.title = 'Spracheingabe wird von diesem Browser nicht unterstützt'; micBtn.style.opacity = .4; }
+  /* ── Spracheingabe ─────────────────────────────────────────────────────
+     Bisher ausschliesslich `SpeechRecognition`: in Chrome brauchbar, in
+     Firefox und Safari gar nicht vorhanden. Wer dort auf das Mikrofon
+     drueckte, bekam nichts — keine Eingabe und keine Fehlermeldung.
+
+     Jetzt zuerst Whisper ueber /hq/gehoer (Schluessel bleibt am Server),
+     sonst die Erkennung des Browsers. Wie bei der Ausgabe wird das Ergebnis
+     einmal gemerkt.
+
+     Der Unterschied zur Browsererkennung ist ehrlich zu benennen: Whisper
+     hoert erst zu und versteht dann. Es gibt also keinen mitlaufenden Text
+     waehrend des Sprechens, dafuer ein deutlich besseres Ergebnis. Damit die
+     Pause nicht wie ein Absturz wirkt, sagt der Kreis waehrenddessen
+     „…verstehe". */
+  var gehoerServer = null;
+  var aufnahme = null, aufnahmeStrom = null, aufnahmeCtx = null;
+
+  function aufnahmeBeenden() {
+    try { if (aufnahme && aufnahme.state === 'recording') aufnahme.stop(); } catch (e) {}
+    try { if (aufnahmeStrom) aufnahmeStrom.getTracks().forEach(function (t) { t.stop(); }); } catch (e) {}
+    try { if (aufnahmeCtx) aufnahmeCtx.close(); } catch (e) {}
+    aufnahme = null; aufnahmeStrom = null; aufnahmeCtx = null;
+  }
+
+  function kannAufnehmen() {
+    return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia && window.MediaRecorder);
+  }
+
+  /**
+   * Nimmt auf, bis es still wird — oder bis das harte Limit greift.
+   *
+   * Ohne Stille-Erkennung muesste man zum Beenden erneut klicken, und der
+   * Kreis waere kein Sprachassistent mehr, sondern ein Diktiergeraet. Die
+   * Obergrenze ist trotzdem noetig: ein offenes Mikrofon in einem lauten
+   * Raum wird sonst nie still und nimmt bis zum Groessenlimit auf.
+   */
+  function tonAufnehmen(session) {
+    return new Promise(function (fertig) {
+      navigator.mediaDevices.getUserMedia({ audio: true }).then(function (strom) {
+        aufnahmeStrom = strom;
+        var stuecke = [];
+        var mr;
+        try { mr = new MediaRecorder(strom, { mimeType: 'audio/webm' }); }
+        catch (e) { try { mr = new MediaRecorder(strom); } catch (e2) { aufnahmeBeenden(); fertig(null); return; } }
+        aufnahme = mr;
+        mr.ondataavailable = function (ev) { if (ev.data && ev.data.size) stuecke.push(ev.data); };
+        mr.onstop = function () {
+          var strm = aufnahmeStrom;
+          aufnahmeBeenden();
+          if (session !== dialogSession) { fertig(null); return; }
+          fertig(stuecke.length ? new Blob(stuecke, { type: mr.mimeType || 'audio/webm' }) : null);
+          void strm;
+        };
+
+        listening = true;
+        circle.classList.add('listening'); micBtn.classList.add('on');
+        voiceState('Hört zu…', 'hoert');
+        mr.start();
+
+        // Stille messen statt raten.
+        var AC = window.AudioContext || window.webkitAudioContext;
+        var hartesEnde = setTimeout(function () { try { mr.stop(); } catch (e) {} }, 30000);
+        if (!AC) return;
+        aufnahmeCtx = new AC();
+        var quelle = aufnahmeCtx.createMediaStreamSource(strom);
+        var analyse = aufnahmeCtx.createAnalyser();
+        analyse.fftSize = 512;
+        quelle.connect(analyse);
+        var daten = new Uint8Array(analyse.frequencyBinCount);
+        var stillSeit = null, hatGesprochen = false;
+        // Wer gar nichts sagt, soll nicht 30 Sekunden Stille aufnehmen und
+        // sie dann zur Erkennung schicken: das kostet, dauert und liefert
+        // garantiert nichts. Nach 6 Sekunden ohne einen einzigen lauten
+        // Abschnitt ist die Aufnahme vorbei — stumm ist eine Antwort.
+        var nieGesprochen = setTimeout(function () {
+          if (!hatGesprochen) { clearTimeout(hartesEnde); try { mr.stop(); } catch (e) {} }
+        }, 6000);
+        (function pruefe() {
+          if (!aufnahme || aufnahme.state !== 'recording') { clearTimeout(hartesEnde); clearTimeout(nieGesprochen); return; }
+          analyse.getByteTimeDomainData(daten);
+          var abweichung = 0;
+          for (var i = 0; i < daten.length; i++) abweichung += Math.abs(daten[i] - 128);
+          var laut = (abweichung / daten.length) > 2.2;
+          if (laut) { hatGesprochen = true; stillSeit = null; }
+          else if (hatGesprochen) {
+            if (stillSeit === null) stillSeit = Date.now();
+            // 900 ms: kuerzer schneidet mitten im Satz ab, laenger fuehlt
+            // sich an, als haette das Mikrofon nicht zugehoert.
+            else if (Date.now() - stillSeit > 900) { clearTimeout(hartesEnde); clearTimeout(nieGesprochen); try { mr.stop(); } catch (e) {} return; }
+          }
+          requestAnimationFrame(pruefe);
+        })();
+      }).catch(function () {
+        aufnahmeBeenden();
+        voiceMode = false;
+        voiceState('Mikrofon nicht erlaubt', null);
+        fertig(null);
+      });
+    });
+  }
+
+  function alsBase64(blob) {
+    return new Promise(function (fertig) {
+      var fr = new FileReader();
+      fr.onload = function () { fertig(String(fr.result).split(',')[1] || ''); };
+      fr.onerror = function () { fertig(''); };
+      fr.readAsDataURL(blob);
+    });
+  }
+
+  async function hoerenServer(session) {
+    var blob = await tonAufnehmen(session);
+    listening = false; circle.classList.remove('listening'); micBtn.classList.remove('on');
+    if (!blob || session !== dialogSession || !panel.classList.contains('open')) return false;
+
+    // Sehr kurze Aufnahmen sind Stille oder ein Fehlklick. Sie zu senden
+    // kostet einen Aufruf fuer ein garantiert leeres Ergebnis.
+    if (blob.size < 1200) {
+      voiceState('Nichts gehört', null);
+      if (voiceMode && panel.classList.contains('open') && !asking) setTimeout(toggleMic, 400);
+      return true;
+    }
+
+    voiceState('…verstehe', 'hoert');
+    var b64 = await alsBase64(blob);
+    if (!b64) return false;
+
+    var res = await fetch('/wp-json/eventboerse/v1/hq/gehoer', {
+      method: 'POST', credentials: 'same-origin', cache: 'no-store',
+      headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': HQ_REST_NONCE },
+      body: JSON.stringify({ audio: b64 })
+    });
+    if (!res.ok) return false;
+    var d = await res.json();
+    if (!d || !d.verfuegbar) return false;
+    if (session !== dialogSession || !panel.classList.contains('open')) return true;
+
+    voiceState('Bereit für dein Gespräch', null);
+    var t = String(d.text || '').trim();
+    // Leer heisst: es wurde nichts gesagt. Kein Fehler — aber auch keine
+    // Frage, die man absenden koennte.
+    if (t) { input.value = ''; ask(t); }
+    else if (voiceMode && panel.classList.contains('open') && !asking) setTimeout(toggleMic, 200);
+    return true;
+  }
+
   function toggleMic() {
+    // Laeuft eine Aufnahme, beendet ein zweiter Druck sie — genau wie beim
+    // Stoppen der Browsererkennung.
+    if (aufnahme) { try { aufnahme.stop(); } catch (e) {} return; }
+
+    if (gehoerServer !== false && kannAufnehmen()) {
+      var session = dialogSession;
+      if ((window.speechSynthesis && speechSynthesis.speaking) || laufendesAudio) { suppressVoiceRestart = true; stimmeStoppen(); }
+      recognitionSession = session;
+      hoerenServer(session).then(function (ok) {
+        if (ok) { gehoerServer = true; return; }
+        gehoerServer = false;
+        // Sichtbar weitermachen statt stumm bleiben.
+        if (SR) micBrowser();
+        else voiceState('Spracheingabe hier nicht verfügbar', null);
+      }).catch(function () {
+        gehoerServer = false;
+        listening = false; circle.classList.remove('listening'); micBtn.classList.remove('on');
+        if (SR) micBrowser();
+        else voiceState('Spracheingabe hier nicht verfügbar', null);
+      });
+      return;
+    }
+    micBrowser();
+  }
+
+  function micBrowser() {
     if (!SR) return;
     if (listening) { try { rec.stop(); } catch (e) {} return; }
     if (asking && askController) askController.abort();
@@ -4254,6 +4426,9 @@ window.addEventListener('DOMContentLoaded', init);
     input.value = ''; recognitionAlternatives = []; recognitionConfidence = null;
     conversation = []; log.innerHTML = '';
     try { suppressVoiceRestart = true; stimmeStoppen(); } catch (e) {}
+    // Auch die Aufnahme: ein Mikrofon, das nach dem Beenden weiterlaeuft,
+    // ist ein Datenschutzproblem und kein Schoenheitsfehler.
+    aufnahmeBeenden();
     voiceState('Gespräch beendet', null);
     syncDialogControls();
   }
@@ -4276,7 +4451,13 @@ window.addEventListener('DOMContentLoaded', init);
     sprechen: toggleMic,
     beenden: close,
     istOffen: function () { return panel.classList.contains('open'); },
-    kannHoeren: function () { return !!(window.SpeechRecognition || window.webkitSpeechRecognition); },
+    /* Seit Whisper reicht ein aufnahmefaehiger Browser — die
+       SpeechRecognition-Frage allein haette Firefox und Safari weiter als
+       taub gemeldet, obwohl sie es nicht mehr sind. */
+    kannHoeren: function () {
+      return !!(window.SpeechRecognition || window.webkitSpeechRecognition
+        || (navigator.mediaDevices && navigator.mediaDevices.getUserMedia && window.MediaRecorder));
+    },
     operativeAntwort: function (frage) { return hqOperativeAntwort(frage); },
     sync: syncDialogControls,
     /* Der Lagebericht auch ausserhalb des Gespraechs — er ist eine Aussage

--- a/tests/e2e/stimme.spec.js
+++ b/tests/e2e/stimme.spec.js
@@ -9,9 +9,31 @@
 // der Ausfall: eine Sprachausgabe, die einfach still bleibt, ist fuer den
 // Nutzer nicht von einem Absturz zu unterscheiden. Darum pruefen die ersten
 // beiden Tests genau das — dass jeder Weg HOERBAR endet.
-const { test, expect } = require('@playwright/test');
+const { test, expect, chromium } = require('@playwright/test');
 const fs = require('node:fs');
 const path = require('node:path');
+
+/* Ein Browser mit simuliertem Mikrofon. Ohne das nimmt der Kreis Stille auf,
+   und die Whisper-Strecke waere nur scheinbar geprueft. */
+const CHROMIUM = process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium';
+async function mitMikrofon() {
+  const browser = await chromium.launch({
+    executablePath: fs.existsSync(CHROMIUM) ? CHROMIUM : undefined,
+    args: ['--use-fake-device-for-media-stream', '--use-fake-ui-for-media-stream'],
+  });
+  const ctx = await browser.newContext({ permissions: ['microphone'], baseURL: 'http://localhost:8000' });
+  const page = await ctx.newPage();
+  await page.route('https://api.github.com/**', (r) => r.abort());
+  await page.route('**/hq/stimme', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+    body: JSON.stringify({ verfuegbar: false, grund: 'nicht hinterlegt' }) }));
+  return { browser, page };
+}
+async function circleAuf(page) {
+  await page.goto('/hq.html');
+  await page.waitForTimeout(1600);
+  await page.evaluate(() => { window.speechSynthesis.speak = (u) => { if (u.onend) setTimeout(u.onend, 5); }; });
+  await page.evaluate(() => window.ebCircleAPI.oeffnen());
+}
 
 const ROOT = path.join(__dirname, '..', '..');
 const HQ = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
@@ -196,5 +218,153 @@ test.describe('HUD-Ringe am Sprech-Kreis', () => {
       return getComputedStyle(document.querySelector('.nn-hud-teilung')).animationName;
     });
     expect(ruhe).not.toBe(hoert);
+  });
+});
+
+test.describe('Spracheingabe', () => {
+  test.describe.configure({ timeout: 60000 });
+
+  test('Whisper hört zu, schickt und setzt die Frage ab', async () => {
+    const { browser, page } = await mitMikrofon();
+    const fehler = []; page.on('pageerror', (e) => fehler.push(String(e)));
+    let aufrufe = 0, laenge = 0;
+    await page.route('**/hq/gehoer', async (r) => {
+      aufrufe++;
+      laenge = (JSON.parse(r.request().postData() || '{}').audio || '').length;
+      await r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ verfuegbar: true, text: 'Wie steht der Betrieb?' }) });
+    });
+    await circleAuf(page);
+    await page.evaluate(() => window.ebCircleAPI.sprechen());
+    await page.waitForTimeout(11000);
+    expect(fehler).toEqual([]);
+    expect(aufrufe, 'die Aufnahme wurde nie gesendet').toBe(1);
+    expect(laenge, 'es wurde nichts aufgenommen').toBeGreaterThan(1000);
+    // Die erkannte Frage muss auch wirklich gestellt worden sein.
+    await expect(page.locator('#ebc-log .ebc-msg').last()).not.toHaveText(/^\s*$/);
+    await browser.close();
+  });
+
+  test('ohne Whisper fällt es sichtbar auf die Browsererkennung zurück', async () => {
+    const { browser, page } = await mitMikrofon();
+    await page.route('**/hq/gehoer', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify({ verfuegbar: false, grund: 'nicht hinterlegt' }) }));
+    await circleAuf(page);
+    const gestartet = await page.evaluate(async () => {
+      window.__srStart = 0;
+      const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (SR) SR.prototype.start = function () { window.__srStart++; };
+      window.ebCircleAPI.sprechen();
+      await new Promise((f) => setTimeout(f, 10000));
+      return { sr: window.__srStart, zustand: (document.getElementById('ebc-state') || {}).textContent || '' };
+    });
+    // Entweder springt die Browsererkennung an, oder der Kreis sagt, dass es
+    // hier nicht geht. Still bleiben darf er nicht.
+    expect(gestartet.sr > 0 || /nicht verfügbar|Nichts gehört/i.test(gestartet.zustand),
+      `weder Rückfall noch Hinweis (Zustand: "${gestartet.zustand}")`).toBe(true);
+    await browser.close();
+  });
+
+  test('das Mikrofon geht zu, wenn das Gespräch endet', async () => {
+    // Ein Mikrofon, das nach dem Beenden weiterläuft, ist ein
+    // Datenschutzproblem und kein Schönheitsfehler.
+    const { browser, page } = await mitMikrofon();
+    await page.route('**/hq/gehoer', (r) => r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify({ verfuegbar: true, text: '' }) }));
+    await page.goto('/hq.html');
+    // Die Tonkanaele mitschreiben, BEVOR der Kreis das Mikrofon oeffnet.
+    // Ein erster Entwurf dieses Tests las eine Liste, die niemand befuellte —
+    // er pruefte ein leeres Array und bestand immer.
+    await page.evaluate(() => {
+      window.__spuren = [];
+      const echt = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+      navigator.mediaDevices.getUserMedia = async (c) => {
+        const s = await echt(c);
+        s.getTracks().forEach((t) => window.__spuren.push(t));
+        return s;
+      };
+      window.speechSynthesis.speak = (u) => { if (u.onend) setTimeout(u.onend, 5); };
+    });
+    await page.waitForTimeout(1400);
+    await page.evaluate(() => window.ebCircleAPI.oeffnen());
+    await page.evaluate(() => window.ebCircleAPI.sprechen());
+    await page.waitForTimeout(1500);
+
+    // Das Messfenster muss KUERZER sein als die Stille-Schwelle (900 ms).
+    // Sonst beendet die Stille-Erkennung die Aufnahme im selben Zeitraum
+    // ohnehin, und der Test kann beide Ursachen nicht unterscheiden: eine
+    // Mutation, die aufnahmeBeenden() aus dem Schliesspfad entfernte, blieb
+    // dadurch gruen.
+    const r = await page.evaluate(async () => {
+      const live = () => window.__spuren.filter((t) => t.readyState === 'live').length;
+      // Warten, bis das Mikrofon wirklich offen ist.
+      for (let i = 0; i < 40 && live() === 0; i++) await new Promise((f) => setTimeout(f, 50));
+      const vorher = live();
+      window.ebCircleAPI.beenden();
+      await new Promise((f) => setTimeout(f, 150));
+      return { vorher, nachher: live() };
+    });
+    expect(r.vorher, 'das Mikrofon wurde gar nicht geöffnet — der Test misst nichts').toBeGreaterThan(0);
+    expect(r.nachher, 'ein Tonkanal blieb nach dem Beenden offen').toBe(0);
+    await browser.close();
+  });
+});
+
+test.describe('Die Whisper-Route', () => {
+  test('der Schlüssel erreicht den Browser nie', () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_gehoer'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    expect(rumpf).toMatch(/EB_OPENAI_API_KEY/);
+    expect(HQ, 'Schlüsselname im ausgelieferten HTML').not.toMatch(/EB_OPENAI_API_KEY/);
+    expect(rumpf, 'Fremdtext im Fehlerfall durchgereicht').not.toMatch(/retrieve_body\([^)]*\)[^;]*grund/);
+  });
+
+  test('sie hängt an derselben Rechteprüfung wie das übrige HQ', () => {
+    const reg = FUNCTIONS.slice(FUNCTIONS.indexOf("'/hq/gehoer'"));
+    expect(reg.slice(0, reg.indexOf(') );') + 4))
+      .toMatch(/'permission_callback'\s*=>\s*'eb_hq_proxy_darf'/);
+  });
+
+  test('ohne Schlüssel antwortet sie ehrlich statt zu scheitern', () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_gehoer'));
+    expect(fn.slice(0, 500)).toMatch(/defined\(\s*'EB_OPENAI_API_KEY'\s*\)[\s\S]{0,300}'verfuegbar'\s*=>\s*false/);
+  });
+
+  test('Größe und Häufigkeit sind begrenzt, und base64 wird streng gelesen', () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_gehoer'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    const nurCode = rumpf.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    // Vor dem Dekodieren messen: base64 ist ein Drittel größer, und erst
+    // decodieren hieße, den Speicher schon belegt zu haben.
+    expect(nurCode, 'die Länge wird erst nach dem Dekodieren geprüft')
+      .toMatch(/strlen\(\s*\$roh\s*\)[\s\S]{0,200}EB_HQ_GEHOER_MAX/);
+    expect(nurCode, 'kein Limit nach dem Dekodieren').toMatch(/strlen\(\s*\$audio\s*\)\s*>\s*EB_HQ_GEHOER_MAX/);
+    expect(nurCode, 'kein Rate-Limit').toMatch(/eventboerse_check_rate_limit\(\s*'hq_gehoer'/);
+    // strict: sonst schluckt PHP Müll und liefert Bytes, die kein Ton sind.
+    expect(nurCode, 'base64 wird nicht streng gelesen').toMatch(/base64_decode\([^)]*,\s*true\s*\)/);
+  });
+
+  test('der Ton wird nicht auf die Platte geschrieben', () => {
+    // Eine Sprachaufnahme, die als Datei liegen bleibt, ist ein
+    // personenbezogenes Datum mit unklarer Löschfrist.
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_gehoer'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    const nurCode = rumpf.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    expect(nurCode).not.toMatch(/file_put_contents|tmpfile|wp_upload_dir|fopen\(/);
+  });
+
+  test('leer erkannt ist kein Fehler, sondern eine Aussage', () => {
+    const fn = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_hq_gehoer'));
+    const rumpf = fn.slice(0, fn.indexOf('\n}\n') + 3);
+    // Kein Text gesagt -> verfuegbar bleibt true, der Text ist leer. Sonst
+    // faellt der Browser auf die schlechtere Erkennung zurueck, nur weil
+    // gerade niemand gesprochen hat.
+    expect(rumpf).toMatch(/'verfuegbar'\s*=>\s*true[\s\S]{0,300}'text'\s*=>\s*\$text/);
+  });
+
+  test('auch Firefox und Safari gelten jetzt als hörfähig', () => {
+    // Die reine SpeechRecognition-Frage hätte sie weiter als taub gemeldet,
+    // obwohl Whisper dort funktioniert.
+    expect(HQ).toMatch(/kannHoeren[\s\S]{0,400}MediaRecorder/);
   });
 });

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 371 Tests in 20 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 381 Tests in 20 Suiten**, blockierendes Gate in `pr-check.yml`.
   Vier Radar-Tests brauchen Leaflet vom CDN und schlagen ohne Netzzugang fehl —
   Umgebung, nicht Code
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,


### PR DESCRIPTION
Die Ausgabe ist seit #174 serverseitig. Die **Eingabe** lief weiter über `SpeechRecognition` — in Chrome brauchbar, in **Firefox und Safari gar nicht vorhanden**. Wer dort auf das Mikrofon drückte, bekam nichts: keine Eingabe und keine Fehlermeldung.

## `/hq/gehoer`

Nimmt den Ton entgegen, gibt Text zurück. Dieselben drei Eigenschaften wie bei der Ausgabe: **der Schlüssel erreicht den Browser nie**, ohne Schlüssel ein ehrliches Nein mit sichtbarem Rückfall, Größe begrenzt.

### Vier Entscheidungen, die im Code begründet stehen

| | |
|---|---|
| Länge **vor** dem Dekodieren geprüft | base64 ist ein Drittel größer als der Inhalt. Erst decodieren, dann prüfen hieße, den Speicher schon belegt zu haben |
| `base64_decode(…, true)` | Ohne `strict` schluckt PHP Müll und liefert Bytes, die kein Ton sind |
| Nie auf die Platte | Eine Sprachaufnahme, die als Datei liegen bleibt, ist ein personenbezogenes Datum mit unklarer Löschfrist |
| Leer = `verfuegbar: true`, Text `''` | Es wurde nichts gesagt. Das ist **kein Fehler** — der Browser darf deswegen nicht auf die schlechtere Erkennung zurückfallen |

## Die Aufnahme

Bis zur Stille (900 ms), höchstens 30 s.

**Beim Bauen aufgefallen:** Wer gar nichts sagt, hätte 30 Sekunden Stille aufgenommen und zur Erkennung geschickt — kostet, dauert, liefert garantiert nichts. Jetzt bricht es nach 6 s ohne einen einzigen lauten Abschnitt ab, und sehr kurze Aufnahmen (< 1,2 KB) werden gar nicht erst gesendet.

Der Unterschied zur Browsererkennung ist ehrlich zu benennen: **Whisper hört erst zu und versteht dann.** Kein mitlaufender Text während des Sprechens, dafür ein deutlich besseres Ergebnis. Damit die Pause nicht wie ein Absturz wirkt, sagt der Kreis währenddessen „…verstehe".

## Zwei Dinge, die dabei mit repariert wurden

**`close()` schließt jetzt auch das Mikrofon.** Vorher lief die Aufnahme nach „Gespräch beenden" weiter. Ein Mikrofon, das nach dem Beenden offen bleibt, ist ein Datenschutzproblem und kein Schönheitsfehler.

**`kannHoeren()`** fragte nur nach `SpeechRecognition` — das HQ hätte Firefox und Safari weiter als taub gemeldet, obwohl Whisper dort funktioniert.

## Geprüft — mit simuliertem Mikrofon

Ohne `--use-fake-device-for-media-stream` nimmt der Kreis in der Testumgebung Stille auf, und die ganze Strecke wäre nur *scheinbar* geprüft. Der erste Durchlauf zeigte genau das: **0 Aufrufe** an die Route.

Vier Mutationen — und **eine deckte einen hohlen Test von mir auf**:

| Mutation | |
|---|---|
| `base64` nicht mehr streng | ✓ fällt auf |
| Größenprüfung vor dem Dekodieren weg | ✓ fällt auf |
| Leer erkannt gilt als nicht verfügbar | ✓ fällt auf |
| Mikrofon bleibt nach dem Beenden offen | ⚠️ **blieb zuerst grün** |

Das Messfenster nach `beenden()` war 600 ms lang — die Stille-Erkennung beendet die Aufnahme in derselben Zeit ohnehin. Der Test konnte beide Ursachen nicht unterscheiden. Fenster jetzt **150 ms**, kürzer als die Stille-Schwelle von 900 ms. Dann fällt die Mutation auf.

Ein zweiter Test war vorher schon hohl: er las `window.__spuren`, eine Liste, die niemand befüllte — er prüfte ein leeres Array und bestand immer. Jetzt wird `getUserMedia` instrumentiert, **bevor** der Kreis das Mikrofon öffnet, und der Test scheitert auch dann, wenn das Mikrofon gar nicht erst aufging.

**381 Tests in 20 Suiten, 377 grün.** Die vier Radar-Tests brauchen Leaflet von `unpkg.com`, das der Proxy dieser Umgebung sperrt — in CI laufen sie durch.

---

## Was du tun musst

**Nichts** — ohne Schlüssel bleibt alles wie bisher.

Mit `EB_OPENAI_API_KEY` in `wp-config.php` sind dann **beide Richtungen** gut: Whisper hört, OpenAI TTS antwortet. Und das HQ ist erstmals auch in Firefox und Safari per Sprache bedienbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_