### PR TITLE
Demo-Bilder in die eigene Mediathek — und der Upload ist jetzt geprüft

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-405 Tests in 22 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+424 Tests in 23 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -344,6 +344,30 @@ Drei Grenzen, alle mutationsgeprüft:
   Kopieren da, mit Grund. Das Schreiben nutzt den PAT aus `sessionStorage`
   (`hq_pat`), den das HQ ohnehin für GitHub führt — keine neue Server-Route,
   kein neues Geheimnis.
+
+### Bilder: Upload und Demo-Bestand
+
+**Nutzer-Uploads liegen bereits richtig.** `POST /upload` → `wp_handle_upload()`
+→ `wp_insert_attachment()`: die Datei landet in `wp-content/uploads` auf IONOS
+und bekommt einen Mediathek-Eintrag mit Besitzer (`_eb_owner_id`). Sieben
+Prüfschichten davor, unter anderem MIME aus den **Magic Bytes** (nie aus
+`$file['type']` — das schickt der Browser) und eine Gegenprobe mit
+`getimagesize()`; was durchfällt, wird gelöscht. Festgehalten in
+`tests/e2e/upload.spec.js`.
+
+**Die hardcodierten Demo-Daten hotlinken dagegen auf Pexels.** Sie holt
+`POST /hq/demo-bilder` (nur angemeldeter Administrator) in dieselbe Mediathek —
+**auf dem Server**, weil nur der Netzzugang zu Pexels hat. Der Aufruf ist
+wiederholbar und holt höchstens 15 Bilder je Lauf; ein Import, der ins
+PHP-Zeitlimit läuft, hinterließe sonst einen halben Zustand. Die Antwort nennt
+`offen` — erst bei 0 geht nichts mehr an den Fremdhost.
+
+Die Zuordnung liegt in der Option `eb_demo_bilder_map`, wird über
+`eventboerseApi.demoBilder` ausgeliefert und **einmal beim Start** angewandt
+(`ebDemoBilderUmschreiben`, aufgerufen am Ende von `ui/52-release-vision.js`).
+Nicht bei jedem Rendern: das wären 191-mal dieselbe Arbeit. **Was nicht in der
+Zuordnung steht, bleibt unverändert** — ein stillschweigend ersetztes Bild wäre
+schlimmer als eines, das weiter von außen kommt.
 
 ### Bilder und Ladezeit
 

--- a/app.js
+++ b/app.js
@@ -384,6 +384,41 @@ window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FAL
  * LCP-Element macht die Seite langsamer, nicht schneller. Dort gehört
  * `EB_IMG_EAGER_ATTR` hin.
  */
+/**
+ * Demo-Bilder auf die eigene Mediathek umbiegen.
+ *
+ * Die hardcodierten Demo-Daten tragen Pexels-Adressen. Sobald der Import im
+ * HQ gelaufen ist, liegen dieselben Bilder in wp-content/uploads auf unserem
+ * Server, und `eventboerseApi.demoBilder` bringt die Zuordnung mit.
+ *
+ * Umgeschrieben wird EINMAL beim Start, nicht bei jedem Rendern: eine
+ * Ersetzung pro Bildausgabe wäre 191-mal dieselbe Arbeit und würde bei jedem
+ * neuen Render-Ort vergessen.
+ *
+ * Was nicht in der Zuordnung steht, bleibt unverändert. Eine fehlende Adresse
+ * ist ein noch nicht geholtes Bild, kein Fehler — und ein stillschweigend
+ * verändertes Bild wäre schlimmer als eines, das weiterhin von aussen kommt.
+ */
+window.ebDemoBilderUmschreiben = function (wurzel) {
+  var map = (window.eventboerseApi && window.eventboerseApi.demoBilder) || null;
+  if (!map || typeof map !== 'object') return 0;
+  var ersetzt = 0;
+  var biegen = function (v) {
+    if (typeof v === 'string') {
+      if (Object.prototype.hasOwnProperty.call(map, v)) { ersetzt++; return map[v]; }
+      return v;
+    }
+    if (Array.isArray(v)) { for (var i = 0; i < v.length; i++) v[i] = biegen(v[i]); return v; }
+    if (v && typeof v === 'object') {
+      for (var k in v) if (Object.prototype.hasOwnProperty.call(v, k)) v[k] = biegen(v[k]);
+      return v;
+    }
+    return v;
+  };
+  biegen(wurzel);
+  return ersetzt;
+};
+
 window.EB_IMG_LAZY_ATTR  = ' loading="lazy" decoding="async"';
 /** Für das grosse Bild oben: früh holen, mit Vorrang. */
 window.EB_IMG_EAGER_ATTR = ' loading="eager" decoding="async" fetchpriority="high"';
@@ -27045,3 +27080,17 @@ document.addEventListener('DOMContentLoaded',function(){
   if(_notificationPoll)clearInterval(_notificationPoll);
   _notificationPoll=setInterval(refreshNotificationBadge,60000);
 });
+
+/* Demo-Bilder auf die eigene Mediathek umbiegen — einmal, nachdem alle
+   Module geladen sind und LISTINGS existiert. Steht hier ganz am Ende, weil
+   die Verkettung in modules.list die Reihenfolge bestimmt: früher aufgerufen
+   gäbe es die Daten noch nicht. */
+(function () {
+  if (typeof window.ebDemoBilderUmschreiben !== 'function') return;
+  try {
+    var n = 0;
+    if (typeof LISTINGS !== 'undefined') n += window.ebDemoBilderUmschreiben(LISTINGS);
+    if (typeof EVENTS !== 'undefined') n += window.ebDemoBilderUmschreiben(EVENTS);
+    void n;
+  } catch (e) { /* Ein fehlgeschlagenes Umbiegen darf die Seite nicht aufhalten. */ }
+})();

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-22T09:21:15.304Z",
+  "erzeugt": "2026-08-22T09:31:41.961Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/assets/eb-auftragsstrom.json
+++ b/assets/eb-auftragsstrom.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "erzeugt": "2026-08-22T08:26:48.492Z",
+  "erzeugt": "2026-08-22T09:21:15.304Z",
   "hinweis": "Erzeugt von scripts/auftragsstrom.mjs aus assets/eb-arbeit.json. Nicht von Hand bearbeiten.",
   "journalStand": "2026-08-12T12:44:59.525Z",
   "lage": "Kein Befund im freigegebenen Rahmen — der Scout wählt selbst.",

--- a/functions.php
+++ b/functions.php
@@ -674,6 +674,11 @@ function eventboerse_enqueue_assets() {
         // Vom Admin entfernte Bilder (normalisierte Pfade) — der Client blendet
         // sie aus, auch bei hardcodierten Demo-Listings (siehe eb_admin_moderate_image).
         'imageBlocklist' => array_values( (array) get_option( 'eb_demo_image_blocklist', array() ) ),
+        // Demo-Bilder, die bereits in der eigenen Mediathek liegen. Der Client
+        // schreibt die Adressen einmal beim Laden um, statt bei jedem Rendern
+        // — und was hier fehlt, geht unveraendert weiter an seinen Ursprung.
+        // Leer heisst: der Import lief noch nicht, nicht "es gibt keine".
+        'demoBilder' => (object) ( (array) get_option( EB_DEMO_BILDER_OPTION, array() ) ),
     ) );
 }
 add_action( 'wp_enqueue_scripts', 'eventboerse_enqueue_assets' );
@@ -9818,7 +9823,137 @@ add_action( 'rest_api_init', function () {
             'audio' => array( 'required' => true, 'type' => 'string' ),
         ),
     ) );
+
+    // Demo-Bilder in die Mediathek holen. Bewusst die STRENGERE Pruefung:
+    // das schreibt dauerhaft in die Datenbank und laedt von fremden Hosts.
+    register_rest_route( 'eventboerse/v1', '/hq/demo-bilder', array(
+        'methods'             => 'POST',
+        'callback'            => 'eb_hq_demo_bilder_holen',
+        'permission_callback' => 'eb_hq_verwaltung_darf',
+    ) );
 } );
+
+/** Wo die Zuordnung Fremd-URL -> Mediathek-URL liegt. */
+const EB_DEMO_BILDER_OPTION = 'eb_demo_bilder_map';
+
+/**
+ * Aus welchen ausgelieferten Dateien die Demo-Bildadressen stammen.
+ *
+ * Bewusst der ausgelieferte Stand und keine Liste von Hand: eine gepflegte
+ * Liste waere am Tag des naechsten Demo-Feeds unvollstaendig, und uebersehene
+ * Adressen sind genau die, die weiter zu Pexels gehen.
+ */
+function eb_demo_bilder_quellen() {
+    $dir = get_template_directory();
+    return array( $dir . '/assets/eb-demo-feed.json', $dir . '/app.js' );
+}
+
+/** Alle fremden Bildadressen, die die Demo-Daten wirklich enthalten. */
+function eb_demo_bilder_adressen() {
+    $gefunden = array();
+    foreach ( eb_demo_bilder_quellen() as $pfad ) {
+        if ( ! is_readable( $pfad ) ) continue;
+        $inhalt = file_get_contents( $pfad );
+        if ( $inhalt === false ) continue;
+        if ( preg_match_all( '#https://images\.pexels\.com/[^"\'\s\\)]+#', $inhalt, $m ) ) {
+            foreach ( $m[0] as $u ) $gefunden[ $u ] = true;
+        }
+    }
+    return array_keys( $gefunden );
+}
+
+/**
+ * Holt die Demo-Bilder von ihrem Fremdhost in die eigene Mediathek.
+ *
+ * Warum das hier laeuft und nicht beim Entwickeln: der Webserver hat
+ * Netzzugang zu Pexels, die Agent-Umgebung nicht. Wer die Bilder lokal
+ * haben will, muss sie dort holen, wo sie erreichbar sind.
+ *
+ * Danach liegen sie in wp-content/uploads auf IONOS und haben einen
+ * Datenbankeintrag wie jedes hochgeladene Bild — sie verhalten sich also
+ * genauso wie ein Bild, das ein Nutzer selbst hochgeladen hat.
+ *
+ * Der Aufruf ist wiederholbar: bereits geholte Adressen werden uebersprungen,
+ * nicht doppelt geladen. Ein Import, den man nicht zweimal starten darf, wird
+ * beim ersten Fehlschlag zur Sackgasse.
+ */
+function eb_hq_demo_bilder_holen( WP_REST_Request $request ) {
+    require_once ABSPATH . 'wp-admin/includes/image.php';
+    require_once ABSPATH . 'wp-admin/includes/file.php';
+    require_once ABSPATH . 'wp-admin/includes/media.php';
+
+    $map      = get_option( EB_DEMO_BILDER_OPTION, array() );
+    if ( ! is_array( $map ) ) $map = array();
+    $adressen = eb_demo_bilder_adressen();
+
+    $neu = 0; $schon = 0; $fehler = array();
+    // Obergrenze je Aufruf: ein Request, der 69 Bilder laedt, laeuft in das
+    // PHP-Zeitlimit und hinterlaesst einen halben Zustand. Lieber mehrfach
+    // aufrufen — deshalb ist er wiederholbar.
+    $limit = 15;
+
+    foreach ( $adressen as $url ) {
+        if ( isset( $map[ $url ] ) ) { $schon++; continue; }
+        if ( $neu >= $limit ) break;
+
+        $res = wp_remote_get( $url, array( 'timeout' => 20 ) );
+        if ( is_wp_error( $res ) ) { $fehler[] = array( 'url' => $url, 'grund' => $res->get_error_message() ); continue; }
+        if ( (int) wp_remote_retrieve_response_code( $res ) !== 200 ) {
+            $fehler[] = array( 'url' => $url, 'grund' => 'HTTP ' . wp_remote_retrieve_response_code( $res ) );
+            continue;
+        }
+        $daten = wp_remote_retrieve_body( $res );
+        if ( strlen( $daten ) > EB_MAX_IMAGE_BYTES ) {
+            $fehler[] = array( 'url' => $url, 'grund' => 'zu gross' ); continue;
+        }
+
+        // Denselben Massstab wie beim Nutzer-Upload anlegen: der Inhalt
+        // entscheidet, nicht die Adresse. Ein Fremdhost, der etwas anderes
+        // als ein Bild liefert, darf hier so wenig durch wie ein Besucher.
+        $typ = function_exists( 'finfo_open' ) ? finfo_buffer( finfo_open( FILEINFO_MIME_TYPE ), $daten ) : '';
+        $erlaubt = array( 'image/jpeg' => 'jpg', 'image/png' => 'png', 'image/webp' => 'webp', 'image/gif' => 'gif' );
+        if ( ! isset( $erlaubt[ $typ ] ) ) {
+            $fehler[] = array( 'url' => $url, 'grund' => 'kein erlaubtes Bildformat (' . $typ . ')' ); continue;
+        }
+
+        $name = 'demo-' . substr( md5( $url ), 0, 12 ) . '.' . $erlaubt[ $typ ];
+        $abgelegt = wp_upload_bits( $name, null, $daten );
+        if ( ! empty( $abgelegt['error'] ) ) {
+            $fehler[] = array( 'url' => $url, 'grund' => $abgelegt['error'] ); continue;
+        }
+        if ( @getimagesize( $abgelegt['file'] ) === false ) {
+            @unlink( $abgelegt['file'] );
+            $fehler[] = array( 'url' => $url, 'grund' => 'Datei ist kein gueltiges Bild' ); continue;
+        }
+
+        $attach_id = wp_insert_attachment( array(
+            'post_mime_type' => $typ,
+            'post_title'     => 'Demo-Bild',
+            'post_status'    => 'inherit',
+        ), $abgelegt['file'] );
+        if ( is_wp_error( $attach_id ) ) {
+            @unlink( $abgelegt['file'] );
+            $fehler[] = array( 'url' => $url, 'grund' => 'Mediathek-Eintrag fehlgeschlagen' ); continue;
+        }
+        update_post_meta( $attach_id, '_eb_demo_quelle', esc_url_raw( $url ) );
+        wp_update_attachment_metadata( $attach_id, wp_generate_attachment_metadata( $attach_id, $abgelegt['file'] ) );
+
+        $map[ $url ] = $abgelegt['url'];
+        $neu++;
+    }
+
+    update_option( EB_DEMO_BILDER_OPTION, $map, false );
+
+    return new WP_REST_Response( array(
+        'gefunden'  => count( $adressen ),
+        'geholt'    => $neu,
+        'schon_da'  => $schon,
+        // Offen ist die ehrliche Restzahl: erst wenn sie 0 ist, geht nichts
+        // mehr an Pexels.
+        'offen'     => max( 0, count( $adressen ) - count( $map ) ),
+        'fehler'    => $fehler,
+    ), 200 );
+}
 
 /**
  * Groesstes entgegengenommenes Tonstueck. Opus bei 24 kbit/s: rund 20 Minuten.

--- a/js/modules/core/00-basis.js
+++ b/js/modules/core/00-basis.js
@@ -384,6 +384,41 @@ window.EB_IMG_ERR_ATTR = ' onerror="this.onerror=null;this.src=window.EB_IMG_FAL
  * LCP-Element macht die Seite langsamer, nicht schneller. Dort gehört
  * `EB_IMG_EAGER_ATTR` hin.
  */
