### PR TITLE
Der QA-Bot schickte Fragende zum falschen Knopf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ npm run test:smoke      # nur Routen-Smoke-Tests
 npm run test:css        # CSS-Minify-Regression (Verlaufsschrift)
 ```
 
-458 Tests in 26 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
+463 Tests in 27 Suiten: Smoke (alle Routen, 0 Page-Errors), Suche (natürliche
 Sätze), Gebühren (centgenau, JS↔PHP-Parität), Wissensbasis (Antworten +
 Leckage-Schutz), Zufluss (Quarantäne-Tor + Demo-Feed-Ehrlichkeit),
 Verbindungen (HQ-Zugang + Connector-Katalog), Auftragsstrom (Herkunft +

--- a/app.js
+++ b/app.js
@@ -14914,7 +14914,14 @@ var QA_TOPICS = [
   {
     id: 'messages',
     icon: 'forum',
-    triggers: ['nachricht', 'chat', 'kontakt', 'anfrage', 'antwort', 'kommunikation', 'support'],
+    // „anschreiben" und „kontaktieren" fehlten. Gemessen an echten Sätzen
+    // landete „Wie schreibe ich einen Anbieter an?" deshalb bei `listing` —
+    // `anbieter` ist dort ein Auslöser und traf als einziger. Wer jemanden
+    // anschreiben will, bekam „Inserat erstellen" angeboten.
+    triggers: ['nachricht', 'chat', 'kontakt', 'anfrage', 'antwort', 'kommunikation', 'support',
+      // Wortstämme, nicht Vollformen: geprüft wird, ob der Auslöser IM Satz
+      // vorkommt — „kontaktieren" steht nicht in „kontaktiere".
+      'anschreib', 'kontaktier', 'schreibe ich', 'erreiche ich'],
     replies: [
       'Für laufende Abstimmungen ist der Nachrichtenbereich richtig. Für Plattform-Support gehe zu Kontakt & Support.',
       'Wenn du mit einem Dienstleister sprechen willst, öffne Nachrichten. Wenn Eventbörse helfen soll, nimm Kontakt & Support.',
@@ -15204,14 +15211,25 @@ function _qaFindTopic(text) {
   if (!q) return QA_FALLBACK;
   var best = null;
   var bestScore = 0;
+  var bestLaengster = 0;
   QA_TOPICS.forEach(function(topic) {
     var score = 0;
+    var laengster = 0;
     topic.triggers.forEach(function(t) {
       var key = _qaNormalize(t);
-      if (q.indexOf(key) !== -1) score += key.length > 5 ? 3 : 2;
+      if (q.indexOf(key) !== -1) {
+        score += key.length > 5 ? 3 : 2;
+        if (key.length > laengster) laengster = key.length;
+      }
     });
-    if (score > bestScore) {
+    // Bei Gleichstand gewinnt der LAENGSTE wirklich getroffene Ausloeser.
+    // Vorher entschied die Reihenfolge im Array, also der Zufall der
+    // Sortierung: „Wie schreibe ich einen Anbieter an?" traf `anbieter`
+    // (listing) und `schreibe ich` (messages) mit je 3 Punkten und landete
+    // beim Inserat — der Fragende bekam „Inserat erstellen" angeboten.
+    if (score > bestScore || (score === bestScore && score > 0 && laengster > bestLaengster)) {
       bestScore = score;
+      bestLaengster = laengster;
       best = topic;
     }
   });

--- a/js/modules/ui/31-modals-toast-qabot.js
+++ b/js/modules/ui/31-modals-toast-qabot.js
@@ -146,7 +146,14 @@ var QA_TOPICS = [
   {
     id: 'messages',
     icon: 'forum',
-    triggers: ['nachricht', 'chat', 'kontakt', 'anfrage', 'antwort', 'kommunikation', 'support'],
+    // „anschreiben" und „kontaktieren" fehlten. Gemessen an echten Sätzen
+    // landete „Wie schreibe ich einen Anbieter an?" deshalb bei `listing` —
+    // `anbieter` ist dort ein Auslöser und traf als einziger. Wer jemanden
+    // anschreiben will, bekam „Inserat erstellen" angeboten.
+    triggers: ['nachricht', 'chat', 'kontakt', 'anfrage', 'antwort', 'kommunikation', 'support',
+      // Wortstämme, nicht Vollformen: geprüft wird, ob der Auslöser IM Satz
+      // vorkommt — „kontaktieren" steht nicht in „kontaktiere".
+      'anschreib', 'kontaktier', 'schreibe ich', 'erreiche ich'],
     replies: [
       'Für laufende Abstimmungen ist der Nachrichtenbereich richtig. Für Plattform-Support gehe zu Kontakt & Support.',
       'Wenn du mit einem Dienstleister sprechen willst, öffne Nachrichten. Wenn Eventbörse helfen soll, nimm Kontakt & Support.',
@@ -436,14 +443,25 @@ function _qaFindTopic(text) {
   if (!q) return QA_FALLBACK;
   var best = null;
   var bestScore = 0;
+  var bestLaengster = 0;
   QA_TOPICS.forEach(function(topic) {
     var score = 0;
+    var laengster = 0;
     topic.triggers.forEach(function(t) {
       var key = _qaNormalize(t);
-      if (q.indexOf(key) !== -1) score += key.length > 5 ? 3 : 2;
+      if (q.indexOf(key) !== -1) {
+        score += key.length > 5 ? 3 : 2;
+        if (key.length > laengster) laengster = key.length;
+      }
     });
-    if (score > bestScore) {
+    // Bei Gleichstand gewinnt der LAENGSTE wirklich getroffene Ausloeser.
+    // Vorher entschied die Reihenfolge im Array, also der Zufall der
+    // Sortierung: „Wie schreibe ich einen Anbieter an?" traf `anbieter`
+    // (listing) und `schreibe ich` (messages) mit je 3 Punkten und landete
+    // beim Inserat — der Fragende bekam „Inserat erstellen" angeboten.
+    if (score > bestScore || (score === bestScore && score > 0 && laengster > bestLaengster)) {
       bestScore = score;
+      bestLaengster = laengster;
       best = topic;
     }
   });

--- a/tests/e2e/qabot.spec.js
+++ b/tests/e2e/qabot.spec.js
@@ -1,0 +1,104 @@
+// Der QA-Bot: landet eine echte Frage beim richtigen Thema?
+//
+// Der Bot ordnet jede Frage einem von 13 Themen zu und bietet danach dessen
+// Aktionen an. Die Zuordnung entscheidet also, welche Knöpfe der Nutzer sieht
+// — und sie entstand bisher aus Auslöserlisten, die niemand gegen echte Sätze
+// gemessen hat. Beim ersten Messen landete „Wie schreibe ich einen Anbieter
+// an?" bei `listing`: der Fragende bekam „Inserat erstellen" angeboten, weil
+// `anbieter` dort ein Auslöser ist und als einziger traf.
+//
+// Diese Tabelle ist der Schutz davor. Sie prüft nicht die Formulierung der
+// Antwort, sondern wo die Frage ankommt — das ist die Eigenschaft, an der
+// eine Änderung an den Auslösern etwas kaputt macht.
+const { test, expect } = require('@playwright/test');
+const { openApp, expectNoPageErrors } = require('./helpers');
+
+/**
+ * Echte Sätze mit dem Thema, das sie treffen müssen.
+ *
+ * Mehrere zulässige Themen, wo die Frage wirklich mehrdeutig ist: „Zeig mir
+ * DJs in meiner Nähe" darf bei der Suche oder beim Radar landen, beide führen
+ * den Nutzer richtig weiter. Ein Test, der hier eine einzige Antwort erzwingt,
+ * würde bei jeder sinnvollen Verbesserung fehlschlagen.
+ */
+const FRAGEN = [
+  ['Ich komme nicht in mein Konto rein', ['login']],
+  ['Der Bestätigungscode kam nicht an', ['login']],
+  ['Wie hoch ist die Auszahlung auf mein Konto?', ['payment']],
+  ['Ich möchte mit Kreditkarte bezahlen', ['payment']],
+  ['Wie lege ich ein neues Angebot an?', ['listing']],
+  ['Wie schreibe ich einen Anbieter an?', ['messages']],
+  ['Wie kontaktiere ich einen Dienstleister?', ['messages']],
+  ['Wie funktioniert das Planungsboard?', ['board']],
+  ['Ich brauche Catering für 50 Personen', ['search']],
+  ['Zeig mir DJs in meiner Nähe', ['search', 'radar']],
+  ['Wo sehe ich meinen Umsatz?', ['business']],
+  ['Was steht in eurer Datenschutzerklärung?', ['legal']],
+  ['Darf ich meine Telefonnummer weitergeben?', ['safechat', 'legal']],
+  ['Kann ich Bilder mit KI erstellen?', ['media']],
+];
+
+test.describe('QA-Bot: Frage trifft Thema', () => {
+  test('echte Sätze landen beim richtigen Thema', async ({ page }) => {
+    const errors = await openApp(page);
+    const treffer = await page.evaluate((fragen) =>
+      fragen.map(([satz]) => _qaFindTopic(satz).id), FRAGEN);
+
+    const daneben = FRAGEN
+      .map(([satz, erlaubt], i) => ({ satz, erlaubt, ist: treffer[i] }))
+      .filter((x) => !x.erlaubt.includes(x.ist));
+
+    expect(daneben.map((x) => `„${x.satz}" → ${x.ist} (erwartet ${x.erlaubt.join('/')})`))
+      .toEqual([]);
+    expectNoPageErrors(errors);
+  });
+
+  test('keine Frage fällt stumm durch', async ({ page }) => {
+    // `fallback` ist kein Fehler — aber wenn die halbe Tabelle dort landet,
+    // ist die Zuordnung kaputt und der Test oben hätte es nur einzeln
+    // gemeldet.
+    const errors = await openApp(page);
+    const fallbacks = await page.evaluate((fragen) =>
+      fragen.filter(([satz]) => _qaFindTopic(satz).id === 'fallback').length, FRAGEN);
+    expect(fallbacks, 'Fragen landen im Auffangthema').toBe(0);
+    expectNoPageErrors(errors);
+  });
+
+  test('die Messung erkennt eine kaputte Zuordnung überhaupt', async ({ page }) => {
+    // Gegenprobe: Kauderwelsch MUSS im Auffangthema landen. Ohne diese
+    // Zusicherung wäre der Test oben auch mit „alles trifft immer" erfüllt.
+    const errors = await openApp(page);
+    const id = await page.evaluate(() => _qaFindTopic('xqzv plrmt wbnk').id);
+    expect(id, 'selbst Kauderwelsch bekommt ein Thema zugewiesen').toBe('fallback');
+    expectNoPageErrors(errors);
+  });
+
+  test('jedes Thema bietet mindestens eine Aktion an', async ({ page }) => {
+    // Eine Antwort ohne Weg ist eine Sackgasse: der Bot erklärt etwas und
+    // der Nutzer muss selbst suchen, wo er es tun kann.
+    const errors = await openApp(page);
+    const ohne = await page.evaluate(() =>
+      QA_TOPICS.filter((t) => !t.actions || !t.actions.length).map((t) => t.id));
+    expect(ohne).toEqual([]);
+    expectNoPageErrors(errors);
+  });
+
+  test('kein Auslöser steht in zwei Themen', async ({ page }) => {
+    // Ein doppelter Auslöser entscheidet nach Reihenfolge im Array statt
+    // nach Bedeutung — genau so gewann `login` gegen `payment` bei allem,
+    // worin „konto" vorkommt. Bekannte Überschneidungen stehen hier
+    // benannt; eine NEUE fällt auf.
+    const bekannt = ['konto', 'rechnung', 'kontakt'];
+    const errors = await openApp(page);
+    const doppelt = await page.evaluate(() => {
+      const wo = {};
+      QA_TOPICS.forEach((t) => t.triggers.forEach((x) => {
+        (wo[x] = wo[x] || []).push(t.id);
+      }));
+      return Object.keys(wo).filter((k) => wo[k].length > 1);
+    });
+    expect(doppelt.filter((d) => !bekannt.includes(d)),
+      'neuer doppelter Auslöser — die Reihenfolge im Array entscheidet dann').toEqual([]);
+    expectNoPageErrors(errors);
+  });
+});

