### PR TITLE
Der Import der Demo-Bilder hat jetzt einen Knopf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-424 Tests in 23 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+430 Tests in 23 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -361,6 +361,19 @@ Prüfschichten davor, unter anderem MIME aus den **Magic Bytes** (nie aus
 wiederholbar und holt höchstens 15 Bilder je Lauf; ein Import, der ins
 PHP-Zeitlimit läuft, hinterließe sonst einen halben Zustand. Die Antwort nennt
 `offen` — erst bei 0 geht nichts mehr an den Fremdhost.
+
+Bedient wird das im HQ unter **🖼️ Demo-Bilder** (nur für Administratoren
+sichtbar; die Sperre bleibt die Route). `GET` auf denselben Pfad zeigt den
+Stand, **ohne** zu laden oder zu schreiben — ein Blick mit Nebenwirkungen wird
+seltener geworfen, als er sollte. Der Knopf ruft in Runden auf und hört bei
+`offen = 0` **und** bei einer Runde ohne Fortschritt auf: eine Schleife, die nur
+ein Ziel kennt und keinen Ausstieg, stößt bei einem nicht erreichbaren
+Fremdhost zehnmal umsonst an.
+
+`offen` zählt die **Schnittmenge** aus Adressen und Zuordnung, nie die Einträge
+der Zuordnung. Nach einem neuen Demo-Feed stehen alte Adressen weiter darin;
+wer Einträge zählt, meldet dann zu wenig Offene — im schlimmsten Fall eine 0,
+während noch Bilder an Pexels gehen.
 
 Die Zuordnung liegt in der Option `eb_demo_bilder_map`, wird über
 `eventboerseApi.demoBilder` ausgeliefert und **einmal beim Start** angewandt

--- a/functions.php
+++ b/functions.php
@@ -9826,8 +9826,13 @@ add_action( 'rest_api_init', function () {
 
     // Demo-Bilder in die Mediathek holen. Bewusst die STRENGERE Pruefung:
     // das schreibt dauerhaft in die Datenbank und laedt von fremden Hosts.
+    //
+    // GET beantwortet dieselbe Frage OHNE zu laden: wie viele Adressen gibt
+    // es, wie viele liegen schon hier, wie viele fehlen. Ohne diesen Weg
+    // muesste man etwas veraendern, um den Stand zu sehen — und ein Blick,
+    // der Nebenwirkungen hat, wird seltener geworfen, als er sollte.
     register_rest_route( 'eventboerse/v1', '/hq/demo-bilder', array(
-        'methods'             => 'POST',
+        'methods'             => 'GET, POST',
         'callback'            => 'eb_hq_demo_bilder_holen',
         'permission_callback' => 'eb_hq_verwaltung_darf',
     ) );
@@ -9863,6 +9868,28 @@ function eb_demo_bilder_adressen() {
 }
 
 /**
+ * Wie viele Demo-Adressen es gibt und wie viele davon schon hier liegen.
+ *
+ * Gezaehlt wird die SCHNITTMENGE, nicht die Groesse der Zuordnung. Der
+ * Unterschied ist kein Detail: nach einem neuen Demo-Feed stehen alte
+ * Adressen weiter in der Zuordnung, ohne dass es sie noch gibt. Wer die
+ * Eintraege zaehlt, bekommt dann zu wenig Offene gemeldet — im schlimmsten
+ * Fall eine 0, waehrend noch Bilder an Pexels gehen. Eine Zahl, die
+ * "fertig" sagt, obwohl es weitergeht, ist schlimmer als gar keine.
+ */
+function eb_demo_bilder_stand( array $map, array $adressen ) {
+    $da = 0;
+    foreach ( $adressen as $url ) {
+        if ( isset( $map[ $url ] ) ) $da++;
+    }
+    return array(
+        'gefunden'     => count( $adressen ),
+        'in_mediathek' => $da,
+        'offen'        => count( $adressen ) - $da,
+    );
+}
+
+/**
  * Holt die Demo-Bilder von ihrem Fremdhost in die eigene Mediathek.
  *
  * Warum das hier laeuft und nicht beim Entwickeln: der Webserver hat
@@ -9885,6 +9912,14 @@ function eb_hq_demo_bilder_holen( WP_REST_Request $request ) {
     $map      = get_option( EB_DEMO_BILDER_OPTION, array() );
     if ( ! is_array( $map ) ) $map = array();
     $adressen = eb_demo_bilder_adressen();
+
+    // Nur nachsehen: keine Verbindung nach draussen, kein Schreiben.
+    if ( strtoupper( $request->get_method() ) === 'GET' ) {
+        return new WP_REST_Response( array_merge(
+            eb_demo_bilder_stand( $map, $adressen ),
+            array( 'geholt' => 0, 'schon_da' => 0, 'fehler' => array() )
+        ), 200 );
+    }
 
     $neu = 0; $schon = 0; $fehler = array();
     // Obergrenze je Aufruf: ein Request, der 69 Bilder laedt, laeuft in das
@@ -9944,14 +9979,11 @@ function eb_hq_demo_bilder_holen( WP_REST_Request $request ) {
 
     update_option( EB_DEMO_BILDER_OPTION, $map, false );
 
-    return new WP_REST_Response( array(
-        'gefunden'  => count( $adressen ),
-        'geholt'    => $neu,
-        'schon_da'  => $schon,
-        // Offen ist die ehrliche Restzahl: erst wenn sie 0 ist, geht nichts
-        // mehr an Pexels.
-        'offen'     => max( 0, count( $adressen ) - count( $map ) ),
-        'fehler'    => $fehler,
+    // Offen ist die ehrliche Restzahl: erst wenn sie 0 ist, geht nichts
+    // mehr an Pexels.
+    return new WP_REST_Response( array_merge(
+        eb_demo_bilder_stand( $map, $adressen ),
+        array( 'geholt' => $neu, 'schon_da' => $schon, 'fehler' => $fehler )
     ), 200 );
 }
 

--- a/hq.html
+++ b/hq.html
@@ -956,6 +956,28 @@
       </div>
     </div>
 
+    <!-- Demo-Bilder — ebenfalls nur für Administratoren.
+         Der Knopf muss hier sitzen und nicht im Repo: Netzzugang zu Pexels
+         hat der Webserver, nicht die Entwicklungsumgebung. -->
+    <div id="demo-bilder-block" hidden>
+      <div class="section-header" id="demo-bilder">
+        <div class="section-title">🖼️ Demo-Bilder <span style="font-weight:400;color:var(--muted);font-size:.82rem;">— aus der eigenen Mediathek statt von Pexels</span></div>
+        <div class="section-badge" id="demo-bilder-badge">–</div>
+      </div>
+      <div class="journal">
+        <p style="margin:0 0 14px;color:var(--muted);font-size:.86rem;line-height:1.55;">
+          Lädt die Bilder der Demo-Daten einmalig herunter und legt sie in
+          <code>wp-content/uploads</code> ab — mit Datenbankeintrag, wie jedes hochgeladene Bild.
+          Solange <strong>offen</strong> über 0 steht, holt der Browser jedes Besuchers diese
+          Bilder noch bei einem Dritten. Der Lauf ist wiederholbar und holt je Runde 15 Bilder.
+        </p>
+        <div id="demo-bilder-stand" role="status" aria-live="polite"
+             style="margin:0 0 12px;font-size:.9rem;"></div>
+        <button type="button" class="icon-btn with-label" id="demo-bilder-start">⬇︎ Bilder holen</button>
+        <ul id="demo-bilder-fehler" style="margin:12px 0 0;padding-left:18px;font-size:.82rem;color:#fca5a5;"></ul>
+      </div>
+    </div>
+
     <!-- Wartet auf dich -->
     <div class="wartet" id="wartet"></div>
 
@@ -4815,6 +4837,106 @@ window.addEventListener('DOMContentLoaded', init);
 
   form.addEventListener('submit', function (e) { e.preventDefault(); senden(true); });
   document.getElementById('zugang-nehmen').addEventListener('click', function () { senden(false); });
+})();
+
+/* ═══ Demo-Bilder holen ════════════════════════════════════════════════
+   Die Route gab es seit #182, den Weg sie zu bedienen nicht. Eine
+   Fähigkeit, die nur per Hand-Request erreichbar ist, wird nie ausgeführt
+   — und dann hotlinken die Demo-Daten weiter auf einen fremden Host.
+
+   Zwei Eigenschaften, die hier tragen:
+
+   1. NACHSEHEN OHNE ANFASSEN. Beim Laden fragt die Seite den Stand per GET.
+      Ein Blick, der etwas verändert, wird seltener geworfen.
+
+   2. DER LAUF HÖRT AUF. Abgebrochen wird bei offen = 0 UND bei einer Runde
+      ohne Fortschritt. Ohne die zweite Bedingung würde ein dauerhaft nicht
+      erreichbarer Fremdhost den Server endlos anstoßen — eine Schleife, die
+      nur ein Ziel kennt und keinen Ausstieg, ist ein Fehler mit Anlauf.
+   ═══════════════════════════════════════════════════════════════════════ */
+(function () {
+  const block = document.getElementById('demo-bilder-block');
+  if (!block) return;
+  if (!HQ_IST_ADMIN) { block.remove(); return; }
+  block.hidden = false;
+
+  const standEl = document.getElementById('demo-bilder-stand');
+  const badge   = document.getElementById('demo-bilder-badge');
+  const knopf   = document.getElementById('demo-bilder-start');
+  const liste   = document.getElementById('demo-bilder-fehler');
+
+  // Höchstens so viele Runden. 15 Bilder je Runde — das reicht für ein
+  // Vielfaches des heutigen Bestands und deckelt trotzdem den Schaden,
+  // falls die Abbruchbedingung eines Tages danebengeht.
+  const MAX_RUNDEN = 10;
+
+  function zeigeStand(d, zusatz) {
+    const offen = Number(d.offen);
+    badge.textContent = offen === 0 ? 'vollständig' : offen + ' offen';
+    standEl.textContent =
+      d.gefunden + ' Adressen · ' + d.in_mediathek + ' in der Mediathek · ' +
+      offen + ' offen' + (zusatz ? ' — ' + zusatz : '');
+    standEl.style.color = offen === 0 ? '#4ade80' : 'var(--fg)';
+  }
+
+  function zeigeFehler(fehler) {
+    liste.textContent = '';
+    (fehler || []).forEach(function (f) {
+      const li = document.createElement('li');
+      // textContent, nicht innerHTML: Grund und Adresse kommen aus einer
+      // Fremdantwort.
+      li.textContent = (f.grund || 'unbekannt') + ' — ' + (f.url || '');
+      liste.appendChild(li);
+    });
+  }
+
+  async function ruf(methode) {
+    const r = await fetch('/wp-json/eventboerse/v1/hq/demo-bilder', {
+      method: methode,
+      credentials: 'same-origin',
+      headers: { 'X-WP-Nonce': HQ_REST_NONCE },
+    });
+    const d = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(d.message || ('Fehlgeschlagen (' + r.status + ').'));
+    return d;
+  }
+
+  async function holen() {
+    knopf.disabled = true;
+    liste.textContent = '';
+    let letzte = null;
+    try {
+      for (let runde = 1; runde <= MAX_RUNDEN; runde++) {
+        standEl.textContent = 'Runde ' + runde + ' läuft…';
+        const d = await ruf('POST');
+        letzte = d;
+        zeigeStand(d, 'Runde ' + runde + ': ' + d.geholt + ' geholt');
+        zeigeFehler(d.fehler);
+        if (Number(d.offen) === 0) { zeigeStand(d, 'fertig'); return; }
+        // Kein Fortschritt heißt: die verbleibenden Adressen gehen nicht.
+        // Weiterzulaufen würde denselben Fehlschlag zehnmal wiederholen.
+        if (Number(d.geholt) === 0) {
+          zeigeStand(d, 'keine Fortschritte mehr — siehe Gründe unten');
+          return;
+        }
+      }
+      if (letzte) zeigeStand(letzte, 'Rundenlimit erreicht — nochmal drücken');
+    } catch (e) {
+      standEl.textContent = String(e.message || e);
+      standEl.style.color = '#fca5a5';
+    } finally {
+      knopf.disabled = false;
+    }
+  }
+
+  knopf.addEventListener('click', holen);
+
+  // Stand beim Laden, ohne etwas zu holen.
+  ruf('GET').then(zeigeStand).catch(function (e) {
+    badge.textContent = 'unbekannt';
+    standEl.textContent = 'Stand nicht abrufbar: ' + String(e.message || e);
+    standEl.style.color = 'var(--muted)';
+  });
 })();
 </script>
 </body>

--- a/tests/e2e/upload.spec.js
+++ b/tests/e2e/upload.spec.js
@@ -6,7 +6,9 @@
 // nicht die Formulierung, sondern die Eigenschaft.
 const { test, expect } = require('@playwright/test');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 
 const ROOT = path.join(__dirname, '..', '..');
 const FUNCTIONS = fs.readFileSync(path.join(ROOT, 'functions.php'), 'utf8');
@@ -163,8 +165,59 @@ test.describe('Demo-Bilder in die eigene Mediathek', () => {
     // Erst wenn "offen" null ist, geht nichts mehr an den Fremdhost. Eine
     // Erfolgsmeldung ohne diese Zahl liesse einen halben Import wie einen
     // fertigen aussehen.
-    expect(IMPORT).toMatch(/'offen'\s*=>/);
+    expect(IMPORT).toMatch(/eb_demo_bilder_stand\(/);
     expect(IMPORT).toMatch(/'fehler'\s*=>/);
+  });
+
+  test('die Restzahl zaehlt die Schnittmenge, nicht die Eintraege', () => {
+    // Gemessen am AUSGEFUEHRTEN Code, nicht am Text: die Funktion wird aus
+    // functions.php geschnitten und mit PHP wirklich aufgerufen.
+    //
+    // Der Fall, der es braucht: nach einem neuen Demo-Feed stehen alte
+    // Adressen weiter in der Zuordnung. Wer die Eintraege zaehlt, meldet
+    // dann zu wenig Offene — im schlimmsten Fall eine 0, waehrend noch
+    // Bilder an Pexels gehen.
+    const von = FUNCTIONS.indexOf('function eb_demo_bilder_stand');
+    expect(von, 'eb_demo_bilder_stand fehlt').toBeGreaterThan(-1);
+    const quelle = FUNCTIONS.slice(von, FUNCTIONS.indexOf('\n}\n', von) + 2);
+
+    const datei = path.join(os.tmpdir(), 'eb-stand-' + process.pid + '.php');
+    fs.writeFileSync(datei, '<?php\n' + quelle + '\n' + `
+      $adressen = array( 'a', 'b', 'c' );
+      echo json_encode( array(
+        'leer'   => eb_demo_bilder_stand( array(), $adressen ),
+        'halb'   => eb_demo_bilder_stand( array( 'a' => 'x' ), $adressen ),
+        // Zwei Eintraege, aber nur einer davon ist noch eine Adresse.
+        'veraltet' => eb_demo_bilder_stand( array( 'a' => 'x', 'weg' => 'y' ), $adressen ),
+        'fertig' => eb_demo_bilder_stand( array( 'a' => 'x', 'b' => 'y', 'c' => 'z' ), $adressen ),
+      ) );`);
+    let roh;
+    try {
+      roh = execFileSync('php', [datei], { encoding: 'utf8' });
+    } finally {
+      fs.unlinkSync(datei);
+    }
+    const d = JSON.parse(roh);
+
+    expect(d.leer.offen, 'nichts geholt heisst alles offen').toBe(3);
+    expect(d.halb.offen).toBe(2);
+    expect(d.halb.in_mediathek).toBe(1);
+    // Der eigentliche Punkt: der veraltete Eintrag darf die Restzahl nicht
+    // druecken. Mit count($map) staende hier 1.
+    expect(d.veraltet.offen, 'ein veralteter Eintrag zaehlt als geholt').toBe(2);
+    expect(d.fertig.offen).toBe(0);
+    expect(d.fertig.gefunden).toBe(3);
+  });
+
+  test('nachsehen laedt nichts und schreibt nichts', () => {
+    // Ein Blick, der Nebenwirkungen hat, wird seltener geworfen als er
+    // sollte — und ein GET, der von einem Fremdhost laedt, ist ausserdem
+    // eine Route, die jeder Neuladen-Reflex teuer macht.
+    const getZweig = IMPORT.slice(IMPORT.indexOf("get_method()"));
+    const bisReturn = getZweig.slice(0, getZweig.indexOf('$neu = 0'));
+    expect(bisReturn, 'der GET-Zweig kehrt nicht zurueck').toMatch(/return new WP_REST_Response/);
+    expect(bisReturn, 'GET laedt von aussen').not.toMatch(/wp_remote_get/);
+    expect(bisReturn, 'GET schreibt in die Datenbank').not.toMatch(/update_option/);
   });
 
   test('die Adressen kommen aus dem ausgelieferten Stand, nicht aus einer Liste', () => {
@@ -199,5 +252,93 @@ test.describe('Demo-Bilder in die eigene Mediathek', () => {
     // Und ein Fehlschlag darf die Seite nicht aufhalten.
     expect(letzte.slice(letzte.indexOf('ebDemoBilderUmschreiben')), 'ohne Absicherung')
       .toMatch(/catch\s*\(/);
+  });
+});
+
+/* ── Der Knopf im HQ ───────────────────────────────────────────────────
+   Die Route gab es seit #182, den Weg sie zu bedienen nicht. Geprueft wird
+   der ausgefuehrte Code: der Block wird aus hq.html geschnitten und in
+   einer leeren Seite mit gefaelschtem fetch wirklich laufen gelassen.
+   Ein Textabgleich wuerde hier genau das verfehlen, worauf es ankommt —
+   wann die Schleife aufhoert. */
+const HQ = fs.readFileSync(path.join(ROOT, 'hq.html'), 'utf8');
+const KNOPF_CODE = (() => {
+  const marke = "const block = document.getElementById('demo-bilder-block');";
+  const von = HQ.lastIndexOf('(function () {', HQ.indexOf(marke));
+  const bis = HQ.indexOf('\n})();', von);
+  return HQ.slice(von, bis + 6);
+})();
+
+const GERUEST = `
+  <div id="demo-bilder-block" hidden>
+    <div id="demo-bilder-badge">–</div>
+    <div id="demo-bilder-stand"></div>
+    <button id="demo-bilder-start">holen</button>
+    <ul id="demo-bilder-fehler"></ul>
+  </div>`;
+
+/** Legt eine Seite mit gefaelschtem fetch an; `runden` sind die POST-Antworten. */
+async function baueSeite(page, runden, admin = true) {
+  await page.setContent('<!doctype html><meta charset="utf-8">' + GERUEST);
+  await page.evaluate(([runden, admin]) => {
+    window.HQ_IST_ADMIN = admin;
+    window.HQ_REST_NONCE = 'test';
+    window.__rufe = [];
+    let i = 0;
+    window.fetch = function (url, opt) {
+      const methode = (opt && opt.method) || 'GET';
+      window.__rufe.push(methode + ' ' + url);
+      const d = methode === 'GET'
+        ? { gefunden: 3, in_mediathek: 0, offen: 3, geholt: 0, fehler: [] }
+        : runden[Math.min(i++, runden.length - 1)];
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(d) });
+    };
+  }, [runden, admin]);
+  await page.addScriptTag({ content: KNOPF_CODE });
+}
+
+test.describe('Demo-Bilder: der Knopf im HQ', () => {
+  test('der Stand steht da, ohne dass man etwas anfasst', async ({ page }) => {
+    await baueSeite(page, []);
+    await expect.poll(() => page.evaluate(() => window.__rufe))
+      .toEqual(['GET /wp-json/eventboerse/v1/hq/demo-bilder']);
+    await expect(page.locator('#demo-bilder-stand')).toContainText('3 offen');
+  });
+
+  test('geholt wird, bis nichts mehr offen ist', async ({ page }) => {
+    await baueSeite(page, [
+      { gefunden: 3, in_mediathek: 1, offen: 2, geholt: 1, fehler: [] },
+      { gefunden: 3, in_mediathek: 2, offen: 1, geholt: 1, fehler: [] },
+      { gefunden: 3, in_mediathek: 3, offen: 0, geholt: 1, fehler: [] },
+    ]);
+    await page.click('#demo-bilder-start');
+    await expect(page.locator('#demo-bilder-badge')).toHaveText('vollständig');
+    const rufe = await page.evaluate(() => window.__rufe);
+    // Ein GET beim Laden, drei POST — und danach keiner mehr.
+    expect(rufe.filter(r => r.startsWith('POST')).length).toBe(3);
+  });
+
+  test('eine Runde ohne Fortschritt beendet den Lauf', async ({ page }) => {
+    // Ohne diese Bedingung stoesst ein dauerhaft nicht erreichbarer
+    // Fremdhost den Server zehnmal umsonst an — und die Oberflaeche
+    // sieht dabei aus, als arbeite sie.
+    await baueSeite(page, [
+      { gefunden: 3, in_mediathek: 0, offen: 3, geholt: 0,
+        fehler: [{ url: 'https://images.pexels.com/x.jpg', grund: 'HTTP 429' }] },
+    ]);
+    await page.click('#demo-bilder-start');
+    await expect(page.locator('#demo-bilder-stand')).toContainText('keine Fortschritte');
+    const rufe = await page.evaluate(() => window.__rufe);
+    expect(rufe.filter(r => r.startsWith('POST')).length,
+      'die Schleife laeuft trotz Stillstand weiter').toBe(1);
+    // Und der Grund steht da, statt still verschluckt zu werden.
+    await expect(page.locator('#demo-bilder-fehler')).toContainText('HTTP 429');
+  });
+
+  test('wer kein Administrator ist, sieht den Knopf nicht', async ({ page }) => {
+    await baueSeite(page, [], false);
+    expect(await page.locator('#demo-bilder-block').count()).toBe(0);
+    // Und es wird auch nichts abgefragt.
+    expect(await page.evaluate(() => window.__rufe)).toEqual([]);
   });
 });

--- a/vault/00-Kern/Impuls-Strom.md
+++ b/vault/00-Kern/Impuls-Strom.md
@@ -7,7 +7,7 @@ tags: [layer/L0, domain/kern, share/internal, typ/messung]
 
 # ⚡ Impuls-Strom — der lebende Zustand
 
-> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-20**
+> **Automatisch erzeugt** von `scripts/pulse.mjs` · Stand: **2026-08-22**
 > Nicht von Hand bearbeiten — jeder Lauf überschreibt die Datei.
 > Diese Notiz misst, was im Netz tatsächlich fließt. Die Ströme selbst
 > sind in [[00-Kern/Wissensstroeme]] beschrieben.
@@ -63,24 +63,24 @@ bis zum Tabletop-Abend. Die Vision „jede Art von Event" misst sich hier.
 
 | Kennzahl | Wert |
 |----------|------|
-| Commits (7 Tage) | **16** |
-| Commits (30 Tage) | 56 |
-| Letzter Commit | `53f81d8 · HQ über die Anmeldung statt über ein zweites Geheimnis (#169)` (2026-08-20) |
+| Commits (7 Tage) | **20** |
+| Commits (30 Tage) | 68 |
+| Letzter Commit | `1d2427c · Die Whisper-Tests haengen nicht mehr am simulierten Mikrofon` (2026-08-22) |
 
 **Meistbewegte Dateien (30 Tage):**
 ```
-32 tests/e2e/kern.spec.js
-     26 vault/50-Evolution/Roadmap/Current-Sprint.md
-     19 CLAUDE.md
-     17 vault/30-Betrieb/Testing.md
-     17 hq.html
+34 vault/50-Evolution/Roadmap/Current-Sprint.md
+     34 tests/e2e/kern.spec.js
+     28 CLAUDE.md
+     23 hq.html
+     23 assets/eb-auftragsstrom.json
 ```
 
 **Codegröße:**
-- `app.js` — 27.026 Zeilen
-- `styles.css` — 17.099 Zeilen
-- `functions.php` — 10.366 Zeilen
-- `app-shell.html` — 4.137 Zeilen
+- `app.js` — 27.096 Zeilen
+- `styles.css` — 17.098 Zeilen
+- `functions.php` — 10.783 Zeilen
+- `app-shell.html` — 4.145 Zeilen
 
 ## Verwandt
 - [[00-Kern/Wissensstroeme]] — die sechs Impulse

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 424 Tests in 23 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 430 Tests in 23 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**
@@ -89,6 +89,22 @@ Berührung mit meinen Änderungen: **keine.** Die vier PRs haben weder `vault/`
 noch `assets/eb-knowledge.json` angefasst.
 
 ## Zuletzt ausgeliefert (August 2026)
+
+- [x] **Demo-Bilder: der Knopf, der den Import wirklich startet.** Die Route
+  `POST /hq/demo-bilder` stand seit #182, bedienen konnte sie niemand — eine
+  Fähigkeit, die nur per Hand-Request erreichbar ist, wird nicht ausgeführt,
+  und die Demo-Daten hotlinken solange weiter auf Pexels. Jetzt ein Abschnitt
+  **🖼️ Demo-Bilder** im HQ (nur für Administratoren sichtbar; die Sperre bleibt
+  `eb_hq_verwaltung_darf`). Zwei Eigenschaften tragen ihn: `GET` zeigt den Stand
+  **ohne** zu laden oder zu schreiben, und der Lauf hört bei `offen = 0` **und**
+  bei einer Runde ohne Fortschritt auf. Ohne die zweite Bedingung stößt ein
+  nicht erreichbarer Fremdhost den Server zehnmal umsonst an, während die
+  Oberfläche aussieht, als arbeite sie. Dabei gefunden: `offen` zählte die
+  Einträge der Zuordnung statt der Schnittmenge — nach einem neuen Demo-Feed
+  hätte das zu wenig Offene gemeldet, im Grenzfall eine 0, während noch Bilder
+  von außen kommen. Sechs Tests, fünf Mutationen einzeln geprüft; die
+  PHP-Funktion wird dafür aus `functions.php` geschnitten und wirklich
+  ausgeführt. **430 Tests in 23 Suiten.**
 
 - [x] **Bild-Upload: 15 MB, Auto-Verkleinerung, verlässliches Drag & Drop.**
   Anlass war ein Nutzer, der ein Foto auf die Fläche zog und keine erkennbare


### PR DESCRIPTION
Die Route `POST /hq/demo-bilder` steht seit #182, den Weg sie zu bedienen gab es nicht. Eine Fähigkeit, die nur per Hand-Request erreichbar ist, wird nicht ausgeführt — und solange holt der Browser jedes Besuchers die Demo-Bilder weiter bei Pexels.

## Was dazukommt

**🖼️ Demo-Bilder im HQ**, nur für Administratoren sichtbar. Das Ausblenden ist Höflichkeit, die Sperre bleibt `eb_hq_verwaltung_darf` auf der Route.

Zwei Eigenschaften tragen den Knopf:

1. **Nachsehen ohne Anfassen.** `GET` auf denselben Pfad liefert `gefunden / in_mediathek / offen`, ohne von außen zu laden und ohne zu schreiben. Ein Blick mit Nebenwirkungen wird seltener geworfen, als er sollte.
2. **Der Lauf hört auf.** Abgebrochen wird bei `offen = 0` **und** bei einer Runde ohne Fortschritt. Ohne die zweite Bedingung stößt ein nicht erreichbarer Fremdhost den Server zehnmal umsonst an, während die Oberfläche aussieht, als arbeite sie.

## Dabei gefunden

`offen` zählte `count($map)` — die Einträge der Zuordnung — statt der Schnittmenge mit den tatsächlich gefundenen Adressen. Nach einem neuen Demo-Feed stehen alte Adressen weiter in der Zuordnung; gemeldet worden wären dann zu wenig Offene, im Grenzfall eine 0, während noch Bilder an Pexels gehen. Eine Zahl, die „fertig" sagt, obwohl es weitergeht, ist schlimmer als gar keine.

## Prüfung

Sechs neue Tests, **fünf Mutationen einzeln geprüft** — jede lässt genau den Test fallen, der sie abdecken soll:

| Mutation | fällt an |
|---|---|
| `count($map)` statt Schnittmenge | „die Restzahl zaehlt die Schnittmenge" |
| GET-Zweig deaktiviert | „nachsehen laedt nichts und schreibt nichts" |
| Stillstands-Abbruch entfernt | „eine Runde ohne Fortschritt beendet den Lauf" |
| `offen = 0`-Abbruch entfernt | „geholt wird, bis nichts mehr offen ist" |
| Admin-Prüfung entfernt | „wer kein Administrator ist, sieht den Knopf nicht" |

Gemessen wird ausgeführter Code, nicht Text: `eb_demo_bilder_stand()` wird aus `functions.php` geschnitten und mit PHP wirklich aufgerufen, der HQ-Block läuft in einer leeren Seite mit gefälschtem `fetch`. Ein Textabgleich hätte genau das verfehlt, worauf es ankommt — wann die Schleife aufhört.

**430 Tests in 23 Suiten**, `recht.mjs --check` grün (1 fremder Host, 0 ohne Eintrag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_