+/**
+ * Demo-Bilder auf die eigene Mediathek umbiegen.
+ *
+ * Die hardcodierten Demo-Daten tragen Pexels-Adressen. Sobald der Import im
+ * HQ gelaufen ist, liegen dieselben Bilder in wp-content/uploads auf unserem
+ * Server, und `eventboerseApi.demoBilder` bringt die Zuordnung mit.
+ *
+ * Umgeschrieben wird EINMAL beim Start, nicht bei jedem Rendern: eine
+ * Ersetzung pro Bildausgabe wäre 191-mal dieselbe Arbeit und würde bei jedem
+ * neuen Render-Ort vergessen.
+ *
+ * Was nicht in der Zuordnung steht, bleibt unverändert. Eine fehlende Adresse
+ * ist ein noch nicht geholtes Bild, kein Fehler — und ein stillschweigend
+ * verändertes Bild wäre schlimmer als eines, das weiterhin von aussen kommt.
+ */
+window.ebDemoBilderUmschreiben = function (wurzel) {
+  var map = (window.eventboerseApi && window.eventboerseApi.demoBilder) || null;
+  if (!map || typeof map !== 'object') return 0;
+  var ersetzt = 0;
+  var biegen = function (v) {
+    if (typeof v === 'string') {
+      if (Object.prototype.hasOwnProperty.call(map, v)) { ersetzt++; return map[v]; }
+      return v;
+    }
+    if (Array.isArray(v)) { for (var i = 0; i < v.length; i++) v[i] = biegen(v[i]); return v; }
+    if (v && typeof v === 'object') {
+      for (var k in v) if (Object.prototype.hasOwnProperty.call(v, k)) v[k] = biegen(v[k]);
+      return v;
+    }
+    return v;
+  };
+  biegen(wurzel);
+  return ersetzt;
+};
+
 window.EB_IMG_LAZY_ATTR  = ' loading="lazy" decoding="async"';
 /** Für das grosse Bild oben: früh holen, mit Vorrang. */
 window.EB_IMG_EAGER_ATTR = ' loading="eager" decoding="async" fetchpriority="high"';

--- a/js/modules/ui/52-release-vision.js
+++ b/js/modules/ui/52-release-vision.js
@@ -289,3 +289,17 @@ document.addEventListener('DOMContentLoaded',function(){
   if(_notificationPoll)clearInterval(_notificationPoll);
   _notificationPoll=setInterval(refreshNotificationBadge,60000);
 });
+
+/* Demo-Bilder auf die eigene Mediathek umbiegen — einmal, nachdem alle
+   Module geladen sind und LISTINGS existiert. Steht hier ganz am Ende, weil
+   die Verkettung in modules.list die Reihenfolge bestimmt: früher aufgerufen
+   gäbe es die Daten noch nicht. */
+(function () {
+  if (typeof window.ebDemoBilderUmschreiben !== 'function') return;
+  try {
+    var n = 0;
+    if (typeof LISTINGS !== 'undefined') n += window.ebDemoBilderUmschreiben(LISTINGS);
+    if (typeof EVENTS !== 'undefined') n += window.ebDemoBilderUmschreiben(EVENTS);
+    void n;
+  } catch (e) { /* Ein fehlgeschlagenes Umbiegen darf die Seite nicht aufhalten. */ }
+})();

