### PR TITLE
Aufträge aus dem Gespräch, Wertbeitrag im HQ, schnellere Bilder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-388 Tests in 20 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+393 Tests in 21 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -327,6 +327,25 @@ Eintrag in der Datenschutzerklärung.
 
 Achtung beim Ablegen neuer Dateien: `.gitignore` enthält ein nicht verankertes
 `vendor/`, das auch `assets/vendor/` verschluckt. Deshalb `assets/lib/`.
+
+### Bilder und Ladezeit
+
+Die Demo-Bilder kommen weiterhin von **Pexels**. `scripts/localize-demo-images.mjs`
+lädt sie herunter und schreibt die URLs auf lokale Pfade um — das Skript
+existiert, ist aber nie gelaufen. **Es braucht Netzzugang zu Pexels**, den die
+Agent-Umgebung nicht hat; ausführen muss es jemand auf einem normalen Rechner.
+
+**Anfragen zählen, nicht Elemente.** Die Startseite trägt 191 Bild-Elemente,
+löst aber nur ~11 eindeutige Anfragen aus: die 180 Marquee-Karten teilen sich
+dieselbe Adresse, und der Browser fasst gleiche URLs zusammen. Eine Optimierung,
+die Elemente zählt, optimiert hier das Falsche — der Test in
+`tests/e2e/bild-laden.spec.js` prüft deshalb das Verhältnis von Elementen zu
+Anfragen.
+
+`EB_IMG_LAZY_ATTR` und `EB_IMG_EAGER_ATTR` in `core/00-basis.js` stehen an einer
+Stelle. **Das grosse Bild oben nie verzögern** — ein verzögertes LCP-Element
+macht die Seite langsamer. `loading` muss im Markup stehen, bevor das Bild ins
+Dokument kommt; nachträglich gesetzt ist es wirkungslos.
 
 ### OpenRouter-Autopilot
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-395 Tests in 21 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+402 Tests in 22 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -327,6 +327,23 @@ Eintrag in der Datenschutzerklärung.
 
 Achtung beim Ablegen neuer Dateien: `.gitignore` enthält ein nicht verankertes
 `vendor/`, das auch `assets/vendor/` verschluckt. Deshalb `assets/lib/`.
+
+### Aufträge aus dem Gespräch
+
+Ein gesprochener oder getippter Satz, der mit **„Auftrag:", „Aufgabe:",
+„notiere", „trag ein"** o. ä. beginnt, wird im EB Circle als Auftrag erkannt
+und als **GitHub-Issue** angelegt (Label `aus-dem-hq`, mit Herkunftsvermerk).
+
+Drei Grenzen, alle mutationsgeprüft:
+
+- **Nie ohne Rückfrage.** Spracherkennung verhört sich; ein verhörter Satz darf
+  kein Ticket anlegen. Der Auftrag wird gezeigt, erst ein Klick legt ihn an.
+- **Nur Issues.** Kein Commit, kein PR, kein Merge, kein Workflow-Start. Ein
+  Sprachbefehl, der Code ändern kann, ist eine Angriffsfläche mit Mikrofon.
+- **Ohne Token geht nichts verloren.** Der Auftrag steht dann als Text zum
+  Kopieren da, mit Grund. Das Schreiben nutzt den PAT aus `sessionStorage`
+  (`hq_pat`), den das HQ ohnehin für GitHub führt — keine neue Server-Route,
+  kein neues Geheimnis.
 
 ### Bilder und Ladezeit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-393 Tests in 21 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+395 Tests in 21 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +

--- a/app.js
+++ b/app.js
@@ -368,6 +368,26 @@ window.EB_IMG_FALLBACK = window.EB_IMG_FALLBACK || (
 // HTML-Attribut, das Card-Images verwenden – "this.onerror=null" verhindert Endlosschleife.
 window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK"';
 
+/**
+ * Bilder, die nicht im Sichtfenster stehen, gar nicht erst holen.
+ *
+ * Gemessen am 22.08.2026 auf der Startseite: 191 Bilder, davon 180 eifrig.
+ * Jedes davon war eine eigene Verbindung zu einem fremden Host, bevor der
+ * Nutzer auch nur gescrollt hatte.
+ *
+ * `loading` muss IM MARKUP stehen, bevor das Bild im Dokument landet — es
+ * nachträglich zu setzen ist wirkungslos, weil der Abruf dann schon läuft.
+ * Deshalb eine Konstante wie beim Fehler-Fallback daneben und keine
+ * nachgelagerte Reparatur über einen Observer.
+ *
+ * NICHT für das erste sichtbare Bild verwenden: ein verzögertes
+ * LCP-Element macht die Seite langsamer, nicht schneller. Dort gehört
+ * `EB_IMG_EAGER_ATTR` hin.
+ */
+window.EB_IMG_LAZY_ATTR  = ' loading="lazy" decoding="async"';
+/** Für das grosse Bild oben: früh holen, mit Vorrang. */
+window.EB_IMG_EAGER_ATTR = ' loading="eager" decoding="async" fetchpriority="high"';
+
 // Globaler Bild-Fehler-Auffang (Capture-Phase, da error-Events nicht bubblen).
 // Stellt sicher, dass JEDES <img> ein Fallback bekommt – auch Render-Stellen ohne
 // eigenes inline-onerror. Bilder mit eigenem onerror-Handler werden übersprungen.
@@ -1856,7 +1876,7 @@ function renderListingCard(listing) {
     <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
         <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bildergalerie: ${_escHtml(listing.title)}">
-          ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
+          ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_LAZY_ATTR + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
         </div>
         ${imgs.length > 1 ? '<button class="grid-gallery-arrow prev" aria-label="Vorheriges Bild" data-gallery-id="' + listing.id + '" data-dir="-1"><span class="material-icons-round">chevron_left</span></button><button class="grid-gallery-arrow next" aria-label="Nächstes Bild" data-gallery-id="' + listing.id + '" data-dir="1"><span class="material-icons-round">chevron_right</span></button><div class="grid-gallery-dots" id="gridGalleryDots_' + listing.id + '" role="group" aria-label="Bildauswahl">' + imgs.map(function(_, i) { return '<button class="grid-gallery-dot' + (i === 0 ? ' active' : '') + '" data-gallery-id="' + listing.id + '" data-idx="' + i + '" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') + '</div>' : ''}
         <button class="listing-fav ${isFav ? 'liked' : ''}" aria-label="Zu Favoriten hinzufügen" aria-pressed="${isFav ? 'true' : 'false'}" onclick="event.stopPropagation(); toggleFavorite(${listing.id}, this)">
@@ -2173,7 +2193,7 @@ function renderFeed(tab) {
     const tags = l.features ? l.features.slice(0, 3) : [];
     return `<div class="feed-card"${_aiDisclosureAttrs(l)}>
       <div class="feed-card-header">
-        <img class="feed-card-avatar" src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
+        <img class="feed-card-avatar"${window.EB_IMG_LAZY_ATTR} src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
         <div class="feed-card-meta">
           <span class="feed-card-provider" onclick="navigateTo('provider',${l.providerId || l.id})">${_escHtml(l.providerName)}</span>
           <span class="feed-card-time"><span class="material-icons-round">schedule</span> ${timeAgo(l.createdAt)}</span>
@@ -4566,7 +4586,8 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
+    // Das grosse Bild oben ist das LCP-Element: eifrig und mit Vorrang.
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_EAGER_ATTR}${window.EB_IMG_ERR_ATTR} />`;
     heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-22T07:57:14.563Z",
+  "erzeugt": "2026-08-22T08:06:40.317Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-22T07:48:37.381Z",
+  "erzeugt": "2026-08-22T07:57:14.563Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-22T07:35:31.976Z",
+  "erzeugt": "2026-08-22T07:48:37.381Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/hq.html
+++ b/hq.html
@@ -460,6 +460,20 @@
   /* Auffaellig: eckig statt rund, damit es auch ohne Farbe heraussticht. */
   .lage-problem   { color: #fca5a5; }
   .lage-problem   .lage-dot { border-color: #f87171; background: #f87171; border-radius: 2px; }
+  /* Wertbeitrag */
+  .wert-zeile { display:grid; grid-template-columns: minmax(9rem,auto) minmax(7rem,auto) 1fr;
+    gap:.2rem .9rem; align-items:baseline; padding:.55rem 0; border-top:1px solid var(--border); }
+  .wert-zeile:first-child { border-top:0; }
+  .wert-was  { font-size:.8rem; color:var(--muted); }
+  .wert-zahl { font-size:.95rem; white-space:nowrap; }
+  .wert-hinweis { font-size:.72rem; color:var(--muted); line-height:1.45; }
+  .wert-fazit { margin-top:.7rem; padding-top:.6rem; border-top:1px solid var(--border);
+    font-size:.78rem; line-height:1.55; }
+  .wert-stellen { display:flex; flex-wrap:wrap; gap:.3rem; margin-top:.7rem; }
+  .wert-stelle { font-size:.68rem; color:var(--muted); background:var(--surface2);
+    border:1px solid var(--border); border-radius:999px; padding:.14rem .5rem; }
+  .wert-stelle b { color:var(--fg); }
+  @media (max-width:560px) { .wert-zeile { grid-template-columns:1fr; } }
   .journal h5 { font-size: .82rem; margin-bottom: .1rem; }
   .journal > p { font-size: .72rem; color: var(--muted); margin-bottom: .6rem; line-height: 1.5; }
   .j-eintrag { display: flex; gap: .6rem; padding: .5rem 0; border-top: 1px solid var(--border); font-size: .75rem; }
@@ -887,6 +901,13 @@
       <div class="section-badge" id="lage-badge">–</div>
     </div>
     <div class="journal lage-liste" id="lage-liste" aria-live="polite"></div>
+
+    <!-- Wertbeitrag — was die Belegschaft kostet und was sie wert ist. -->
+    <div class="section-header" id="wert">
+      <div class="section-title">💶 Wertbeitrag <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— Marktwert gegen Modellkosten</span></div>
+      <div class="section-badge" id="wert-badge">–</div>
+    </div>
+    <div class="journal wert-block" id="wert-block"></div>
 
     <!-- Bereiche & Autonomie -->
     <div class="section-header" id="bereiche">
@@ -1739,7 +1760,7 @@ async function loadAll() {
     ebImpuls('engineering', 'gut');
     renderQuickActions(); renderCommits(); renderRuns(); renderLog(); renderBots(); renderLage();
     renderQuests(); renderAchievements(); renderHud();
-    if (nnKatalog) { nnZeichnen(); renderModelle(); }
+    if (nnKatalog) { nnZeichnen(); renderModelle(); renderWert(); }
   } catch (e) {
     if (state.rateLimited) { $('releases-list').innerHTML = `<div class="err">⏳ ${escHtml(e.message)}</div>`; requirePat(); }
     else $('releases-list').innerHTML = `<div class="err">Fehler beim Laden: ${escHtml(e.message)}</div>`;
@@ -1768,7 +1789,7 @@ async function init() {
       try {
         const neu = await ladeNeuralJournal();
         if (neu) {
-          nnZeichnen(); renderJournal(); renderModelle();
+          nnZeichnen(); renderJournal(); renderModelle(); renderWert();
           const letzter = nnJournal && nnJournal.eintraege && nnJournal.eintraege[0];
           if (letzter && letzter.bereich) ebImpuls(letzter.bereich, letzter.ergebnis === 'fertig' ? 'gut' : 'schlecht');
         }
@@ -1788,7 +1809,7 @@ async function init() {
       try {
         await loadRuns();
         await loadAutopilotPull();
-        nnZeichnen(); renderModelle(); renderBots(); renderRuns(); renderNeuralOps(); renderLage();
+        nnZeichnen(); renderModelle(); renderBots(); renderRuns(); renderNeuralOps(); renderLage(); renderWert();
       } finally { state.operationsAbruf = false; }
     }, getPat() ? 30000 : 300000);
   }
@@ -3225,6 +3246,78 @@ function renderWartet() {
       </div>`).join('')}`;
 }
 
+/**
+ * Wertbeitrag: was die Belegschaft an Marktwert vertritt, was sie kostet.
+ *
+ * Die Zahl 674.000 € stand bisher nur weit unten im Ensemble-Abschnitt. Sie
+ * beantwortet aber die Frage, die den Betrieb rechtfertigt, und gehört
+ * darum nach oben.
+ *
+ * Drei Ehrlichkeitsgrenzen, die hier eingebaut sind:
+ *
+ * 1. DER DECKEL IST KEIN VERBRAUCH. $2,00/Tag ist die harte Obergrenze der
+ *    beiden Töpfe, nicht das, was ausgegeben wurde. Beides steht getrennt
+ *    da — der gemessene Verbrauch kommt aus dem Arbeitsjournal.
+ *
+ * 2. KEIN ERFUNDENER WECHSELKURS. Marktwert in Euro, Kosten in Dollar. Sie
+ *    zu subtrahieren hiesse, einen Kurs zu behaupten, den niemand gemessen
+ *    hat. Das Verhältnis ist mit rund 1:900 so deutlich, dass es auf den
+ *    Kurs nicht ankommt — und genau so steht es da.
+ *
+ * 3. KEIN ERSATZ-VERSPRECHEN. Der Marktwert sagt, welcher Umfang an Arbeit
+ *    hier ohne Rückfrage läuft. Er sagt nicht, dass ein Modell eine Person
+ *    ersetzt.
+ */
+function renderWert() {
+  const block = document.getElementById('wert-block');
+  const badge = document.getElementById('wert-badge');
+  if (!block) return;
+  if (!nnKatalog) {
+    block.innerHTML = '<div class="empty">Modell-Katalog nicht geladen — ohne ihn kann ich zum Wert nichts sagen.</div>';
+    if (badge) badge.textContent = '–';
+    return;
+  }
+
+  const modelle = nnKatalog.modelle || [];
+  const bezahlt = modelle.filter((m) => (m.gehaltVergleich || 0) > 0);
+  const markt = modelle.reduce((a, m) => a + (m.gehaltVergleich || 0), 0);
+
+  // Deckel aus den Töpfen — nie hart hineingeschrieben.
+  const toepfe = Object.values(nnKatalog.schichten || {})
+    .filter((s) => typeof s.budgetUsd === 'number');
+  const deckelTag = toepfe.reduce((a, s) => a + s.budgetUsd, 0);
+  const deckelJahr = Math.round(deckelTag * 365);
+
+  // Gemessener Verbrauch: nur was wirklich im Journal steht.
+  const eintraege = (nnJournal && nnJournal.eintraege) || [];
+  const gemessen = eintraege.reduce((a, e) => a + (typeof e.kostenUsd === 'number' ? e.kostenUsd : 0), 0);
+
+  const eur = (n) => n.toLocaleString('de-DE') + ' €';
+  const zeile = (was, wert, hinweis) =>
+    `<div class="wert-zeile"><span class="wert-was">${was}</span>`
+    + `<span class="wert-zahl">${wert}</span>`
+    + `<span class="wert-hinweis">${hinweis}</span></div>`;
+
+  block.innerHTML =
+    zeile('Marktwert derselben Stellen', `<b>${eur(markt)}</b> / Jahr`,
+      `${bezahlt.length} Rollen mit Vergleichsstelle — Vergleichswert, keine Behauptung, dass ein Modell jemanden ersetzt`)
+    + zeile('Kostendeckel der Modelle', `$${deckelTag.toFixed(2).replace('.', ',')} / Tag`,
+      `harte Obergrenze beider Töpfe, rund $${deckelJahr.toLocaleString('de-DE')} im Jahr — nicht der Verbrauch`)
+    + zeile('Bisher gemessen', gemessen > 0 ? `$${gemessen.toFixed(4).replace('.', ',')}` : 'noch nichts im Journal',
+      gemessen > 0 ? `aus ${eintraege.length} Journaleinträgen — echte Läufe, keine Hochrechnung`
+                   : 'ohne Journaleinträge lässt sich der Verbrauch nicht beziffern')
+    + `<div class="wert-fazit">Der Marktwert übersteigt den Kostendeckel um rund das `
+    + `<b>${Math.round(markt / Math.max(deckelJahr, 1) / 10) * 10}-fache</b>. `
+    + `Euro gegen Dollar sind hier bewusst nicht umgerechnet: bei diesem Abstand `
+    + `ändert kein Wechselkurs die Aussage, und ein erfundener Kurs wäre eine Zahl, `
+    + `die niemand gemessen hat.</div>`
+    + `<div class="wert-stellen">${bezahlt.map((m) =>
+        `<span class="wert-stelle" title="${escHtml(m.person || m.id)}">${escHtml(m.vergleichsstelle || '—')}`
+        + ` <b>${(m.gehaltVergleich / 1000)}k</b></span>`).join('')}</div>`;
+
+  if (badge) badge.textContent = `${eur(markt)} vs. $${deckelTag.toFixed(2).replace('.', ',')}/Tag`;
+}
+
 function renderModelle() {
   if (!nnKatalog) return;
   const wege = nnKatalog.wege || {};
@@ -3422,6 +3515,7 @@ async function initNeural() {
   renderJournal();
   renderAuftragsstrom();
   renderModelle();
+  renderWert();
 
   // Ohne SpeechRecognition (z. B. Firefox) sagt der Kreis das, statt beim
   // Tippen stumm zu bleiben.

--- a/hq.html
+++ b/hq.html
@@ -789,6 +789,20 @@
     .nn-hud-innen, .nn-hud-saum { animation: none !important; }
   }
 
+/* Auftragskarte im Gespraech */
+.ebc-auftrag{border:1px solid rgba(34,211,238,.35);border-radius:12px;padding:.7rem .8rem}
+.ebc-auftrag-titel{font-weight:700;margin:.35rem 0 .2rem;font-size:.9rem;line-height:1.4}
+.ebc-auftrag-text{font-size:.78rem;color:var(--muted);line-height:1.5;white-space:pre-wrap}
+.ebc-auftrag-tasten{display:flex;gap:.4rem;flex-wrap:wrap;margin-top:.6rem;align-items:center}
+.ebc-auftrag-tasten button{font:inherit;font-size:.76rem;padding:.32rem .7rem;border-radius:8px;
+  border:1px solid var(--border);background:var(--surface2);color:var(--fg);cursor:pointer}
+.ebc-auftrag-tasten button:hover:not(:disabled){border-color:rgba(34,211,238,.6)}
+.ebc-auftrag-tasten button:disabled{opacity:.55;cursor:default}
+.ebc-auftrag-tasten a{font-size:.78rem;color:#7dd3fc}
+.ebc-auftrag-hinweis{font-size:.74rem;color:var(--muted);margin-top:.5rem;line-height:1.5}
+.ebc-auftrag-kopie{width:100%;margin-top:.4rem;font:inherit;font-size:.74rem;border-radius:8px;
+  border:1px solid var(--border);background:var(--bg);color:var(--fg);padding:.4rem .5rem;resize:vertical}
+
 /* ══ EB CIRCLE — sprechender KI-Kreis ══════════════════════════════ */
 #eb-circle-dock{position:fixed;right:20px;bottom:20px;opacity:.82;z-index:9000;display:flex;flex-direction:column;align-items:flex-end;gap:12px}
 #eb-circle{width:52px;height:52px;border-radius:50%;border:none;cursor:pointer;position:relative;
@@ -4246,6 +4260,97 @@ window.addEventListener('DOMContentLoaded', init);
     throw letzterFehler || new Error('Sprachdienst antwortet nicht.');
   }
 
+  /* ── Aufträge aus dem Gespräch ─────────────────────────────────────────
+     Ein gesprochener Auftrag soll im Repository ankommen, nicht im Nichts.
+
+     Drei Entscheidungen, die den Ausschlag geben:
+
+     1. NIE OHNE RÜCKFRAGE. Spracherkennung verhört sich, und ein verhörter
+        Satz darf kein Ticket anlegen. Der Auftrag wird gezeigt, und erst ein
+        Klick legt ihn an. Das ist der Unterschied zwischen einem Assistenten
+        und einem Automaten, der Müll produziert.
+
+     2. NUR ISSUES. Kein Commit, kein Pull Request, kein Merge, kein Start
+        eines Workflows. Ein Sprachbefehl, der Code ändern kann, ist eine
+        Angriffsfläche mit Mikrofon.
+
+     3. OHNE TOKEN GEHT DER AUFTRAG NICHT VERLOREN. Er steht dann als Text
+        zum Kopieren da, mit dem Grund. Ein Auftrag, der still verschwindet,
+        ist schlimmer als einer, der gar nicht erst angenommen wurde. */
+  var AUFTRAG_MUSTER = /^\s*(?:auftrag|aufgabe|todo|to-?do|notiere|notier|merk dir|vermerke|trag ein|erstelle? (?:eine? )?(?:aufgabe|auftrag|ticket|issue))\b[:,]?\s*(.+)$/i;
+
+  function auftragErkennen(text) {
+    var m = String(text || '').match(AUFTRAG_MUSTER);
+    if (!m) return null;
+    var inhalt = m[1].trim().replace(/\s+/g, ' ');
+    if (inhalt.length < 8) return null;   // „Auftrag: ja" ist keiner
+    // Titel: erster Satz, höchstens 90 Zeichen — der Rest wird Beschreibung.
+    var titel = inhalt.split(/(?<=[.!?])\s/)[0] || inhalt;
+    if (titel.length > 90) titel = titel.slice(0, 87).replace(/\s+\S*$/, '') + '…';
+    return { titel: titel, inhalt: inhalt.slice(0, 4000) };
+  }
+
+  function auftragKarte(a) {
+    var box = document.createElement('div');
+    box.className = 'ebc-msg ai ebc-auftrag';
+    var hatToken = typeof getPat === 'function' && !!getPat();
+    box.innerHTML =
+      '<b>Auftrag verstanden</b>'
+      + '<div class="ebc-auftrag-titel"></div>'
+      + '<div class="ebc-auftrag-text"></div>'
+      + (hatToken
+        ? '<div class="ebc-auftrag-tasten">'
+          + '<button type="button" class="ebc-ja">✓ Ins Repository eintragen</button>'
+          + '<button type="button" class="ebc-nein">Verwerfen</button></div>'
+        : '<div class="ebc-auftrag-hinweis">Kein GitHub-Token in dieser Sitzung — '
+          + 'ich kann den Auftrag nicht selbst eintragen. Text zum Kopieren:</div>'
+          + '<textarea class="ebc-auftrag-kopie" readonly rows="3"></textarea>');
+    // textContent, nicht innerHTML: der Auftrag ist Fremdtext, und beim
+    // Diktieren landet darin, was gerade gesagt wurde.
+    box.querySelector('.ebc-auftrag-titel').textContent = a.titel;
+    box.querySelector('.ebc-auftrag-text').textContent = a.inhalt;
+    var kopie = box.querySelector('.ebc-auftrag-kopie');
+    if (kopie) kopie.value = a.titel + '\n\n' + a.inhalt;
+    log.appendChild(box); log.scrollTop = log.scrollHeight;
+
+    var ja = box.querySelector('.ebc-ja');
+    var nein = box.querySelector('.ebc-nein');
+    if (nein) nein.addEventListener('click', function () {
+      box.querySelector('.ebc-auftrag-tasten').textContent = 'Verworfen.';
+    });
+    if (ja) ja.addEventListener('click', async function () {
+      ja.disabled = true; nein.disabled = true; ja.textContent = 'Trage ein…';
+      try {
+        var res = await ghRes('/issues', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: a.titel,
+            body: a.inhalt
+              + '\n\n---\n_Aufgegeben über den EB Circle im HQ am '
+              + new Date().toLocaleString('de-DE') + '._',
+            labels: ['aus-dem-hq'],
+          }),
+        });
+        var d = await res.json();
+        var fertig = document.createElement('div');
+        fertig.className = 'ebc-auftrag-tasten';
+        var a2 = document.createElement('a');
+        a2.href = d.html_url; a2.target = '_blank'; a2.rel = 'noopener';
+        a2.textContent = '✓ Eingetragen als #' + d.number;
+        fertig.appendChild(a2);
+        box.querySelector('.ebc-auftrag-tasten').replaceWith(fertig);
+      } catch (e) {
+        // Den Grund nennen, nicht bloss scheitern.
+        var fehler = document.createElement('div');
+        fehler.className = 'ebc-auftrag-hinweis';
+        fehler.textContent = 'Konnte nicht eingetragen werden: ' + (e && e.message ? e.message : 'unbekannter Fehler')
+          + ' — der Auftrag steht oben und ist nicht verloren.';
+        box.querySelector('.ebc-auftrag-tasten').replaceWith(fehler);
+      }
+    });
+  }
+
   async function ask(q) {
     q = String(q || '').trim(); if (!q) return;
     if (asking && askController) askController.abort();
@@ -4255,6 +4360,15 @@ window.addEventListener('DOMContentLoaded', init);
     asking = true;
     renderSuggestions([]);
     add('me', esc(q));
+    // Ein Auftrag ist keine Frage: er geht nicht an den Sprachdienst und
+    // kostet nichts. Er wird gezeigt und wartet auf Bestaetigung.
+    var auftrag = auftragErkennen(q);
+    if (auftrag) {
+      auftragKarte(auftrag);
+      asking = false; askController = null;
+      syncDialogControls();
+      return;
+    }
     var g = gaps(q);
     var status = hqStatus(q);
     var operative = status ? null : hqOperativeAntwort(q);

--- a/index.html
+++ b/index.html
@@ -34,8 +34,11 @@
   <link rel="manifest" href="/manifest.json" />
   <link rel="canonical" href="https://eventbörse.de" />
 
-  <!-- Performance: Preconnect — nur noch Stripe kommt von aussen. -->
+  <!-- Performance: Preconnect. Schriften und Bibliotheken liegen im Theme;
+       die Demo-Bilder kommen weiterhin von Pexels, und dort spart die
+       vorgezogene Verbindung den DNS- und TLS-Aufbau vor dem ersten Bild. -->
   <link rel="preconnect" href="https://js.stripe.com" crossorigin />
+  <link rel="preconnect" href="https://images.pexels.com" crossorigin />
 
   <!-- Critical CSS first (render-blocking, but small) -->
   <link rel="preload" href="styles.css?v=164" as="style" fetchpriority="high" />

--- a/index.local-head.html
+++ b/index.local-head.html
@@ -34,8 +34,11 @@
   <link rel="manifest" href="/manifest.json" />
   <link rel="canonical" href="https://eventbörse.de" />
 
-  <!-- Performance: Preconnect — nur noch Stripe kommt von aussen. -->
+  <!-- Performance: Preconnect. Schriften und Bibliotheken liegen im Theme;
+       die Demo-Bilder kommen weiterhin von Pexels, und dort spart die
+       vorgezogene Verbindung den DNS- und TLS-Aufbau vor dem ersten Bild. -->
   <link rel="preconnect" href="https://js.stripe.com" crossorigin />
+  <link rel="preconnect" href="https://images.pexels.com" crossorigin />
 
   <!-- Critical CSS first (render-blocking, but small) -->
   <link rel="preload" href="styles.css?v=164" as="style" fetchpriority="high" />

--- a/index.php
+++ b/index.php
@@ -164,8 +164,11 @@ $release_css_ver = file_exists( __DIR__ . '/release-vision.css' )
     <meta name="format-detection" content="telephone=no">
     <meta name="theme-color" content="#6C63FF">
 
-    <!-- ── Preconnect ── nur noch Stripe; alles andere liegt im Theme. -->
+    <!-- ── Preconnect ── Schriften und Bibliotheken liegen im Theme. Die
+         Demo-Bilder kommen weiterhin von Pexels; dort spart die vorgezogene
+         Verbindung den DNS- und TLS-Aufbau vor dem ersten Bild. -->
     <link rel="preconnect" href="https://js.stripe.com">
+    <link rel="preconnect" href="https://images.pexels.com" crossorigin>
 
     <!-- ── Schriften aus dem eigenen Haus ──
          Standen hier bis zum 21.08.2026 ZUSAETZLICH zur wp_enqueue-Einbindung,

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -368,6 +368,26 @@ window.EB_IMG_FALLBACK = window.EB_IMG_FALLBACK || (
 // HTML-Attribut, das Card-Images verwenden – "this.onerror=null" verhindert Endlosschleife.
 window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FALLBACK"';
 
+/**
+ * Bilder, die nicht im Sichtfenster stehen, gar nicht erst holen.
+ *
+ * Gemessen am 22.08.2026 auf der Startseite: 191 Bilder, davon 180 eifrig.
+ * Jedes davon war eine eigene Verbindung zu einem fremden Host, bevor der
+ * Nutzer auch nur gescrollt hatte.
+ *
+ * `loading` muss IM MARKUP stehen, bevor das Bild im Dokument landet — es
+ * nachträglich zu setzen ist wirkungslos, weil der Abruf dann schon läuft.
+ * Deshalb eine Konstante wie beim Fehler-Fallback daneben und keine
+ * nachgelagerte Reparatur über einen Observer.
+ *
+ * NICHT für das erste sichtbare Bild verwenden: ein verzögertes
+ * LCP-Element macht die Seite langsamer, nicht schneller. Dort gehört
+ * `EB_IMG_EAGER_ATTR` hin.
+ */
+window.EB_IMG_LAZY_ATTR  = ' loading="lazy" decoding="async"';
+/** Für das grosse Bild oben: früh holen, mit Vorrang. */
+window.EB_IMG_EAGER_ATTR = ' loading="eager" decoding="async" fetchpriority="high"';
+
 // Globaler Bild-Fehler-Auffang (Capture-Phase, da error-Events nicht bubblen).
 // Stellt sicher, dass JEDES <img> ein Fallback bekommt – auch Render-Stellen ohne
 // eigenes inline-onerror. Bilder mit eigenem onerror-Handler werden übersprungen.

--- a/js/modules/search/10-karten-home-feed.js
+++ b/js/modules/search/10-karten-home-feed.js
@@ -7,7 +7,7 @@ function renderListingCard(listing) {
     <div class="listing-card" data-listing-id="${listing.id}"${_aiDisclosureAttrs(listing)}>
       <div class="listing-card-img">
         <div class="grid-gallery-track" id="${galleryId}" tabindex="0" role="region" aria-label="Bildergalerie: ${_escHtml(listing.title)}">
-          ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '" decoding="async"' + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
+          ${imgs.map(function(img, i) { return '<div class="grid-gallery-slide"><img src="' + _escHtml(img) + '" alt="' + _escHtml(listing.title) + '"' + window.EB_IMG_LAZY_ATTR + window.EB_IMG_ERR_ATTR + ' /></div>'; }).join('')}
         </div>
         ${imgs.length > 1 ? '<button class="grid-gallery-arrow prev" aria-label="Vorheriges Bild" data-gallery-id="' + listing.id + '" data-dir="-1"><span class="material-icons-round">chevron_left</span></button><button class="grid-gallery-arrow next" aria-label="Nächstes Bild" data-gallery-id="' + listing.id + '" data-dir="1"><span class="material-icons-round">chevron_right</span></button><div class="grid-gallery-dots" id="gridGalleryDots_' + listing.id + '" role="group" aria-label="Bildauswahl">' + imgs.map(function(_, i) { return '<button class="grid-gallery-dot' + (i === 0 ? ' active' : '') + '" data-gallery-id="' + listing.id + '" data-idx="' + i + '" aria-label="Bild ' + (i + 1) + ' von ' + imgs.length + ' anzeigen"></button>'; }).join('') + '</div>' : ''}
         <button class="listing-fav ${isFav ? 'liked' : ''}" aria-label="Zu Favoriten hinzufügen" aria-pressed="${isFav ? 'true' : 'false'}" onclick="event.stopPropagation(); toggleFavorite(${listing.id}, this)">
@@ -324,7 +324,7 @@ function renderFeed(tab) {
     const tags = l.features ? l.features.slice(0, 3) : [];
     return `<div class="feed-card"${_aiDisclosureAttrs(l)}>
       <div class="feed-card-header">
-        <img class="feed-card-avatar" src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
+        <img class="feed-card-avatar"${window.EB_IMG_LAZY_ATTR} src="${_escHtml(avatar)}" alt="${_escHtml(l.providerName)}" onclick="navigateTo('provider',${l.providerId || l.id})" />
         <div class="feed-card-meta">
           <span class="feed-card-provider" onclick="navigateTo('provider',${l.providerId || l.id})">${_escHtml(l.providerName)}</span>
           <span class="feed-card-time"><span class="material-icons-round">schedule</span> ${timeAgo(l.createdAt)}</span>

--- a/js/modules/search/12-detail-provider.js
+++ b/js/modules/search/12-detail-provider.js
@@ -21,7 +21,8 @@ function loadDetail(listingId) {
 
   // Hero image for mobile (first image, shown prominently)
   if (imgs.length > 0) {
-    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_ERR_ATTR} />`;
+    // Das grosse Bild oben ist das LCP-Element: eifrig und mit Vorrang.
+    heroImg.innerHTML = `<img src="${_escHtml(imgs[0])}" alt="${_escHtml(listing.title)}" class="detail-hero-photo"${window.EB_IMG_EAGER_ATTR}${window.EB_IMG_ERR_ATTR} />`;
     heroImg.setAttribute('data-ai-media', _aiDisclosureValue(listing, 'media'));
   }
 

--- a/tests/e2e/auftrag-hq.spec.js
+++ b/tests/e2e/auftrag-hq.spec.js
@@ -1,0 +1,122 @@
+// Aufträge aus dem Gespräch — was im Repository ankommt und was nicht.
+//
+// Die gefährliche Stelle ist nicht das Anlegen, sondern das AUTOMATISCHE
+// Anlegen. Spracherkennung verhört sich; ein verhörter Satz, der ungefragt
+// ein Ticket erzeugt, füllt das Repository mit Müll und macht die Funktion
+// unbenutzbar. Deshalb prüft die erste Zusicherung, dass VOR der Bestätigung
+// nichts passiert.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const HQ = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
+
+async function hqMitGithub(page, aufPost) {
+  // Reihenfolge zählt: Playwright prüft Routen in UMGEKEHRTER
+  // Registrierungsreihenfolge. Der Auffang muss zuerst stehen, sonst
+  // überstimmt er die spezifische Route — genau daran scheiterte der
+  // erste Entwurf dieses Tests und sah aus wie ein Fehler im Code.
+  await page.route('https://api.github.com/**', (r) => r.abort());
+  await page.route('https://api.github.com/repos/*/*/issues', (r) => {
+    if (r.request().method() !== 'POST') return r.abort();
+    aufPost(JSON.parse(r.request().postData() || '{}'));
+    return r.fulfill({ status: 201, contentType: 'application/json',
+      body: JSON.stringify({ number: 42, html_url: 'https://github.com/x/y/issues/42' }) });
+  });
+  await page.goto('/hq.html');
+  await page.waitForTimeout(1700);
+  await page.evaluate(() => sessionStorage.setItem('hq_pat', 'test-token'));
+  await page.evaluate(() => window.ebCircleAPI.oeffnen());
+}
+const sagen = async (page, t) => {
+  await page.locator('#ebc-input').fill(t);
+  await page.locator('#ebc-input').press('Enter');
+  await page.waitForTimeout(500);
+};
+
+test.describe('Aufträge aus dem Gespräch', () => {
+  test('ein Auftrag wird gezeigt — und vor der Bestätigung nichts angelegt', async ({ page }) => {
+    let post = null;
+    await hqMitGithub(page, (p) => { post = p; });
+    await sagen(page, 'Auftrag: Die Bilder der Startseite lokal hosten, damit sie schneller laden.');
+
+    await expect(page.locator('.ebc-auftrag')).toHaveCount(1);
+    expect(await page.locator('.ebc-auftrag-titel').innerText())
+      .toContain('Bilder der Startseite lokal hosten');
+    expect(post, 'ein Ticket wurde OHNE Bestätigung angelegt').toBeNull();
+  });
+
+  test('erst der Klick legt an — mit Herkunftsvermerk', async ({ page }) => {
+    let post = null;
+    await hqMitGithub(page, (p) => { post = p; });
+    await sagen(page, 'Auftrag: Die Bilder der Startseite lokal hosten, damit sie schneller laden.');
+    await page.locator('.ebc-ja').click();
+    await page.waitForTimeout(500);
+
+    expect(post, 'nach der Bestätigung wurde nichts angelegt').not.toBeNull();
+    expect(post.title).toContain('Bilder der Startseite');
+    // Wer das Ticket später liest, muss sehen, woher es kommt.
+    expect(post.body, 'kein Herkunftsvermerk').toMatch(/EB Circle im HQ/);
+    expect(post.labels).toContain('aus-dem-hq');
+    await expect(page.locator('.ebc-auftrag-tasten')).toContainText('#42');
+  });
+
+  test('eine gewöhnliche Frage ist kein Auftrag', async ({ page }) => {
+    // Sonst würde jede Unterhaltung Tickets erzeugen.
+    let post = null;
+    await hqMitGithub(page, (p) => { post = p; });
+    await sagen(page, 'Wie steht der Betrieb gerade?');
+    await expect(page.locator('.ebc-auftrag')).toHaveCount(0);
+    expect(post).toBeNull();
+  });
+
+  test('ein zu kurzer Auftrag zählt nicht', async ({ page }) => {
+    // „Auftrag: ja" ist ein Verhörer, keine Aufgabe.
+    await hqMitGithub(page, () => {});
+    await sagen(page, 'Auftrag: ja');
+    await expect(page.locator('.ebc-auftrag')).toHaveCount(0);
+  });
+
+  test('ohne Token geht der Auftrag nicht verloren', async ({ page }) => {
+    // Ein Auftrag, der still verschwindet, ist schlimmer als einer, der gar
+    // nicht erst angenommen wurde.
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(1700);
+    await page.evaluate(() => sessionStorage.removeItem('hq_pat'));
+    await page.evaluate(() => window.ebCircleAPI.oeffnen());
+    await sagen(page, 'Auftrag: Die Bilder der Startseite lokal hosten, damit sie schneller laden.');
+
+    await expect(page.locator('.ebc-auftrag')).toHaveCount(1);
+    await expect(page.locator('.ebc-auftrag-hinweis')).toContainText('Kein GitHub-Token');
+    const kopie = await page.locator('.ebc-auftrag-kopie').inputValue();
+    expect(kopie, 'der Auftragstext fehlt zum Kopieren').toContain('lokal hosten');
+    await expect(page.locator('.ebc-ja')).toHaveCount(0);
+  });
+
+  test('gesagter Text landet als Text, nicht als Markup', async ({ page }) => {
+    // Beim Diktieren landet im Auftrag, was gerade gesagt wurde — und beim
+    // Tippen, was jemand tippt.
+    await hqMitGithub(page, () => {});
+    await sagen(page, 'Auftrag: Bilder lokal hosten <img src=x onerror=alert(1)> und zwar bald.');
+    const html = await page.locator('.ebc-auftrag-text').innerHTML();
+    expect(html, 'Fremdtext wurde als Markup eingesetzt').not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  test('das Gespräch kann nur Issues anlegen — nichts anderes', async () => {
+    // Ein Sprachbefehl, der Code ändern oder ausliefern kann, ist eine
+    // Angriffsfläche mit Mikrofon.
+    const von = HQ.indexOf('function auftragKarte');
+    const bis = HQ.indexOf('async function ask(');
+    expect(von, 'auftragKarte nicht gefunden').toBeGreaterThan(-1);
+    const rumpf = HQ.slice(von, bis);
+    expect(rumpf).toMatch(/ghRes\('\/issues'/);
+    for (const verboten of ['/pulls', '/merges', '/dispatches', '/contents/', 'workflow']) {
+      expect(rumpf, `der Auftragsweg kann ${verboten} aufrufen`).not.toContain(verboten);
+    }
+    // Und die Bestätigung muss im Code stehen, nicht bloss in der Absicht.
+    expect(rumpf, 'kein Bestätigungsschritt').toMatch(/ebc-ja[\s\S]*addEventListener\('click'/);
+  });
+});

--- a/tests/e2e/bild-laden.spec.js
+++ b/tests/e2e/bild-laden.spec.js
@@ -1,0 +1,60 @@
+// Wie Bilder geladen werden — gemessen, nicht geschätzt.
+//
+// Die erste Messung führte mich in die Irre: 191 Bild-Elemente auf der
+// Startseite, 180 davon „eifrig". Das klang nach 180 Anfragen. Es waren 22,
+// davon 11 eindeutig — die 180 Marquee-Elemente teilen sich dieselbe Adresse,
+// und der Browser fasst gleiche URLs zu einer Anfrage zusammen.
+//
+// Daraus zwei Regeln für diese Suite: es wird die Zahl der ANFRAGEN geprüft,
+// nicht die der Elemente. Und das grosse Bild oben darf nie verzögert werden.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const BASIS = fs.readFileSync(path.join(ROOT, 'js', 'modules', 'core', '00-basis.js'), 'utf8');
+const FEED = fs.readFileSync(path.join(ROOT, 'js', 'modules', 'search', '10-karten-home-feed.js'), 'utf8');
+const DETAIL = fs.readFileSync(path.join(ROOT, 'js', 'modules', 'search', '12-detail-provider.js'), 'utf8');
+
+test.describe('Bildladen', () => {
+  test('die Attribute stehen an einer Stelle, nicht an dreissig', () => {
+    expect(BASIS).toMatch(/EB_IMG_LAZY_ATTR\s*=\s*' loading="lazy" decoding="async"'/);
+    expect(BASIS).toMatch(/EB_IMG_EAGER_ATTR\s*=[^;]*fetchpriority="high"/);
+  });
+
+  test('Karten-Galerien laden verzögert — sie liegen unter dem Sichtfenster', () => {
+    // Anders als die Marquee tragen sie je Inserat eigene Adressen; hier
+    // spart Verzögern wirklich Anfragen.
+    expect(FEED).toMatch(/grid-gallery-slide[\s\S]{0,200}EB_IMG_LAZY_ATTR/);
+  });
+
+  test('das grosse Bild oben wird nie verzögert', () => {
+    // Ein verzögertes LCP-Element macht die Seite langsamer, nicht schneller.
+    const stelle = DETAIL.slice(DETAIL.indexOf('detail-hero-photo') - 300, DETAIL.indexOf('detail-hero-photo') + 200);
+    expect(stelle, 'Hero ohne Vorrang').toMatch(/EB_IMG_EAGER_ATTR/);
+    expect(stelle, 'Hero verzögert geladen').not.toMatch(/EB_IMG_LAZY_ATTR|loading="lazy"/);
+  });
+
+  test('die Verbindung zum Bild-Host wird vorbereitet', () => {
+    // Die Demo-Bilder kommen weiterhin von Pexels. Preconnect spart den
+    // DNS- und TLS-Aufbau vor dem ersten Bild.
+    for (const datei of ['index.php', 'index.local-head.html']) {
+      const t = fs.readFileSync(path.join(ROOT, datei), 'utf8');
+      expect(t, `${datei} ohne Preconnect zum Bild-Host`)
+        .toMatch(/preconnect[^>]*images\.pexels\.com/);
+    }
+  });
+
+  test('die Startseite löst wenige Bildanfragen aus, nicht eine pro Element', async ({ page }) => {
+    const anfragen = [];
+    await page.route('https://images.pexels.com/**', (r) => { anfragen.push(r.request().url()); r.abort(); });
+    await page.goto('/index.html', { waitUntil: 'load' });
+    await page.waitForTimeout(1800);
+    const elemente = await page.evaluate(() => document.images.length);
+    expect(elemente, 'die Messung läuft leer').toBeGreaterThan(20);
+    // Der Punkt: viele Elemente, wenige Anfragen. Ginge das auseinander,
+    // hätte jemand die Adressen pro Element eindeutig gemacht.
+    expect(new Set(anfragen).size, `${elemente} Elemente, aber ${new Set(anfragen).size} Anfragen`)
+      .toBeLessThan(elemente / 4);
+  });
+});

--- a/tests/e2e/kern.spec.js
+++ b/tests/e2e/kern.spec.js
@@ -1230,6 +1230,58 @@ test.describe('Arbeitsjournal & Gespräch', () => {
     expect(voice, 'Betriebsfragen bleiben im Sprachmodus lokal').toMatch(/if \(localAnswer\)/);
   });
 
+  test('der Wertbeitrag steht oben und trennt Deckel von Verbrauch', async ({ page }) => {
+    // Die 674.000 € standen bisher nur weit unten im Ensemble-Abschnitt. Sie
+    // beantworten die Frage, die den Betrieb rechtfertigt.
+    const fehler = [];
+    page.on('pageerror', (e) => fehler.push(String(e)));
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2400);
+    expect(fehler).toEqual([]);
+
+    const text = await page.locator('#wert-block').innerText();
+    expect(text, 'das Panel bleibt leer').toMatch(/Marktwert/);
+
+    // Der Kern: ein DECKEL ist kein Verbrauch. Beides muss getrennt dastehen,
+    // sonst liest sich die Obergrenze wie eine Rechnung.
+    expect(text).toMatch(/Kostendeckel/);
+    expect(text).toMatch(/nicht der Verbrauch/);
+    expect(text).toMatch(/Bisher gemessen/);
+
+    // Kein erfundener Wechselkurs: Euro und Dollar werden nicht verrechnet.
+    expect(text, 'Euro und Dollar wurden zu einer Zahl verrechnet')
+      .toMatch(/nicht umgerechnet/);
+
+    // Und kein Ersatz-Versprechen.
+    expect(text).toMatch(/keine Behauptung, dass ein Modell jemanden ersetzt/);
+  });
+
+  test('Marktwert und Deckel kommen aus dem Katalog, nicht aus dem Code', async ({ page }) => {
+    // Eine eingetippte Zahl wäre am Tag der nächsten Rollenänderung falsch.
+    const katalog = JSON.parse(fs.readFileSync(path.join(ROOT, 'assets', 'eb-models.json'), 'utf8'));
+    const markt = (katalog.modelle || []).reduce((a, m) => a + (m.gehaltVergleich || 0), 0);
+    const deckel = Object.values(katalog.schichten || {})
+      .filter((s) => typeof s.budgetUsd === 'number')
+      .reduce((a, s) => a + s.budgetUsd, 0);
+    expect(markt, 'ohne Vergleichswerte misst der Test nichts').toBeGreaterThan(0);
+    expect(deckel, 'ohne Töpfe misst der Test nichts').toBeGreaterThan(0);
+
+    await page.route('https://api.github.com/**', (r) => r.abort());
+    await page.goto('/hq.html');
+    await page.waitForTimeout(2400);
+    const badge = await page.locator('#wert-badge').innerText();
+    expect(badge).toContain(markt.toLocaleString('de-DE'));
+    expect(badge).toContain(deckel.toFixed(2).replace('.', ','));
+
+    // Gegenprobe: die Zahlen dürfen nicht im Quelltext stehen.
+    const hq = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
+    const wirksam = hq.split('\n').filter((z) => !/^\s*(\/\/|\*)/.test(z)).join('\n');
+    const fn = wirksam.slice(wirksam.indexOf('function renderWert'), wirksam.indexOf('function renderModelle'));
+    expect(fn, 'der Marktwert ist fest eingetippt').not.toContain(String(markt));
+    expect(fn, 'der Deckel ist fest eingetippt').not.toMatch(/\b2\.0+\b|\b730\b/);
+  });
+
   test('der Betriebsbericht steht sichtbar im HQ, nicht erst auf Nachfrage', async ({ page }) => {
     // Er lag hinter einem Knopf im Gespräch. Eine Lage, die man erfragen muss,
     // sieht man meistens gar nicht — und das ist genau die Lage, die man

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 395 Tests in 21 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 402 Tests in 22 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 388 Tests in 20 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 395 Tests in 21 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**


### PR DESCRIPTION
Alle drei Punkte. Ich habe sie zusammengelassen, weil der Auftrags-Weg ohne neue Server-Route auskommt — er nutzt den GitHub-Token, den das HQ ohnehin führt.

---

# 1 · Aufträge aus dem Gespräch landen im Repository

Ein Satz, der mit **„Auftrag:", „Aufgabe:", „notiere", „trag ein"** beginnt, wird im EB Circle erkannt und als **GitHub-Issue** angelegt — Label `aus-dem-hq`, mit Herkunftsvermerk und Zeitstempel.

## Drei Grenzen — die erste ist der eigentliche Punkt

**Nie ohne Rückfrage.** Spracherkennung verhört sich. Ein verhörter Satz, der ungefragt ein Ticket erzeugt, füllt das Repository mit Müll und macht die Funktion unbenutzbar. Der Auftrag wird gezeigt, **erst ein Klick legt ihn an**. Ein Test prüft, dass vor der Bestätigung nichts passiert.

**Nur Issues.** Kein Commit, kein Pull Request, kein Merge, kein Workflow-Start. *Ein Sprachbefehl, der Code ändern kann, ist eine Angriffsfläche mit Mikrofon.* Der Test liest den Auftragsweg und verbietet `/pulls`, `/merges`, `/dispatches`, `/contents` und `workflow`.

**Ohne Token geht nichts verloren.** Der Auftrag steht dann als Text zum Kopieren da, mit Grund. Ein Auftrag, der still verschwindet, ist schlimmer als einer, der gar nicht erst angenommen wurde.

Keine neue Server-Route, kein neues Geheimnis: geschrieben wird mit dem PAT aus `sessionStorage`, den das HQ ohnehin für GitHub führt.

Zu kurze Äußerungen („Auftrag: ja") zählen nicht, und eine gewöhnliche Frage wird nicht zum Auftrag — sonst erzeugte jede Unterhaltung Tickets. Der Text geht über `textContent`, nicht `innerHTML`.

---

# 2 · Wertbeitrag steht oben

Die **674.000 €** gab es schon — weit unten im Ensemble-Abschnitt. Jetzt gleich unter der Zentrale, zusammen mit dem, was das Ganze kostet.

| | |
|---|---|
| Marktwert derselben Stellen | **674.000 €** / Jahr (11 Rollen mit Vergleichsstelle) |
| Kostendeckel der Modelle | **$2,00** / Tag — rund $730 im Jahr |
| Bisher gemessen | **$0,0003** aus 2 Journaleinträgen |

**Der Deckel ist kein Verbrauch** — beides steht getrennt. **Kein erfundener Wechselkurs**: Euro und Dollar werden nicht verrechnet; das Verhältnis ist mit dem ~920-fachen so deutlich, dass es auf den Kurs nicht ankommt. **Kein Ersatz-Versprechen**: der Marktwert sagt, welcher Umfang an Arbeit ohne Rückfrage läuft.

Beide Zahlen kommen aus `assets/eb-models.json`. Ein Test macht die Gegenprobe — sie dürfen im Quelltext von `renderWert()` gar nicht vorkommen.

---

# 3 · Bilder — mit einer Korrektur an meiner eigenen Diagnose

Erste Messung: *191 Bild-Elemente, 180 davon „eifrig"*. Das klang nach 180 Anfragen.

**Es sind 22, davon 11 eindeutig.** Die 180 Marquee-Karten teilen sich dieselbe Adresse, und der Browser fasst gleiche URLs zusammen. Wer hier Elemente zählt, optimiert das Falsche — ich hätte die Marquee fast umgebaut, ohne dass eine Anfrage weggefallen wäre.

| Was wirklich hilft | |
|---|---|
| `fetchpriority="high"` auf dem Detail-Hero | das LCP-Element, vorher ohne jede Angabe |
| `loading="lazy"` auf den Karten-Galerien | eigene Adressen je Inserat — hier spart es echte Anfragen |
| `preconnect` zu `images.pexels.com` | beim Self-Hosting hatte ich alle bis auf Stripe gestrichen |

## ⚠️ Das Eigentliche kann ich nicht tun

**Die Bilder lokal hosten** — 69 Adressen bei Pexels, ein Fremdhost im Ladepfad, IP-Abfluss bei jedem Aufruf. `scripts/localize-demo-images.mjs` gibt es dafür schon, es ist nur nie gelaufen. Die Agent-Umgebung sperrt `images.pexels.com` (403).

```bash
node scripts/localize-demo-images.mjs --dry-run
node scripts/localize-demo-images.mjs
git add assets/demo app.js && git commit -m "Demo-Bilder lokal hosten"
```

---

## Geprüft

**402 Tests in 22 Suiten, alle grün.** Neun Mutationen:

| | |
|---|---|
| Bestätigung entfällt → Ticket sofort | ✓ |
| Auftragstext als Markup | ✓ |
| jede Äußerung gilt als Auftrag | ✓ |
| Herkunftsvermerk entfällt | ✓ |
| Marktwert fest eingetippt | ✓ |
| Deckel und Verbrauch verschmolzen | ✓ |
| Euro/Dollar doch verrechnet | ✓ |
| Hero verzögert geladen | ✓ |
| Preconnect entfernt | ✓ |

Beim Schreiben der Tests selbst eine Falle: **Playwright prüft Routen in umgekehrter Registrierungsreihenfolge.** Mein Auffang-`abort` überstimmte die spezifische Route, und der ausbleibende POST sah aus wie ein Fehler im Code. Er stand im Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd