### PR TITLE
CLAUDE.md wird nachgemessen statt geglaubt

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -158,6 +158,13 @@ jobs:
       - name: Icon-Schrift deckt alle benutzten Symbole
         run: node scripts/icons.mjs --check | tee -a "$GITHUB_STEP_SUMMARY"
 
+      # CLAUDE.md ist das erste, was jede Sitzung liest. Eine falsche Zahl
+      # dort kostet mehr als keine, weil sie Vertrauen geniesst — am 22.08.
+      # waren vier Angaben veraltet, darunter eine "bekannte Schwaeche", die
+      # es laengst nicht mehr gibt.
+      - name: Kontext stimmt mit dem Code überein
+        run: node scripts/kontext.mjs --check | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Testsuite ausführen
         run: npx playwright test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,27 @@ WordPress trotz Admin-Cookie die Identität und die Route antwortet 401/403.
 nur `eb-knowledge.json` und `eb-demo-feed.json`.
 Details: `vault/30-Betrieb/Verbindungen.md`.
 
+### Der Kontext wird nachgemessen
+
+```bash
+node scripts/kontext.mjs           # Behauptung und Messung nebeneinander
+node scripts/kontext.mjs --check   # CI-Tor (pr-check.yml)
+```
+
+Diese Datei ist das erste, was jede Sitzung liest — und war die einzige, die
+niemand nachmisst. Am 22.08.2026 waren vier Angaben veraltet: 22 statt 24
+Module, 86 statt 101 Routen, „~16 300 Zeilen CSS" statt 17 100, und beim
+Messaging „alle 3s" für ein Polling, das längst bei 5 s beginnt.
+
+Die letzte war die teuerste: sie beschrieb eine **Schwäche, die es nicht mehr
+gibt**. Wer sie liest, sucht ein behobenes Problem. Ein veraltetes
+Steuerungsdokument kostet mehr als gar keins, weil es Vertrauen genießt.
+
+**Findet der Prüfer eine Aussage nicht mehr, ist das ein Fehler — kein
+bestandener Test.** Ein Tor, das bei umformuliertem Text stillschweigend
+durchwinkt, prüft nichts mehr und sieht dabei grün aus. Wer eine geprüfte
+Angabe umformuliert, passt das Muster in `scripts/kontext.mjs` mit an.
+
 ### Impuls-Strom messen
 
 ```bash
@@ -297,7 +318,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-452 Tests in 25 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+458 Tests in 26 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +
@@ -483,12 +504,12 @@ Push auf `main` → GitHub Actions (`.github/workflows/ionos-deploy.yml`) → SF
 | Datei | Inhalt |
 |-------|--------|
 | `app.js` | **Generiert** aus `js/modules/**` via `./build-app-js.sh` — nie von Hand editieren |
-| `js/modules/` | Quelle des Frontends: 22 Module in `core/`, `search/`, `chat/`, `payments/`, `board/`, `ai/`, `ui/` (Reihenfolge: `modules.list`) |
-| `styles.css` | ~16 300 Zeilen CSS, mobile-first |
+| `js/modules/` | Quelle des Frontends: 24 Module in `core/`, `search/`, `chat/`, `payments/`, `board/`, `ai/`, `ui/` (Reihenfolge: `modules.list`) |
+| `styles.css` | ~17 100 Zeilen CSS, mobile-first |
 | `app-shell.html` | **Einzige Quelle des SPA-Bodys** (PHP-frei). Body-Markup NUR hier editieren. |
 | `index.php` | WordPress-Template: PHP-Head (Per-Page-Meta) + `readfile(app-shell.html)` + `wp_footer()`. Body NICHT direkt editieren. |
 | `index.html` | Lokale Dev-Shell, **generiert** via `./build-index-html.sh` (= `index.local-head.html` + `app-shell.html` + `index.local-foot.html`). Nicht von Hand editieren. |
-| `functions.php` | WordPress-Theme: REST API (86 Routen), Asset-Registrierung |
+| `functions.php` | WordPress-Theme: REST API (101 Routen), Asset-Registrierung |
 | `webauthn.php` | Passkey/WebAuthn ohne Composer-Dependencies |
 
 **JS-Workflow (seit 2026-08, kein Drift):** Frontend-Änderungen NUR in `js/modules/**`,
@@ -509,7 +530,7 @@ Alle Navigation läuft über `navigateTo(page, data, skipHistory)`. Seiten-Token
 
 Base: `/wp-json/eventboerse/v1/`. Aufgebaut per `_apiUrl(endpoint)` (fällt auf relativen Pfad zurück wenn `eventboerseApi.restUrl` nicht gesetzt). Authentifizierung per WordPress-Nonce → `X-WP-Nonce` Header via `_apiHeaders()`.
 
-~81 Route-Registrierungen (`register_rest_route`, Stand 2026-06), grob gruppiert nach: Auth, Nutzer, WebAuthn, 2FA, Listings, Messaging, Reviews, Payments, Favoriten, Admin, Utilities.
+101 Route-Registrierungen (`register_rest_route`), grob gruppiert nach: Auth, Nutzer, WebAuthn, 2FA, Listings, Messaging, Reviews, Payments, Favoriten, Admin, Utilities.
 
 ### State
 
@@ -522,4 +543,9 @@ Kanban/Flow-Planer (`renderBoardPage`, `renderKanban`, `renderBoardFlow`) mit `l
 ## Bekannte Schwächen (nicht neu einführen)
 
 - Demo-Daten (`LISTINGS`/`REVIEWS`/`CHATS`) noch hardcoded — werden schrittweise durch DB-Calls ersetzt
-- Messaging nutzt Polling (alle 3s), kein WebSocket/SSE
+- Messaging nutzt Polling statt WebSocket/SSE. **Nicht mehr „alle 3s":** der
+  Takt beginnt bei 5 s, faellt ohne neue Nachricht um Faktor 1,6 bis auf 20 s
+  zurueck und pausiert bei verstecktem Tab ganz. Auf dem kleinen PHP-Pool von
+  IONOS ist echtes SSE die schlechtere Wahl — eine offene Verbindung haelt
+  einen Worker dauerhaft belegt, und genau daran ist am 22.08. die Website
+  gehangen (Demo-Bildimport)

--- a/scripts/kontext.mjs
+++ b/scripts/kontext.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Stimmen die Zahlen in CLAUDE.md noch?
+ *
+ * CLAUDE.md ist die Datei, die jede Sitzung zuerst liest — und die einzige,
+ * die niemand nachmisst. Gemessen am 22.08.2026 waren vier Angaben veraltet:
+ * 22 statt 24 Module, „86 Routen" statt 101, „~16 300 Zeilen CSS" statt
+ * 17 100, und beim Messaging „alle 3s", obwohl das Polling längst mit 5 s
+ * beginnt, bis 20 s zurückfährt und bei verstecktem Tab ganz pausiert.
+ *
+ * Die letzte Angabe ist die teuerste: sie beschreibt eine Schwäche, die es
+ * nicht mehr gibt. Wer sie liest, sucht ein Problem, das schon behoben ist.
+ * Ein veraltetes Steuerungsdokument kostet mehr als gar keins, weil es
+ * Vertrauen genießt.
+ *
+ *   node scripts/kontext.mjs          Behauptung und Messung nebeneinander
+ *   node scripts/kontext.mjs --check  CI-Tor
+ *
+ * WICHTIG: Findet ein Sucher seine Aussage nicht mehr in CLAUDE.md, ist das
+ * ein FEHLER, kein bestandener Test. Ein Tor, das bei umformulierten Text
+ * stillschweigend durchwinkt, prüft nichts mehr und sieht dabei grün aus.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WURZEL = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const lies = (p) => fs.readFileSync(path.join(WURZEL, p), 'utf8');
+const zeilen = (p) => lies(p).split('\n').filter((z) => z.trim() && !z.trim().startsWith('#')).length;
+
+const CLAUDE = lies('CLAUDE.md');
+const SPRINT = lies('vault/50-Evolution/Roadmap/Current-Sprint.md');
+
+/**
+ * Eine Zahl aus einem Text ziehen.
+ *
+ * `null` = Stelle nicht mehr gefunden. `NaN` = mehrdeutig, also an mehreren
+ * Stellen mit verschiedenen Zahlen. Beides ist ein Fehler.
+ *
+ * Die Mehrdeutigkeit ist keine Theorie: als dieser Prüfer dokumentiert wurde,
+ * zitierte der Fliesstext die alte Zahl („~16 300 Zeilen CSS"), das Muster
+ * griff die erste Fundstelle und meldete einen Fehler, den es nicht gab. Ein
+ * Muster, das mehrere Stellen trifft, misst nicht die Aussage, sondern die
+ * Reihenfolge im Dokument.
+ */
+function behauptet(text, muster) {
+  const alle = [...text.matchAll(new RegExp(muster.source, muster.flags.replace('g', '') + 'g'))]
+    .map((m) => Number(String(m[1]).replace(/[.\s]/g, '')));
+  if (!alle.length) return null;
+  return alle.every((z) => z === alle[0]) ? alle[0] : NaN;
+}
+
+export const AUSSAGEN = [
+  {
+    name: 'Frontend-Module',
+    wo: 'CLAUDE.md · Architektur-Tabelle',
+    behauptet: () => behauptet(CLAUDE, /(\d+)\s+Module in `core\/`/),
+    gemessen: () => zeilen('js/modules/modules.list'),
+  },
+  {
+    name: 'REST-Routen (functions.php)',
+    wo: 'CLAUDE.md · Dateitabelle',
+    behauptet: () => behauptet(CLAUDE, /REST API \((\d+)\s+Routen\)/),
+    gemessen: () => (lies('functions.php').match(/register_rest_route/g) || []).length,
+  },
+  {
+    name: 'Test-Suiten',
+    wo: 'CLAUDE.md · Tests',
+    behauptet: () => behauptet(CLAUDE, /Tests in (\d+)\s+Suiten/),
+    gemessen: () => fs.readdirSync(path.join(WURZEL, 'tests', 'e2e'))
+      .filter((f) => f.endsWith('.spec.js')).length,
+  },
+  {
+    name: 'Benutzte Icons',
+    wo: 'CLAUDE.md · Icon-Schrift',
+    behauptet: () => behauptet(CLAUDE, /benutzt werden (\d+)\./),
+    gemessen: () => zeilen('scripts/lib/material-icons-benutzt.txt'),
+  },
+  {
+    name: 'Dateien im Autopilot-Rahmen',
+    wo: 'CLAUDE.md · Befund → Arbeit',
+    behauptet: () => behauptet(CLAUDE, /Rahmen umfasst \*\*(\d+)\s+Dateien\*\*/),
+    // Aus der Datei gelesen statt importiert: der Sicherheitsrahmen soll
+    // hier nicht von einer Modulauflösung abhängen.
+    //
+    // Das Muster darf sich NICHT auf `js/modules/` verengen — der Rahmen
+    // enthält auch drei CSS-Dateien. Mit der engeren Fassung meldete dieser
+    // Prüfer 12 statt 15 und hätte beinahe dazu geführt, eine korrekte
+    // Sicherheitsgrenze in der Dokumentation kleiner zu schreiben, als sie
+    // ist. Ein Prüfer, der sich irrt, ist gefährlicher als keiner.
+    gemessen: () => (lies('scripts/lib/sichere-dateien.mjs')
+      .match(/^\s{2}'[^']+':/gm) || []).length,
+  },
+  {
+    name: 'Zeilen in styles.css (auf Hunderter)',
+    wo: 'CLAUDE.md · Dateitabelle',
+    // An die Tabellenzeile gebunden, nicht an den Fliesstext.
+    behauptet: () => behauptet(CLAUDE, /\| `styles\.css` \| ~([\d\s]+) Zeilen CSS/),
+    gemessen: () => Math.round(lies('styles.css').split('\n').length / 100) * 100,
+    // CSS wächst bei fast jedem PR. Eine Angabe auf Hunderter mit Spielraum
+    // ist ehrlicher als eine exakte Zahl, die dauernd falsch ist.
+    spielraum: 500,
+  },
+];
+
+/** Zwei Dokumente, die dieselbe Zahl nennen, müssen dieselbe Zahl nennen. */
+function testzahlEinig() {
+  const a = behauptet(CLAUDE, /(\d+) Tests in \d+ Suiten/);
+  const b = behauptet(SPRINT, /Playwright-Suite: (\d+) Tests/);
+  return { a, b };
+}
+
+function pruefen(streng) {
+  const zeilenAus = [];
+  let fehler = 0;
+
+  for (const s of AUSSAGEN) {
+    const b = s.behauptet();
+    const g = s.gemessen();
+    if (b === null) {
+      // Nicht mehr auffindbar: der Sucher greift ins Leere. Das ist der
+      // gefährlichste Fall, weil er wie „geprüft" aussieht.
+      zeilenAus.push(`✗ ${s.name}: Aussage nicht mehr gefunden (${s.wo})`);
+      fehler++;
+      continue;
+    }
+    if (Number.isNaN(b)) {
+      zeilenAus.push(`✗ ${s.name}: Aussage mehrdeutig — das Muster trifft mehrere`);
+      zeilenAus.push(`  Stellen mit verschiedenen Zahlen (${s.wo}). Muster enger fassen.`);
+      fehler++;
+      continue;
+    }
+    const ok = s.spielraum ? Math.abs(b - g) <= s.spielraum : b === g;
+    zeilenAus.push(`${ok ? '✓' : '✗'} ${s.name.padEnd(34)} behauptet ${String(b).padStart(6)}  gemessen ${String(g).padStart(6)}`);
+    if (!ok) fehler++;
+  }
+
+  const t = testzahlEinig();
+  if (t.a === null || t.b === null) {
+    zeilenAus.push('✗ Testzahl: in CLAUDE.md oder im Sprint nicht gefunden');
+    fehler++;
+  } else if (t.a !== t.b) {
+    zeilenAus.push(`✗ Testzahl uneinig: CLAUDE.md ${t.a}, Current-Sprint ${t.b}`);
+    fehler++;
+  } else {
+    zeilenAus.push(`✓ Testzahl einig${''.padEnd(19)} beide ${String(t.a).padStart(6)}`);
+  }
+
+  console.log('── Kontext gegen Code ───────────────────────────');
+  zeilenAus.forEach((z) => console.log(z));
+  console.log('─────────────────────────────────────────────────');
+  if (fehler) {
+    console.log(`${fehler} Angabe(n) stimmen nicht. CLAUDE.md ist das erste, was jede`);
+    console.log('Sitzung liest — eine falsche Zahl dort kostet mehr als keine.');
+    if (streng) process.exit(1);
+  } else {
+    console.log('✓ Alle prüfbaren Angaben stimmen mit dem Code überein.');
+  }
+}
+
+pruefen(process.argv.includes('--check'));

--- a/tests/e2e/kontext.spec.js
+++ b/tests/e2e/kontext.spec.js
@@ -1,0 +1,101 @@
+// Stimmen die Zahlen in CLAUDE.md noch?
+//
+// CLAUDE.md ist die Datei, die jede Sitzung zuerst liest — und war die
+// einzige, die niemand nachmisst. Am 22.08.2026 waren vier Angaben veraltet,
+// darunter eine „bekannte Schwäche", die es seit Langem nicht mehr gibt. Wer
+// sie liest, sucht ein behobenes Problem; ein veraltetes Steuerungsdokument
+// kostet mehr als gar keins, weil es Vertrauen geniesst.
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SKRIPT = path.join(ROOT, 'scripts', 'kontext.mjs');
+const CLAUDE_MD = path.join(ROOT, 'CLAUDE.md');
+
+/** Führt das Tor aus; gibt Erfolg und Ausgabe zurück, ohne zu werfen. */
+function tor() {
+  try {
+    return { ok: true, aus: execFileSync('node', [SKRIPT, '--check'], { cwd: ROOT, encoding: 'utf8' }) };
+  } catch (e) {
+    return { ok: false, aus: String(e.stdout || '') + String(e.stderr || '') };
+  }
+}
+
+/** Ändert CLAUDE.md vorübergehend und stellt den Stand danach wieder her. */
+function mitGeaenderterNotiz(alt, neu, fn) {
+  const vorher = fs.readFileSync(CLAUDE_MD, 'utf8');
+  expect(vorher.includes(alt), `Muster nicht in CLAUDE.md: ${alt}`).toBe(true);
+  fs.writeFileSync(CLAUDE_MD, vorher.replace(alt, neu));
+  try { return fn(); } finally { fs.writeFileSync(CLAUDE_MD, vorher); }
+}
+
+// Diese Tests schreiben CLAUDE.md kurzzeitig um. Sie MÜSSEN nacheinander
+// laufen: bei `fullyParallel` änderte ein Test die Datei, während ein anderer
+// sie prüfte — zwei Fehlschläge, die nichts mit dem Prüfer zu tun hatten.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Kontext: CLAUDE.md gegen den Code', () => {
+  test('der ausgelieferte Stand ist stimmig', () => {
+    const r = tor();
+    expect(r.ok, r.aus).toBe(true);
+    expect(r.aus).toMatch(/Alle prüfbaren Angaben stimmen/);
+  });
+
+  test('eine falsche Zahl fällt auf', () => {
+    const r = mitGeaenderterNotiz('Quelle des Frontends: 24 Module',
+      'Quelle des Frontends: 99 Module', tor);
+    expect(r.ok, 'eine erfundene Modulzahl kommt durch').toBe(false);
+    expect(r.aus).toMatch(/Frontend-Module/);
+  });
+
+  test('eine umformulierte Aussage gilt nicht als bestanden', () => {
+    // Der gefährlichste Fall: der Sucher greift ins Leere und das Tor sieht
+    // grün aus, obwohl es nichts mehr prüft. Deshalb ist „nicht gefunden"
+    // ein Fehler und kein Durchwinken.
+    const r = mitGeaenderterNotiz('REST API (101 Routen)', 'REST API (viele Routen)', tor);
+    expect(r.ok, 'eine verschwundene Aussage wird stillschweigend übergangen').toBe(false);
+    expect(r.aus).toMatch(/nicht mehr gefunden/);
+  });
+
+  test('eine mehrdeutige Aussage gilt nicht als bestanden', () => {
+    // Passiert beim Dokumentieren von selbst: der Fliesstext zitiert die
+    // alte Zahl, und das Muster greift plötzlich zwei Stellen. Dann misst
+    // der Prüfer nicht die Aussage, sondern die Reihenfolge im Dokument —
+    // und meldete beim Bauen prompt einen Fehler, den es nicht gab.
+    const r = mitGeaenderterNotiz('### Der Kontext wird nachgemessen',
+      '### Der Kontext wird nachgemessen\n\nFrüher: REST API (86 Routen).', tor);
+    expect(r.ok, 'eine doppelt getroffene Aussage kommt durch').toBe(false);
+    expect(r.aus).toMatch(/mehrdeutig/);
+  });
+
+  test('zwei Dokumente dürfen nicht verschiedene Testzahlen nennen', () => {
+    // Beide Zahlen pflege ich von Hand; genau dort läuft es auseinander.
+    // Die aktuelle Zahl aus der Datei lesen statt sie hier zu verdrahten —
+    // sonst bricht dieser Test bei jedem neuen Test in der Suite.
+    const md = fs.readFileSync(CLAUDE_MD, 'utf8');
+    const jetzt = (md.match(/(\d+ Tests in \d+ Suiten)/) || [])[1];
+    expect(jetzt, 'die Testzahl steht nicht mehr in CLAUDE.md').toBeTruthy();
+    const r = mitGeaenderterNotiz(jetzt, jetzt.replace(/^\d+/, '999'), tor);
+    expect(r.ok).toBe(false);
+    expect(r.aus).toMatch(/Testzahl uneinig/);
+  });
+
+  test('die überholte Polling-Angabe kommt nicht zurück', () => {
+    // Sie beschrieb eine Schwäche, die es nicht mehr gibt: das Polling
+    // beginnt bei 5 s, fällt bis 20 s zurück und pausiert bei verstecktem
+    // Tab. Gemessen am Code, nicht an der Notiz.
+    const md = fs.readFileSync(CLAUDE_MD, 'utf8');
+    expect(md, 'die veraltete 3-Sekunden-Angabe steht wieder da')
+      .not.toMatch(/Polling \(alle 3s\)/);
+    const chat = fs.readFileSync(
+      path.join(ROOT, 'js', 'modules', 'chat', '20-chat-nachrichten.js'), 'utf8');
+    const basis = Number((chat.match(/_CHAT_POLL_BASE\s*=\s*(\d+)/) || [, 0])[1]);
+    const deckel = Number((chat.match(/_CHAT_POLL_CAP\s*=\s*(\d+)/) || [, 0])[1]);
+    expect(basis, 'der Takt ist wieder aggressiver als beschrieben').toBeGreaterThanOrEqual(5000);
+    expect(deckel, 'ohne Rückfall pollt ein offener Chat dauerhaft').toBeGreaterThan(basis);
+    // Und die Pause bei verstecktem Tab ist der Teil, der den PHP-Pool schont.
+    expect(chat, 'kein Anhalten bei verstecktem Tab').toMatch(/document\.hidden/);
+  });
+});

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 452 Tests in 25 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 458 Tests in 26 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**
@@ -89,6 +89,21 @@ Berührung mit meinen Änderungen: **keine.** Die vier PRs haben weder `vault/`
 noch `assets/eb-knowledge.json` angefasst.
 
 ## Zuletzt ausgeliefert (August 2026)