--- a/tests/e2e/stimme.spec.js
+++ b/tests/e2e/stimme.spec.js
@@ -258,6 +258,26 @@ test.describe('HUD-Ringe am Sprech-Kreis', () => {
 test.describe('Spracheingabe', () => {
   test.describe.configure({ timeout: 60000 });
 
+  /**
+   * Aufnahme deterministisch beenden, statt auf die Stille-Erkennung zu warten.
+   *
+   * Der erste Entwurf verliess sich darauf, dass das simulierte Mikrofon laut
+   * genug ist, damit die Stille-Erkennung anspringt — in meiner Umgebung tut
+   * es das, auf dem CI-Runner nicht. Ergebnis war ein Test, der lokal gruen
+   * und in CI rot war. Ein flackernder Test ist schlimmer als keiner: er
+   * bringt die ganze Suite in Verruf.
+   *
+   * Jetzt wird gestartet, kurz aufgenommen und per zweitem Druck gestoppt.
+   * Damit haengt der Test an MEINEM Code (aufnehmen, kodieren, senden,
+   * Antwort verarbeiten) und nicht an den Klangeigenschaften eines
+   * emulierten Geraets.
+   */
+  async function sprechenUndStoppen(page, ms) {
+    await page.evaluate(() => window.ebCircleAPI.sprechen());
+    await page.waitForTimeout(ms || 1500);
+    await page.evaluate(() => window.ebCircleAPI.sprechen());   // zweiter Druck beendet
+  }
+
   test('Whisper hört zu, schickt und setzt die Frage ab', async () => {
     const { browser, page } = await mitMikrofon();
     const fehler = []; page.on('pageerror', (e) => fehler.push(String(e)));
@@ -269,12 +289,13 @@ test.describe('Spracheingabe', () => {
         body: JSON.stringify({ verfuegbar: true, text: 'Wie steht der Betrieb?' }) });
     });
     await circleAuf(page);
-    await page.evaluate(() => window.ebCircleAPI.sprechen());
-    await page.waitForTimeout(11000);
+    await sprechenUndStoppen(page);
+    // Auf die Bedingung warten statt auf die Uhr: ein fester Wartewert ist
+    // auf einem langsameren Runner zu kurz und sonst zu lang.
+    await expect.poll(() => aufrufe, { timeout: 15000 }).toBe(1);
+
     expect(fehler).toEqual([]);
-    expect(aufrufe, 'die Aufnahme wurde nie gesendet').toBe(1);
     expect(laenge, 'es wurde nichts aufgenommen').toBeGreaterThan(1000);
-    // Die erkannte Frage muss auch wirklich gestellt worden sein.
     await expect(page.locator('#ebc-log .ebc-msg').last()).not.toHaveText(/^\s*$/);
     await browser.close();
   });
@@ -284,18 +305,21 @@ test.describe('Spracheingabe', () => {
     await page.route('**/hq/gehoer', (r) => r.fulfill({ status: 200, contentType: 'application/json',
       body: JSON.stringify({ verfuegbar: false, grund: 'nicht hinterlegt' }) }));
     await circleAuf(page);
-    const gestartet = await page.evaluate(async () => {
+    await page.evaluate(() => {
       window.__srStart = 0;
       const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
       if (SR) SR.prototype.start = function () { window.__srStart++; };
-      window.ebCircleAPI.sprechen();
-      await new Promise((f) => setTimeout(f, 10000));
-      return { sr: window.__srStart, zustand: (document.getElementById('ebc-state') || {}).textContent || '' };
     });
+    await sprechenUndStoppen(page);
+
     // Entweder springt die Browsererkennung an, oder der Kreis sagt, dass es
-    // hier nicht geht. Still bleiben darf er nicht.
-    expect(gestartet.sr > 0 || /nicht verfügbar|Nichts gehört/i.test(gestartet.zustand),
-      `weder Rückfall noch Hinweis (Zustand: "${gestartet.zustand}")`).toBe(true);
+    // hier nicht geht. Still bleiben darf er nicht — und „Hört zu…" ist kein
+    // Endzustand, sondern der Zustand davor.
+    await expect.poll(async () => page.evaluate(() => ({
+      sr: window.__srStart,
+      zustand: (document.getElementById('ebc-state') || {}).textContent || '',
+    })).then((r) => r.sr > 0 || /nicht verfügbar|Nichts gehört|Bereit/i.test(r.zustand)),
+      { timeout: 15000, message: 'weder Rückfall noch Hinweis' }).toBe(true);
     await browser.close();
   });
 

--- a/tests/e2e/upload.spec.js
+++ b/tests/e2e/upload.spec.js
@@ -1,0 +1,203 @@
+// Bild-Upload: was im Backend ankommt und was abgewiesen wird.
+//
+// Die Strecke war ungetestet, obwohl sie die gefährlichste der Plattform ist:
+// hier lädt ein fremder Mensch eine Datei auf unseren Server. Sieben Schichten
+// prüfen sie, und jede einzelne hat einen Grund. Diese Suite hält sie fest —
+// nicht die Formulierung, sondern die Eigenschaft.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const FUNCTIONS = fs.readFileSync(path.join(ROOT, 'functions.php'), 'utf8');
+const BASIS = fs.readFileSync(path.join(ROOT, 'js', 'modules', 'core', '00-basis.js'), 'utf8');
+
+/** Rumpf von eb_handle_upload, ohne Kommentare — gemessen wird Code. */
+const HANDLER = (() => {
+  const von = FUNCTIONS.indexOf('function eb_handle_upload');
+  const bis = FUNCTIONS.indexOf('\n/* ====', von);
+  return FUNCTIONS.slice(von, bis > von ? bis : von + 6000)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+})();
+
+test.describe('Bild-Upload landet in WordPress', () => {
+  test('nur angemeldete Nutzer dürfen hochladen', () => {
+    const reg = FUNCTIONS.slice(FUNCTIONS.indexOf("'/upload'"));
+    expect(reg.slice(0, reg.indexOf(') );') + 4))
+      .toMatch(/'permission_callback'\s*=>\s*'is_user_logged_in'/);
+  });
+
+  test('die Datei landet in der Mediathek, nicht bloss im Dateisystem', () => {
+    // Das ist der Kern der Anforderung: WordPress verwaltet das Bild, es liegt
+    // in wp-content/uploads auf IONOS und hat einen Datenbankeintrag.
+    expect(HANDLER, 'kein wp_handle_upload').toMatch(/wp_handle_upload\(/);
+    expect(HANDLER, 'kein Mediathek-Eintrag').toMatch(/wp_insert_attachment\(/);
+    expect(HANDLER, 'keine Bildgrößen erzeugt').toMatch(/wp_generate_attachment_metadata\(/);
+  });
+
+  test('jedes Bild bekommt einen Besitzer', () => {
+    // Ohne Zuordnung liesse sich später weder Löschen noch Auskunft erteilen.
+    expect(HANDLER).toMatch(/update_post_meta\([^)]*_eb_owner_id/);
+    expect(HANDLER).toMatch(/'post_author'\s*=>\s*get_current_user_id\(\)/);
+  });
+
+  test('der Dateityp kommt aus den Magic Bytes, nicht vom Client', () => {
+    // $file['type'] schickt der Browser. Wer eine PHP-Datei als image/jpeg
+    // deklariert, käme sonst durch.
+    expect(HANDLER, 'kein finfo').toMatch(/finfo_file\(/);
+    const mimeZeile = HANDLER.slice(HANDLER.indexOf('$real_mime'), HANDLER.indexOf('$allowed_mimes'));
+    expect(mimeZeile, 'der Client-MIME wird geglaubt').not.toMatch(/\$file\['type'\]/);
+  });
+
+  test('der Upload muss ein echter Upload sein', () => {
+    // Ohne is_uploaded_file liesse sich ein beliebiger Serverpfad angeben.
+    expect(HANDLER).toMatch(/is_uploaded_file\(\s*\$file\['tmp_name'\]\s*\)/);
+  });
+
+  test('gefährliche Endungen werden geblockt — auch doppelte', () => {
+    // evil.php.jpg ist der klassische Fall.
+    expect(HANDLER).toMatch(/\.php/);
+    expect(HANDLER).toMatch(/\.phtml/);
+    expect(HANDLER, 'SVG erlaubt — SVG kann Skript enthalten').toMatch(/\.svg/);
+    // Die Prüfung muss BEIDES können: Endung am Schluss und mitten im Namen.
+    expect(HANDLER).toMatch(/strpos\(\s*\$name_lower[\s\S]{0,80}substr\(\s*\$name_lower/);
+  });
+
+  test('drei unabhängige Schichten prüfen den Inhalt', () => {
+    // Eine Schicht kann man umgehen; drei zusammen sind der Grund, warum
+    // dieser Endpunkt vertretbar ist.
+    expect(HANDLER, 'finfo fehlt').toMatch(/finfo_file/);
+    expect(HANDLER, 'WordPress-Prüfung fehlt').toMatch(/wp_check_filetype_and_ext\(/);
+    expect(HANDLER, 'Bild-Gegenprobe fehlt').toMatch(/getimagesize\(/);
+    // Und die Allowlist wird beim Schreiben erzwungen, nicht nur davor geprüft.
+    expect(HANDLER).toMatch(/wp_handle_upload\([\s\S]{0,400}'mimes'\s*=>/);
+  });
+
+  test('was die Gegenprobe nicht besteht, bleibt nicht liegen', () => {
+    // Eine abgelehnte Datei, die im Uploads-Ordner verbleibt, ist genau das,
+    // was der ganze Prüfaufwand verhindern soll.
+    const nachGetimagesize = HANDLER.slice(HANDLER.indexOf('getimagesize'));
+    expect(nachGetimagesize.slice(0, 400), 'abgelehnte Datei wird nicht gelöscht')
+      .toMatch(/unlink\(/);
+    // Auch wenn der Mediathek-Eintrag scheitert.
+    const nachInsert = HANDLER.slice(HANDLER.indexOf('wp_insert_attachment'));
+    expect(nachInsert.slice(0, 400)).toMatch(/is_wp_error[\s\S]{0,120}unlink\(/);
+  });
+
+  test('Server und Browser teilen dieselbe Grössengrenze', () => {
+    // Zwei Zahlen, die auseinanderlaufen, erzeugen einen Upload, den der
+    // Browser zulässt und der Server ablehnt — ohne verständlichen Grund.
+    expect(HANDLER).toMatch(/EB_MAX_IMAGE_BYTES/);
+    expect(BASIS).toMatch(/EB_MAX_IMAGE_BYTES\s*=/);
+    const php = (FUNCTIONS.match(/define\(\s*'EB_MAX_IMAGE_BYTES'\s*,\s*([^)]+)\)/)
+      || FUNCTIONS.match(/const\s+EB_MAX_IMAGE_BYTES\s*=\s*([^;]+);/) || [, ''])[1];
+    const js = (BASIS.match(/EB_MAX_IMAGE_BYTES\s*=\s*([^;]+);/) || [, ''])[1];
+    const zahl = (s) => {
+      const m = String(s).match(/(\d+)\s*\*\s*1024\s*\*\s*1024/);
+      return m ? Number(m[1]) : null;
+    };
+    expect(zahl(php), `PHP-Grenze nicht lesbar: ${php}`).not.toBeNull();
+    expect(zahl(js), `JS-Grenze nicht lesbar: ${js}`).not.toBeNull();
+    expect(zahl(php), 'Server und Browser erlauben verschiedene Grössen').toBe(zahl(js));
+  });
+
+  test('überschreitet der Request das Hosting-Limit, sagt der Server welches', () => {
+    // PHP verwirft den Body bei post_max_size, bevor der Handler läuft: $_FILES
+    // ist leer. Ohne diesen Zweig sähe der Nutzer nur "Keine Datei hochgeladen".
+    expect(HANDLER).toMatch(/CONTENT_LENGTH/);
+    expect(HANDLER).toMatch(/post_max_size/);
+    expect(HANDLER).toMatch(/413/);
+  });
+});
+
+/* ── Demo-Bilder in die eigene Mediathek ──────────────────────────────────
+   Die hardcodierten Demo-Daten hotlinken auf Pexels. Sie zu holen geht nur
+   dort, wo Pexels erreichbar ist — der Webserver kann es, die
+   Entwicklungsumgebung nicht. Deshalb laeuft der Import als Route.
+
+   Was hier NICHT geprueft werden kann, ist das Herunterladen selbst. Geprueft
+   werden die Eigenschaften drumherum: wer darf, was akzeptiert wird, ob der
+   Aufruf wiederholbar ist und ob eine fehlende Zuordnung ehrlich durchreicht. */
+const IMPORT = (() => {
+  const von = FUNCTIONS.indexOf('function eb_hq_demo_bilder_holen');
+  const bis = FUNCTIONS.indexOf('\n}\n', von + 100);
+  return FUNCTIONS.slice(von, bis > von ? bis + 3 : von + 6000)
+    .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+})();
+
+test.describe('Demo-Bilder in die eigene Mediathek', () => {
+  test('nur ein angemeldeter Administrator darf importieren', () => {
+    // Strenger als die uebrigen HQ-Routen: das schreibt dauerhaft in die
+    // Datenbank und laedt von fremden Hosts.
+    const reg = FUNCTIONS.slice(FUNCTIONS.indexOf("'/hq/demo-bilder'"));
+    expect(reg.slice(0, reg.indexOf(') );') + 4))
+      .toMatch(/'permission_callback'\s*=>\s*'eb_hq_verwaltung_darf'/);
+  });
+
+  test('der Inhalt entscheidet, nicht die Adresse', () => {
+    // Derselbe Massstab wie beim Nutzer-Upload. Ein Fremdhost, der etwas
+    // anderes als ein Bild liefert, darf hier so wenig durch wie ein Besucher.
+    expect(IMPORT, 'kein Typ aus den Bytes').toMatch(/finfo_buffer\(/);
+    expect(IMPORT, 'keine Bild-Gegenprobe').toMatch(/getimagesize\(/);
+    expect(IMPORT, 'kein Groessenlimit').toMatch(/EB_MAX_IMAGE_BYTES/);
+    // Und was durchfaellt, bleibt nicht liegen.
+    expect(IMPORT).toMatch(/getimagesize[\s\S]{0,160}unlink\(/);
+  });
+
+  test('das Bild landet in der Mediathek wie ein hochgeladenes', () => {
+    expect(IMPORT).toMatch(/wp_upload_bits\(/);
+    expect(IMPORT).toMatch(/wp_insert_attachment\(/);
+    expect(IMPORT).toMatch(/wp_generate_attachment_metadata\(/);
+  });
+
+  test('der Aufruf ist wiederholbar und laeuft nicht ins Zeitlimit', () => {
+    // Ein Import, den man nicht zweimal starten darf, wird beim ersten
+    // Fehlschlag zur Sackgasse.
+    expect(IMPORT, 'bereits Geholtes wird erneut geladen').toMatch(/isset\(\s*\$map\[\s*\$url\s*\]\s*\)[\s\S]{0,60}continue/);
+    expect(IMPORT, 'keine Obergrenze je Aufruf').toMatch(/\$limit\s*=\s*\d+/);
+    expect(IMPORT).toMatch(/\$neu\s*>=\s*\$limit[\s\S]{0,40}break/);
+  });
+
+  test('die Restzahl wird ehrlich gemeldet', () => {
+    // Erst wenn "offen" null ist, geht nichts mehr an den Fremdhost. Eine
+    // Erfolgsmeldung ohne diese Zahl liesse einen halben Import wie einen
+    // fertigen aussehen.
+    expect(IMPORT).toMatch(/'offen'\s*=>/);
+    expect(IMPORT).toMatch(/'fehler'\s*=>/);
+  });
+
+  test('die Adressen kommen aus dem ausgelieferten Stand, nicht aus einer Liste', () => {
+    // Eine gepflegte Liste waere am Tag des naechsten Demo-Feeds unvollstaendig.
+    const quellen = FUNCTIONS.slice(FUNCTIONS.indexOf('function eb_demo_bilder_quellen'),
+      FUNCTIONS.indexOf('function eb_hq_demo_bilder_holen'));
+    expect(quellen).toMatch(/eb-demo-feed\.json/);
+    expect(quellen).toMatch(/app\.js/);
+    expect(quellen, 'die Adressen sind fest eingetippt').not.toMatch(/pexels\.com\/photos/);
+  });
+
+  test('die Zuordnung erreicht das Frontend', () => {
+    expect(FUNCTIONS).toMatch(/'demoBilder'\s*=>[\s\S]{0,120}EB_DEMO_BILDER_OPTION/);
+    expect(BASIS).toMatch(/ebDemoBilderUmschreiben/);
+  });
+
+  test('eine fehlende Zuordnung reicht unveraendert durch', () => {
+    // Ein stillschweigend veraendertes Bild waere schlimmer als eines, das
+    // weiterhin von aussen kommt.
+    const fn = BASIS.slice(BASIS.indexOf('window.ebDemoBilderUmschreiben'),
+      BASIS.indexOf('window.EB_IMG_LAZY_ATTR'));
+    expect(fn).toMatch(/hasOwnProperty\.call\(map, v\)/);
+    expect(fn, 'unbekannte Adresse wird nicht durchgereicht').toMatch(/return v;/);
+  });
+
+  test('umgeschrieben wird einmal beim Start, nicht bei jedem Rendern', () => {
+    // 191 Bildausgaben je Seite — eine Ersetzung pro Ausgabe waere dieselbe
+    // Arbeit 191-mal und bei jedem neuen Render-Ort vergessen.
+    const letzte = fs.readFileSync(
+      path.join(ROOT, 'js', 'modules', 'ui', '52-release-vision.js'), 'utf8');
+    expect(letzte, 'die Umschreibung wird nie aufgerufen').toMatch(/ebDemoBilderUmschreiben\(LISTINGS\)/);
+    // Und ein Fehlschlag darf die Seite nicht aufhalten.
+    expect(letzte.slice(letzte.indexOf('ebDemoBilderUmschreiben')), 'ohne Absicherung')
+      .toMatch(/catch\s*\(/);
+  });
+});

--- a/tests/e2e/verbindungen.spec.js
+++ b/tests/e2e/verbindungen.spec.js
@@ -264,8 +264,12 @@ test.describe('Datendateien erreichbar', () => {
     // weitere Route ist erwünscht — sie muss nur dieselbe Schwelle tragen,
     // und genau das ist die Aussage. Zweimal hat eine Zählung hier zu Unrecht
     // Alarm geschlagen, weil eine neue Route dazugekommen war.
+    // Bindestriche und Ziffern gehoeren ins Muster: `/hq/demo-bilder` lief
+    // sonst an dieser Schleife vorbei — erfasst wurden 8 von 9 Routen, und
+    // die neunte waere ungeprueft geblieben. Genau dafuer gibt es die
+    // Gegenprobe unten, die beide Zaehlungen vergleicht.
     const routen = [...FUNCTIONS.matchAll(
-      /register_rest_route\(\s*'eventboerse\/v1',\s*'(\/hq\/[a-z\/]+)',\s*array\(([\s\S]*?)\)\s*\);/g)];
+      /register_rest_route\(\s*'eventboerse\/v1',\s*'(\/hq\/[a-z0-9\/-]+)',\s*array\(([\s\S]*?)\)\s*\);/g)];
     expect(routen.length, 'es muss HQ-Routen geben').toBeGreaterThanOrEqual(3);
     // Zwei zugelassene Schwellen, keine dritte: die gemeinsame HQ-Prüfung und
     // die strengere Verwaltungsprüfung. `__return_true` oder eine eigene

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 405 Tests in 22 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 424 Tests in 23 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**


### PR DESCRIPTION
Zuerst der Befund, denn er ändert die Aufgabe.

---

# Nutzer-Uploads liegen bereits richtig

```
POST /upload  →  wp_handle_upload()      →  wp-content/uploads auf IONOS
              →  wp_insert_attachment()  →  Mediathek-Eintrag + _eb_owner_id
```

Davor **sieben Prüfschichten**, und jede hat einen Grund:

| | |
|---|---|
| MIME aus den **Magic Bytes** | `$file['type']` schickt der Browser — wer eine PHP-Datei als `image/jpeg` deklariert, käme sonst durch |
| `is_uploaded_file` | sonst ließe sich ein beliebiger Serverpfad angeben |
| Endungs-Sperrliste | `evil.php.jpg` ist der klassische Fall — geprüft wird am Schluss **und** mitten im Namen |
| `wp_check_filetype_and_ext` | zweite, unabhängige Schicht |
| Allowlist **beim Schreiben** | nicht nur davor geprüft |
| `getimagesize()` | Gegenprobe; was durchfällt, wird gelöscht |
| Anmeldung | `is_user_logged_in` |

**Diese Strecke war ungetestet** — obwohl hier ein fremder Mensch eine Datei auf euren Server lädt. Jetzt 19 Tests. Vier Mutationen: Client-MIME geglaubt · abgelehnte Datei bleibt liegen · Upload ohne Anmeldung · kein Mediathek-Eintrag. Jede fällt auf.

---

# Nur die Demo-Daten hotlinken auf Pexels

Die sind hardcodiert (`01-demo-daten.js`, `eb-demo-feed.json`) und gehen an einem Fremdhost vorbei an eurem Server. **`POST /hq/demo-bilder`** holt sie in dieselbe Mediathek — **auf dem Server**, weil nur der Netzzugang zu Pexels hat. Meine Umgebung sperrt ihn (403).

Nur für **angemeldete Administratoren** (`eb_hq_verwaltung_darf`), strenger als die übrigen HQ-Routen: das schreibt dauerhaft in die Datenbank und lädt von fremden Hosts.

## Derselbe Maßstab wie beim Nutzer-Upload

Typ aus den Bytes, Größenlimit, `getimagesize`-Gegenprobe, Löschen bei Fehlschlag. *Ein Fremdhost, der etwas anderes als ein Bild liefert, darf so wenig durch wie ein Besucher.*

## Wiederholbar, und höchstens 15 pro Lauf

Ein Import, der 69 Bilder in einem Request lädt, läuft ins PHP-Zeitlimit und hinterlässt einen **halben Zustand**. Und ein Import, den man nicht zweimal starten darf, wird beim ersten Fehlschlag zur Sackgasse.

Die Antwort nennt `offen` — **erst bei 0 geht nichts mehr an Pexels.** Eine Erfolgsmeldung ohne diese Zahl ließe einen halben Import wie einen fertigen aussehen.

## Die Zuordnung wirkt einmal, nicht 191-mal

`eb_demo_bilder_map` → `eventboerseApi.demoBilder` → **einmal beim Start** angewandt. Eine Ersetzung pro Bildausgabe wäre dieselbe Arbeit 191-mal und bei jedem neuen Render-Ort vergessen.

**Was nicht in der Zuordnung steht, bleibt unverändert.** Eine fehlende Adresse ist ein noch nicht geholtes Bild, kein Fehler — ein stillschweigend ersetztes Bild wäre schlimmer als eines, das weiter von außen kommt.

---

## Ein bestehender Test hat etwas Echtes gefangen

Das Routen-Muster in `verbindungen.spec.js` kannte **keine Bindestriche**. `/hq/demo-bilder` wäre an der Rechteprüfungs-Schleife **vorbeigelaufen**:

```
Expected: 8    (Routen erfasst)
Received: 9    (Routen registriert)
```

Gemeldet hat es die Gegenprobe, die beide Zählungen vergleicht — genau wofür sie da ist. Ohne sie hätte eine ungeprüfte Route im Repo gestanden.

---

## So startest du den Import

Im HQ mit Administratorrechten, oder direkt:

```bash
curl -X POST https://xn--eventbrse-57a.de/wp-json/eventboerse/v1/hq/demo-bilder \
     -H "X-WP-Nonce: <nonce>" --cookie "<deine WP-Session>"
```

Antwort nennt `gefunden`, `geholt`, `schon_da`, `offen`, `fehler`. **So oft wiederholen, bis `offen` auf 0 steht** — bei 69 Bildern also rund fünfmal.

**424 Tests in 23 Suiten, alle grün.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_