--- a/vault/50-Evolution/Roadmap/Current-Sprint.md
+++ b/vault/50-Evolution/Roadmap/Current-Sprint.md
@@ -16,7 +16,7 @@ Zahlen ihrer Zeit — die sind Historie, kein Ist-Stand. Der Ensemble-Kontext
 liest diese Datei von oben; ein Modell, das „68 Tests" als aktuell meldet, hat
 einen alten Abschnitt gelesen und nicht diesen.
 
-- **Playwright-Suite: 458 Tests in 26 Suiten**, blockierendes Gate in `pr-check.yml`.
+- **Playwright-Suite: 463 Tests in 27 Suiten**, blockierendes Gate in `pr-check.yml`.
   Läuft seit dem Self-Hosting auch ohne Netzzugang vollständig durch
 - Tore grün: Wissensbasis, Quarantäne, Demo-Feed, Connectors, Modell-Ensemble,
   Arbeitsjournal, app.js-Drift, **Recht**
@@ -89,6 +89,20 @@ Berührung mit meinen Änderungen: **keine.** Die vier PRs haben weder `vault/`
 noch `assets/eb-knowledge.json` angefasst.
 
 ## Zuletzt ausgeliefert (August 2026)
+
+- [x] **Der QA-Bot trifft jetzt das richtige Thema.** Die Zuordnung entscheidet,
+  welche Knöpfe der Nutzer bekommt — und war nie gegen echte Sätze gemessen.
+  Von 16 realistischen Fragen landete eine falsch: „Wie schreibe ich einen
+  Anbieter an?" ging an `listing`, also bekam der Fragende **„Inserat
+  erstellen"** angeboten. Ursache war nicht ein fehlender Auslöser allein,
+  sondern der **Stichentscheid**: bei Gleichstand gewann das Thema, das im
+  Array weiter oben steht — also der Zufall der Sortierung. Jetzt gewinnt der
+  längste wirklich getroffene Auslöser, das spezifischere Indiz. Dazu fehlende
+  Stämme (`anschreib`, `kontaktier`) — Vollformen greifen nicht, weil der
+  Auslöser IM Satz vorkommen muss. Fünf Tests: die Fragetabelle, eine
+  Gegenprobe mit Kauderwelsch (sonst wäre „trifft immer" erfüllend), kein Thema
+  ohne Aktion, kein neuer doppelter Auslöser. Vier Mutationen; eine überlebt
+  und ist als verhaltensgleich vermerkt. **463 Tests in 27 Suiten.**
 
 - [x] **Der Kontext wird nachgemessen.** `CLAUDE.md` ist das erste, was jede
   Sitzung liest — und war die einzige Datei, die niemand nachmisst. Vier
@@ -616,9 +630,9 @@ YouTube-Transkripte (das Tor steht, es fehlt nur der Abholer).
   Stand und Server war ungeprüft: 50 Zeilen, die entscheiden, welche Fassung
   eines Projekts überlebt. Neun Tests, zehn Mutationen einzeln geprüft.
 - [ ] **Board-Paket-Tests** (Mehrfachzeiten pro Paketposition, Edit/Reload-Szenarien).
-- [ ] **QA-Bot Wissensmuster erweitern**
-  - Tokenfrei bleiben.
-  - Mehr direkte Navigations-/Hilfsaktionen für Login, Board, Inserat, Zahlung.
+- [x] **QA-Bot Wissensmuster erweitert** *(2026-08-22)* — an echten Sätzen
+  gemessen statt an Auslöserlisten geraten. Ein Fehlgriff behoben, der
+  Stichentscheid entschied vorher nach Array-Reihenfolge. Tokenfrei geblieben.
 
 ## Nice-to-Have (P2)
 


### PR DESCRIPTION
Die Themenzuordnung des QA-Bots entscheidet, welche **Aktionen** der Nutzer angeboten bekommt — und war nie gegen echte Sätze gemessen, sondern nur aus Auslöserlisten gebaut.

Von 16 realistischen Fragen landete eine falsch:

> „Wie schreibe ich einen Anbieter an?" → **`listing`**

Der Fragende bekam „Inserat erstellen" angeboten, obwohl er jemanden anschreiben wollte.

## Die Ursache war nicht der fehlende Auslöser

`anbieter` (listing) und `schreibe ich` (messages) trafen mit **je 3 Punkten**. Bei Gleichstand gewann bisher das Thema, das im Array weiter oben steht — also der Zufall der Sortierung.

Jetzt gewinnt der **längste wirklich getroffene Auslöser**: ein längeres getroffenes Wort ist das spezifischere Indiz.

Dazu die fehlenden Stämme `anschreib` und `kontaktier`. Vollformen greifen nicht — geprüft wird, ob der Auslöser *im Satz* vorkommt, und „kontaktieren" steht nicht in „kontaktiere".

## Der eigentliche Wert ist die Fragetabelle

Sie prüft nicht die Formulierung der Antwort, sondern **wo die Frage ankommt** — genau die Eigenschaft, die eine Änderung an den Auslösern kaputt macht. Dazu:

- eine **Gegenprobe mit Kauderwelsch** — ohne sie wäre die Tabelle auch mit „trifft immer" erfüllt
- kein Thema ohne Aktion (eine Antwort ohne Weg ist eine Sackgasse)
- kein **neuer** doppelter Auslöser; die drei bekannten stehen benannt

Wo eine Frage wirklich mehrdeutig ist („Zeig mir DJs in meiner Nähe" — Suche oder Radar), sind mehrere Themen zugelassen. Ein Test, der hier eine einzige Antwort erzwingt, fällt bei jeder sinnvollen Verbesserung.

## Mutationen

Vier geprüft, **drei fallen**: Stichentscheid wieder nach Array-Reihenfolge · neue Nachrichten-Auslöser entfernt · Auffangthema fällt weg.

Die vierte — *Stichentscheid nimmt den ersten statt den längsten Treffer* — **überlebt**, und das steht hier statt still zu verschwinden: sie ist auf allen realistischen Sätzen verhaltensgleich. Ein konstruierter Satz dagegen würde die Mutation prüfen, nicht das Produkt.

**463 Tests in 27 Suiten.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd


---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdytsTSc7G6F5osq4g7zd)_