+
+- [x] **Der Kontext wird nachgemessen.** `CLAUDE.md` ist das erste, was jede
+  Sitzung liest — und war die einzige Datei, die niemand nachmisst. Vier
+  Angaben waren veraltet: 22 statt 24 Module, 86 statt 101 Routen, „~16 300
+  Zeilen CSS" statt 17 100, und beim Messaging „alle 3s" für ein Polling, das
+  längst bei 5 s beginnt, bis 20 s zurückfällt und bei verstecktem Tab
+  pausiert. Die letzte war die teuerste: sie beschrieb eine **Schwäche, die es
+  nicht mehr gibt**. `scripts/kontext.mjs` prüft das jetzt im PR. Zwei Fallen
+  beim Bauen selbst gefunden: mein erstes Muster für den Autopilot-Rahmen
+  übersah die drei CSS-Dateien und hätte beinahe eine korrekte
+  Sicherheitsgrenze kleiner geschrieben, als sie ist; und der eigene
+  Dokumentationstext zitierte die alte CSS-Zahl, worauf das Muster zwei
+  Stellen traf — seitdem ist **mehrdeutig** ebenso ein Fehler wie **nicht
+  gefunden**. Sechs Tests, fünf Mutationen gegen den Prüfer selbst.
+  **458 Tests in 26 Suiten.**
 
 - [x] **Board-Sync: die Zusammenführung ist jetzt abgesichert.** Das Board liegt
   in `localStorage` UND auf dem Server; `_mergeBoardProjects()` entscheidet, welche


### PR DESCRIPTION
`CLAUDE.md` ist das erste, was jede Sitzung liest — und war die einzige Datei, die niemand nachmisst. Vier Angaben waren veraltet:

| Angabe | behauptet | gemessen |
|---|---|---|
| Frontend-Module | 22 | **24** |
| REST-Routen | 86 | **101** |
| Zeilen CSS | ~16 300 | **17 100** |
| Messaging-Polling | „alle 3s" | **5 s → 20 s, Pause bei verstecktem Tab** |

Die letzte ist die teuerste, weil sie keine Zahl ist, sondern eine **Behauptung über eine Schwäche, die es nicht mehr gibt**. Wer den alten Satz liest, sucht ein behobenes Problem — und hält womöglich SSE für die Lösung. Auf dem kleinen PHP-Pool von IONOS wäre eine offene Verbindung genau der Fehler, an dem am 22.08. die Website gehangen hat.

`scripts/kontext.mjs` vergleicht jetzt sieben Angaben mit dem Code, Tor in `pr-check.yml`.

## Zwei Fallen, beide selbst gebaut und gefunden

**1 · Ein Prüfer, der sich irrt, ist gefährlicher als keiner.** Mein erstes Muster für den Autopilot-Rahmen zählte nur `js/modules/` und übersah die drei CSS-Dateien. Es meldete 12 statt 15 — ich hätte beinahe eine **korrekte Sicherheitsgrenze** in der Dokumentation kleiner geschrieben, als sie ist.

**2 · Mehrdeutig ist so schlimm wie nicht gefunden.** Der eigene Dokumentationstext zitierte die alte CSS-Zahl. Damit traf das Muster zwei Stellen und maß nicht mehr die Aussage, sondern die Reihenfolge im Dokument. Beide Fälle sind jetzt Fehler — ein Tor, das bei umformuliertem Text stillschweigend durchwinkt, prüft nichts mehr und sieht dabei grün aus.

## Mutationen

Fünf, **gegen den Prüfer selbst**, alle fallen:

nicht gefunden gilt als bestanden · mehrdeutig gilt als bestanden · Abweichung wird nicht gezählt · Testzahl-Vergleich abgeschaltet · `--check` beendet nie mit Fehler

Nebenbei: die Tests schreiben `CLAUDE.md` kurzzeitig um und müssen deshalb seriell laufen — unter `fullyParallel` änderte einer die Datei, während ein anderer sie prüfte.

**458 Tests in 26 Suiten.** Kein Produktionscode geändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_